### PR TITLE
chore(web3signer): update web3signer 22.11.0 -> 23.1.0

### DIFF
--- a/packages/signers/web3signer/default.nix
+++ b/packages/signers/web3signer/default.nix
@@ -7,11 +7,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "web3signer";
-  version = "22.11.0";
+  version = "23.1.0";
 
   src = fetchzip {
     url = "https://artifacts.consensys.net/public/${pname}/raw/names/${pname}.tar.gz/versions/${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-zF2rv+Vjxd4LIFujK67MQgPCFZ3SiOKRfetd2CjuY84=";
+    sha256 = "sha256-O6u7dNpFoURbMpIQy7JVj6sknN1vXqCrFhCVnpwuGzY=";
   };
 
   nativeBuildInputs = [makeWrapper];


### PR DESCRIPTION
Update web3signer from [22.11.0 to 23.1.0](https://github.com/ConsenSys/web3signer/compare/22.11.0...23.1.0)
