### PR TITLE
chore(teku): update teku 22.12.0 -> 23.1.0

### DIFF
--- a/packages/clients/consensus/teku/default.nix
+++ b/packages/clients/consensus/teku/default.nix
@@ -7,11 +7,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "teku";
-  version = "22.12.0";
+  version = "23.1.0";
 
   src = fetchurl {
     url = "https://artifacts.consensys.net/public/${pname}/raw/names/${pname}.tar.gz/versions/${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-kgoHWUZdaV4v2SECPyBMRVMdH3OmnRQYzBbgEFOc27Q=";
+    sha256 = "sha256-sNNLxqFi/TqLe+itENVdroAL9z4hdJU2xkz5aDZLePA=";
   };
 
   nativeBuildInputs = [makeWrapper];


### PR DESCRIPTION
Update teku to a new [version](https://github.com/ConsenSys/teku/releases/tag/23.1.0)