### PR TITLE
feat(modules/restore): add a configurable timeout

### DIFF
--- a/modules/backup/default.nix
+++ b/modules/backup/default.nix
@@ -438,7 +438,7 @@
     with lib; let
       inherit (cfg) restic;
       extraOptions = concatMapStrings (arg: " -o ${arg}") restic.extraOptions;
-      resticCmd = "${pkgs.restic}/bin/restic${extraOptions}";
+      resticCmd = "${pkgs.restic}/bin/restic${extraOptions} -vv";
       # Helper functions for rclone remotes
       rcloneRemoteName = builtins.elemAt (splitString ":" restic.repository) 1;
       rcloneAttrToOpt = v: "RCLONE_" + toUpper (builtins.replaceStrings ["-"] ["_"] v);

--- a/modules/restore/default.nix
+++ b/modules/restore/default.nix
@@ -106,6 +106,8 @@
         ExecStartPre = mkOrder 501 [
           "+${mkRestoreScript cfg}"
         ];
+        # increase start timeout
+        TimeoutStartSec = cfg.timeout;
       };
     };
 in {

--- a/modules/restore/lib.nix
+++ b/modules/restore/lib.nix
@@ -7,6 +7,13 @@ lib: {
       description = mdDoc "The id of the snapshot to restore from";
     };
 
+    timeout = mkOption {
+      type = types.int;
+      description = mdDoc "The max time to wait before timing out on startup. This value is used for TimeoutStartSec in the systemd service config.";
+      default = 600;
+      example = "900";
+    };
+
     restic = import ../backup/restic.nix lib;
   };
 }


### PR DESCRIPTION
When restoring we need to increase the `TimeoutStartSec` for the service as the restoration is run as an `ExecStartPre` script.

This makes the timeout configurable, with a default of 10 minutes.
