### PR TITLE
erigon: 2.39.0 -> 2.40.1

### DIFF
--- a/packages/clients/execution/erigon/default.nix
+++ b/packages/clients/execution/erigon/default.nix
@@ -5,17 +5,17 @@
 }:
 buildGoModule rec {
   pname = "erigon";
-  version = "2.39.0";
+  version = "2.40.1";
 
   src = fetchFromGitHub {
     owner = "ledgerwatch";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-HlAnuc6n/de6EzHTit3xGCFLrc2+S+H/o0gCxH8d0aU=";
+    sha256 = "sha256-iuJ/iajZiqKBP4hgrwt8KKkWEdYa+idpai/aWpCOjQw=";
     fetchSubmodules = true;
   };
 
-  vendorSha256 = "sha256-kKwaA6NjRdg97tTEzEI+TWMSx7izzFWcefR5B086cUY=";
+  vendorSha256 = "sha256-0xHu7uvk7kRxyLXGvrT9U8vgfZPrs7Rmg2lFH49YOSI=";
   proxyVendor = true;
 
   # Build errors in mdbx when format hardening is enabled:


### PR DESCRIPTION
Diff: https://github.com/ledgerwatch/erigon/compare/v2.39.0...v2.40.1
