### PR TITLE
feat(workflows): add gpg-signs

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,6 +1,5 @@
 name: "Deploy content to Pages"
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/update-inputs.yaml
+++ b/.github/workflows/update-inputs.yaml
@@ -15,6 +15,9 @@ jobs:
         id: update
         uses: DeterminateSystems/update-flake-lock@v16
         with:
+          sign-commits: true
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
           pr-title: "chore: update flake.lock"
           commit-msg: "chore: update flake.lock"
           pr-labels: |

--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -13,9 +13,12 @@ jobs:
         uses: cachix/install-nix-action@v20
       - name: Update flake packages
         id: update
-        uses: selfuryon/nix-update-action@v0.1.0
+        uses: selfuryon/nix-update-action@v0.2.0
         with:
           blacklist: "bls,blst,evmc,mcl,besu,teku,docs,foundry,mev-geth,web3signer"
+          sign-commits: true
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
           pr-title: "chore: update packages"
           pr-labels: |
             dependencies

--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -15,7 +15,7 @@ jobs:
         id: update
         uses: selfuryon/nix-update-action@v0.2.0
         with:
-          blacklist: "bls,blst,evmc,mcl,besu,teku,docs,foundry,mev-geth,web3signer"
+          blacklist: "bls,blst,evmc,mcl,besu,teku,docs,foundry,mev-geth,web3signer,plugeth"
           sign-commits: true
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
Add gpg signs to github actions when we want to update packages and lock.
Someone need to add `GPG_PRIVATE_KEY` and  `GPG_PASSPHRASE` secrets with verified (or nor, do we have a policy about that?) email.
The example of workflow execution: https://github.com/selfuryon/ethereum.nix/pull/11 and https://github.com/selfuryon/ethereum.nix/pull/12