### PR TITLE
chore(mission-control): replace installToDevShell with a new config option

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -240,11 +240,11 @@
     },
     "mission-control": {
       "locked": {
-        "lastModified": 1679674077,
-        "narHash": "sha256-hGz63fsyRGthjE6LLqB08IHApcBvHhI87gWrFN/Uu5w=",
+        "lastModified": 1680209746,
+        "narHash": "sha256-P8Q0mPdeo2SvKQUejvl7nOKO2ahIXb6aintYofCxcP8=",
         "owner": "Platonic-Systems",
         "repo": "mission-control",
-        "rev": "d07854a616f559370b71c1c440d916ab6869f084",
+        "rev": "c1bd7344283d4006efb02cc660c5fd9befb73980",
         "type": "github"
       },
       "original": {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -6,18 +6,18 @@
     inputs',
     ...
   }: let
-    inherit (config.mission-control) installToDevShell;
     inherit (pkgs) mkShellNoCC;
     inherit (inputs'.nixpkgs-unstable.legacyPackages) nix-update statix mkdocs;
   in {
-    devShells.default = installToDevShell (mkShellNoCC {
+    devShells.default = mkShellNoCC {
       name = "ethereum.nix";
+      inputsFrom = [config.mission-control.devShell];
       packages = [
         nix-update
         statix
         mkdocs
         pkgs.python310Packages.mkdocs-material
       ];
-    });
+    };
   };
 }


### PR DESCRIPTION
Hello!
After update my system I found out that `mission-control` changed [the way how to work](https://github.com/Platonic-Systems/mission-control/pull/30/files) with devShell. Fix that before `Update Flake Inputs` task performs an update.