### PR TITLE
geth: 1.11.2 -> 1.11.3

### DIFF
--- a/packages/clients/execution/geth/default.nix
+++ b/packages/clients/execution/geth/default.nix
@@ -20,16 +20,16 @@
 in
   buildGoModule rec {
     pname = "geth";
-    version = "1.11.2";
+    version = "1.11.3";
 
     src = fetchFromGitHub {
       owner = "ethereum";
       repo = "go-ethereum";
       rev = "v${version}";
-      sha256 = "sha256-LCJDpSyQUL7DXZDbZepaoU78uXfoPPMKMETy/uq+0LE=";
+      sha256 = "sha256-BFj2ggeBeL3THmwAPZqU5sn3bqtM3Kqc83TJ+Ldl/Ec=";
     };
 
-    vendorSha256 = "sha256-6yLkeT5DrAPUohAmobssKkvxgXI8kACxiu17WYbw+n0=";
+    vendorSha256 = "sha256-ngOYJMcnh+vSFKuI904rjCUlpO8SyL7BsGCewVv26wU=";
 
     ldflags = ["-s" "-w"];
 


### PR DESCRIPTION
Diff: https://github.com/ethereum/go-ethereum/compare/v1.11.2...v1.11.3
