### PR TITLE
fix: move erigon back to args pattern

### DIFF
--- a/modules/erigon.nix
+++ b/modules/erigon.nix
@@ -112,7 +112,7 @@
           };
         };
 
-        websocket = {
+        ws = {
           enable = mkEnableOption (mdDoc "Erigon WebSocket API");
           compression = mkEnableOption (mdDoc "Enable compression over HTTP-RPC.");
         };


### PR DESCRIPTION
Much like Geth, Erigon's interpretation of toml/yaml config is a bit non-standard and as a result generating the correct yaml from the nix config is non-trivial and error prone. 

This PR moves back to using args, which seems to be the least brittle approach with the best documentation.