### PR TITLE
feat/service improvements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673362319,
-        "narHash": "sha256-Pjp45Vnj7S/b3BRpZEVfdu8sqqA6nvVjvYu59okhOyI=",
+        "lastModified": 1674771137,
+        "narHash": "sha256-Zpk1GbEsYrqKmuIZkx+f+8pU0qcCYJoSUwNz1Zk+R00=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "82c16f1682cf50c01cb0280b38a1eed202b3fe9f",
+        "rev": "7c7a8bce3dffe71203dcd4276504d1cb49dfe05f",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673201017,
-        "narHash": "sha256-7kIHMGtsbC7CIlJPA7F1HwAXlqHf61mfjvnvA/v1Uno=",
+        "lastModified": 1674752624,
+        "narHash": "sha256-ejhmcqHZ6E5L+YA8WX1z4KkiDYK3AsXc9i3ohGMFOKA=",
         "owner": "mic92",
         "repo": "nix-update",
-        "rev": "18b0f84ce5671b33515735fc8feaf17678630844",
+        "rev": "f570df2044c41ffa44d7d86a4c2d7ae3dc59b4eb",
         "type": "github"
       },
       "original": {
@@ -150,11 +150,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1673947312,
-        "narHash": "sha256-xx/2nRwRy3bXrtry6TtydKpJpqHahjuDB5sFkQ/XNDE=",
+        "lastModified": 1674807565,
+        "narHash": "sha256-zOLE1YXf2RhYhtNv4n8C0xPaSjduchLlCxZaAeoAvxU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d38b664b4400335086a713a0036aafaa002c003",
+        "rev": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
     },
     "treefmt-nix": {
       "locked": {
-        "lastModified": 1672931382,
-        "narHash": "sha256-lgtc2Sct/xtvqkdzlJ4AL3Vesw0Wz/fxqNGOBFS7YXU=",
+        "lastModified": 1674470002,
+        "narHash": "sha256-Tk1VaMeBTMMGEZeqv3TEwrTAdR9fYb3EH/TPI27AdKk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6717065d6a432bc3f5b827007ad959e6032d5856",
+        "rev": "d5ed9a1e6793f99b2e179d5dec9639e48ef22db7",
         "type": "github"
       },
       "original": {

--- a/modules/erigon.nix
+++ b/modules/erigon.nix
@@ -7,10 +7,8 @@
 }: let
   inherit (lib.lists) optionals findFirst;
   inherit (lib) mdDoc flatten nameValuePair;
-  inherit (lib) zipAttrsWith filterAttrsRecursive filterAttrs mapAttrs mapAttrs' mapAttrsToList;
+  inherit (lib) zipAttrsWith filterAttrsRecursive optionalAttrs filterAttrs mapAttrs mapAttrs' mapAttrsToList;
   inherit (lib) optionalString literalExpression mkEnableOption mkIf mkOption types concatStringsSep;
-
-  settingsFormat = pkgs.formats.yaml {};
 
   eachErigon = config.services.erigon;
 
@@ -19,12 +17,6 @@
       enable = mkEnableOption (mdDoc "Erigon Ethereum Node.");
 
       args = {
-        datadir = mkOption {
-          type = types.nullOr types.path;
-          default = null;
-          description = mdDoc "Data directory for the databases.";
-        };
-
         port = mkOption {
           type = types.port;
           default = 30303;
@@ -290,35 +282,6 @@ in {
       ])
       eachErigon);
 
-    # add a group for each instance
-    users.groups =
-      mapAttrs'
-      (erigonName: _: nameValuePair "erigon-${erigonName}" {})
-      eachErigon;
-
-    # add a system user for each instance
-    users.users =
-      mapAttrs'
-      (erigonName: _:
-        nameValuePair "erigon-${erigonName}" {
-          isSystemUser = true;
-          group = "erigon-${erigonName}";
-          description = "System user for erigon ${erigonName} instance";
-        })
-      eachErigon;
-
-    # ensure data directories are created and have the correct permissions for any instances that specify one
-    systemd.tmpfiles.rules =
-      lib.lists.flatten
-      (mapAttrsToList
-        (
-          erigonName: cfg:
-            lib.lists.optionals (cfg.args.datadir != null) [
-              "d ${cfg.args.datadir} 0700 erigon-${erigonName} erigon-${erigonName} - -"
-            ]
-        )
-        eachErigon);
-
     # configure the firewall for each service
     networking.firewall = let
       openFirewall = filterAttrs (_: cfg: cfg.openFirewall) eachErigon;
@@ -344,84 +307,45 @@ in {
       mapAttrs'
       (
         erigonName: let
-          stateDir = "erigon-${erigonName}";
-          datadir = "/var/lib/${stateDir}";
+          serviceName = "erigon-${erigonName}";
 
           modulesLib = import ./lib.nix {inherit lib pkgs;};
-          inherit (modulesLib.flags) mkFlags;
+          inherit (modulesLib) baseServiceConfig mkArgs foldListToAttrs;
         in
           cfg:
-            nameValuePair "erigon-${erigonName}" (mkIf cfg.enable {
+            nameValuePair serviceName (mkIf cfg.enable {
               description = "Erigon Ethereum node (${erigonName})";
               wantedBy = ["multi-user.target"];
               after = ["network.target"];
 
-              unitConfig = {
-                RequiresMountsFor = optionals (cfg.args.datadir != null) [
-                  cfg.args.datadir
-                ];
-              };
+              # create service config by merging with the base config
+              serviceConfig = foldListToAttrs [
+                baseServiceConfig
+                {
+                  DynamicUser = true;
+                  User = serviceName;
+                  StateDirectory = serviceName;
+                }
+              ];
 
-              serviceConfig = {
-                User = "erigon-${erigonName}";
-                Group = "erigon-${erigonName}";
+              script = "${cfg.package}/bin/erigon $@";
 
-                Restart = "always";
-                StateDirectory = stateDir;
-                SupplementaryGroups = cfg.service.supplementaryGroups;
-
-                # bind custom data dir to /var/lib/... if provided
-                BindPaths = lib.lists.optionals (cfg.args.datadir != null) [
-                  "${cfg.args.datadir}:${datadir}"
-                ];
-
-                # Hardening measures
-                CapabilityBoundingSet = "";
-                RemoveIPC = "true";
-                PrivateTmp = "true";
-                ProtectSystem = "full";
-                ProtectHome = "read-only";
-                ProtectClock = true;
-                ProtectProc = "noaccess";
-                ProcSubset = "pid";
-                ProtectKernelLogs = true;
-                ProtectKernelModules = true;
-                ProtectKernelTunables = true;
-                ProtectControlGroups = true;
-                ProtectHostname = true;
-                NoNewPrivileges = "true";
-                PrivateDevices = "true";
-                RestrictSUIDSGID = "true";
-                RestrictRealtime = true;
-                RestrictNamespaces = true;
-                LockPersonality = true;
-                MemoryDenyWriteExecute = "true";
-                SystemCallFilter = ["@system-service" "~@privileged"];
-              };
-
-              script = let
+              scriptArgs = let
                 # replace enable flags like --http.enable with just --http
                 pathReducer = path: let
                   arg = concatStringsSep "." (lib.lists.remove "enable" path);
                 in "--${arg}";
 
-                # filter out certain args which need to be treated differently
-                specialArgs = ["datadir"];
-                isNormalArg = name: (findFirst (a: a == name) null specialArgs) == null;
-
-                filteredOpts = filterAttrs (n: v: isNormalArg n) erigonOpts.options.args;
-
                 # generate flags
-                flags = mkFlags {
+                args = mkArgs {
                   inherit pathReducer;
                   inherit (cfg) args;
-                  opts = filteredOpts;
+                  opts = erigonOpts.options.args;
                 };
               in ''
-                ${cfg.package}/bin/erigon \
-                    ${concatStringsSep " \\\n" flags} \
-                    --datadir ${datadir} \
-                    ${lib.escapeShellArgs cfg.extraArgs}
+                --datadir %S/${serviceName} \
+                ${concatStringsSep " \\\n" args} \
+                ${lib.escapeShellArgs cfg.extraArgs}
               '';
             })
       )

--- a/modules/erigon.nix
+++ b/modules/erigon.nix
@@ -333,10 +333,8 @@ in {
               serviceConfig = foldListToAttrs [
                 baseServiceConfig
                 {
-                  DynamicUser = true;
                   User = serviceName;
                   StateDirectory = serviceName;
-
                   ExecStart = "${cfg.package}/bin/erigon ${scriptArgs}";
                 }
               ];

--- a/modules/erigon.nix
+++ b/modules/erigon.nix
@@ -275,13 +275,6 @@ in {
   ###### implementation
 
   config = mkIf (eachErigon != {}) {
-    # collect packages and add them to the system
-    environment.systemPackages = flatten (mapAttrsToList
-      (_: cfg: [
-        cfg.package
-      ])
-      eachErigon);
-
     # configure the firewall for each service
     networking.firewall = let
       openFirewall = filterAttrs (_: cfg: cfg.openFirewall) eachErigon;

--- a/modules/geth.nix
+++ b/modules/geth.nix
@@ -203,13 +203,6 @@ in {
   ###### implementation
 
   config = mkIf (eachGeth != {}) {
-    # collect packages and add them to the system
-    environment.systemPackages = flatten (mapAttrsToList
-      (_: cfg: [
-        cfg.package
-      ])
-      eachGeth);
-
     # configure the firewall for each service
     networking.firewall = let
       openFirewall = filterAttrs (_: cfg: cfg.openFirewall) eachGeth;

--- a/modules/geth.nix
+++ b/modules/geth.nix
@@ -278,10 +278,8 @@ in {
               serviceConfig = foldListToAttrs [
                 baseServiceConfig
                 {
-                  DynamicUser = true;
                   User = serviceName;
                   StateDirectory = serviceName;
-
                   ExecStart = "${cfg.package}/bin/geth ${scriptArgs}";
                 }
                 (optionalAttrs (cfg.args.authrpc.jwtsecret != null) {

--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -60,28 +60,32 @@
       opts
     );
 
-  baseServiceConfig = {
-    Restart = "on-failure";
-    CapabilityBoundingSet = "";
-    RemoveIPC = "true";
-    PrivateTmp = "true";
-    ProtectSystem = "full";
-    ProtectHome = "read-only";
-    ProtectClock = true;
-    ProtectProc = "noaccess";
-    ProtectKernelLogs = true;
-    ProtectKernelModules = true;
-    ProtectKernelTunables = true;
-    ProtectControlGroups = true;
-    ProtectHostname = true;
-    NoNewPrivileges = "true";
-    PrivateDevices = "true";
-    RestrictSUIDSGID = "true";
-    RestrictRealtime = true;
-    RestrictNamespaces = true;
-    LockPersonality = true;
-    MemoryDenyWriteExecute = "true";
-    SystemCallFilter = ["@system-service" "~@privileged"];
+  baseServiceConfig = with lib; {
+    Restart = mkDefault "on-failure";
+
+    # https://www.freedesktop.org/software/systemd/man/systemd.exec.html#DynamicUser=
+    # Enabling dynamic user implies other options which cannot be changed:
+    #   * RemoveIPC = true
+    #   * PrivateTmp = true
+    #   * NoNewPrivileges = "strict"
+    #   * RestrictSUIDSGID = true
+    #   * ProtectSystem = "strict"
+    #   * ProtectHome = "read-only"
+    DynamicUser = mkDefault true;
+
+    ProtectClock = mkDefault true;
+    ProtectProc = mkDefault "noaccess";
+    ProtectKernelLogs = mkDefault true;
+    ProtectKernelModules = mkDefault true;
+    ProtectKernelTunables = mkDefault true;
+    ProtectControlGroups = mkDefault true;
+    ProtectHostname = mkDefault true;
+    PrivateDevices = mkDefault true;
+    RestrictRealtime = mkDefault true;
+    RestrictNamespaces = mkDefault true;
+    LockPersonality = mkDefault true;
+    MemoryDenyWriteExecute = mkDefault true;
+    SystemCallFilter = lib.mkDefault ["@system-service" "~@privileged"];
   };
 in {
   inherit baseServiceConfig;

--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -27,7 +27,7 @@
     arg = concatStringsSep "." path;
   in "--${arg}";
 
-  mkFlag = {
+  mkArg = {
     path,
     opt,
     args,
@@ -48,7 +48,7 @@
         else "${arg} ${argReducer value}"
       else "";
 
-  mkFlags = {
+  mkArgs = {
     opts,
     args,
     pathReducer ? defaultPathReducer,
@@ -56,11 +56,35 @@
     collect (v: (isString v) && v != "") (
       mapAttrsRecursiveCond
       (as: !isOption as)
-      (path: opt: mkFlag {inherit path opt args pathReducer;})
+      (path: opt: mkArg {inherit path opt args pathReducer;})
       opts
     );
-in {
-  flags = {
-    inherit mkFlag mkFlags defaultPathReducer dotPathReducer;
+
+  baseServiceConfig = {
+    Restart = "on-failure";
+    CapabilityBoundingSet = "";
+    RemoveIPC = "true";
+    PrivateTmp = "true";
+    ProtectSystem = "full";
+    ProtectHome = "read-only";
+    ProtectClock = true;
+    ProtectProc = "noaccess";
+    ProtectKernelLogs = true;
+    ProtectKernelModules = true;
+    ProtectKernelTunables = true;
+    ProtectControlGroups = true;
+    ProtectHostname = true;
+    NoNewPrivileges = "true";
+    PrivateDevices = "true";
+    RestrictSUIDSGID = "true";
+    RestrictRealtime = true;
+    RestrictNamespaces = true;
+    LockPersonality = true;
+    MemoryDenyWriteExecute = "true";
+    SystemCallFilter = ["@system-service" "~@privileged"];
   };
+in {
+  inherit baseServiceConfig;
+  inherit mkArg mkArgs defaultPathReducer dotPathReducer;
+  foldListToAttrs = lib.fold (a: b: a // b) {};
 }

--- a/modules/prysm/beacon.nix
+++ b/modules/prysm/beacon.nix
@@ -234,12 +234,9 @@ in {
               serviceConfig = foldListToAttrs [
                 baseServiceConfig
                 {
-                  DynamicUser = true;
                   User = serviceName;
                   StateDirectory = serviceName;
-
                   ExecStart = "${cfg.package}/bin/beacon-chain ${scriptArgs}";
-
                   MemoryDenyWriteExecute = "false"; # causes a library loading error
                 }
                 (optionalAttrs (cfg.args.jwt-secret != null) {

--- a/modules/prysm/beacon.nix
+++ b/modules/prysm/beacon.nix
@@ -167,13 +167,6 @@ in {
   ###### implementation
 
   config = mkIf (eachBeacon != {}) {
-    # collect packages and add them to the system
-    environment.systemPackages = flatten (mapAttrsToList
-      (_: cfg: [
-        cfg.package
-      ])
-      eachBeacon);
-
     # configure the firewall for each service
     networking.firewall = let
       openFirewall = filterAttrs (_: cfg: cfg.openFirewall) eachBeacon;


### PR DESCRIPTION
Simplify the service implementations, re-using common code between them and removing anything related to management of mounts which will be done separately in a new module. 

- chore: update flake.lock
- feat(modules): simplify services
- fix(modules): do not add client packages to system
- feat(modules): use ExecStart instead of script
- feat(modules): remove redundant options in base service config
