### PR TITLE
fix(modules/backup): remove reference to RESTIC_REPOSITORY in backup script

### DIFF
--- a/modules/backup/default.nix
+++ b/modules/backup/default.nix
@@ -296,7 +296,6 @@
 
         # first we ensure the repo exists
         if ! $RESTIC_CMD snapshots > /dev/null; then
-            echo "Creating repo: $RESTIC_REPOSITORY"
             $RESTIC_CMD init
         fi
 

--- a/modules/restore/default.nix
+++ b/modules/restore/default.nix
@@ -21,16 +21,11 @@
 
       echo "Running restore"
 
+      # we only perform a restore if the directory is empty
       if [ "$(ls -A $STATE_DIRECTORY)" ]; then
           echo "$STATE_DIRECTORY is not empty, restore will exit"
           exit 0
       fi
-
-      # we only perform a restore if the directory is empty
-
-      # restore from the repo
-      echo "RESTIC_REPOSITORY=$RESTIC_REPOSITORY"
-      echo "SNAPSHOT=$SNAPSHOT"
 
       $RESTIC_CMD restore \
         --target $STATE_DIRECTORY \


### PR DESCRIPTION
When specifying the repository via `RESTIC_REPOSITORY_FILE` the variable `RESTIC_REPOSITORY` is not set.

The log message which required it was superfluous anyway.
