### PR TITLE
fix: move pkgs and lib to imports

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,17 +58,17 @@
       }
       {
         imports = [
+          ({inputs', ...}: {
+            # make pkgs available to all `perSystem` functions
+            _module.args.pkgs = inputs'.nixpkgs.legacyPackages;
+            # make custom lib available to all `perSystem` functions
+            _module.args.lib = lib;
+          })
           ./nix
           ./packages
           ./modules
         ];
         systems = ["x86_64-linux"];
-        perSystem = {inputs', ...}: {
-          # make pkgs available to all `perSystem` functions
-          _module.args.pkgs = inputs'.nixpkgs.legacyPackages;
-          # make custom lib available to all `perSystem` functions
-          _module.args.lib = lib;
-        };
       })
     .config
     .flake;


### PR DESCRIPTION
This PR sets correctly `pkg` and `lib` for flake.parts by setting them on `imports` clause.