### PR TITLE
chore(erigon): update erigon 2.38.1 -> 2.39.0

### DIFF
--- a/packages/clients/execution/erigon/default.nix
+++ b/packages/clients/execution/erigon/default.nix
@@ -5,17 +5,17 @@
 }:
 buildGoModule rec {
   pname = "erigon";
-  version = "2.38.1";
+  version = "2.39.0";
 
   src = fetchFromGitHub {
     owner = "ledgerwatch";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-sLJMmSEUQNsodZ9Ms0ipDwN2QOYa9pZTlEqt4CF23Sc=";
+    sha256 = "sha256-HlAnuc6n/de6EzHTit3xGCFLrc2+S+H/o0gCxH8d0aU=";
     fetchSubmodules = true;
   };
 
-  vendorSha256 = "sha256-KESY+PSbWQHPJphop4GnVF4T8Q/MPb2GFDEko0ieXEM=";
+  vendorSha256 = "sha256-kKwaA6NjRdg97tTEzEI+TWMSx7izzFWcefR5B086cUY=";
   proxyVendor = true;
 
   # Build errors in mdbx when format hardening is enabled:


### PR DESCRIPTION
Update erigon to [v2.39.0](https://github.com/ledgerwatch/erigon/releases/tag/v2.39.0)