### PR TITLE
feat: add acktree-blockchain.solidity-tools and consensys.vscode-solidity-auditor plugins

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -64,6 +64,10 @@
         meta.platforms = [system];
       });
 
+      # Editors
+      vscode-plugin-ackee-blockchain-solidity-tools = callPackage ./editors/vscode/extensions/ackee-blockchain.solidity-tools {};
+      vscode-plugin-consensys-vscode-solidity-visual-editor = callPackage ./editors/vscode/extensions/consensys.vscode-solidity-auditor {};
+
       # Libs
       evmc = callPackage ./libs/evmc {};
       mcl = callPackage ./libs/mcl {};

--- a/packages/editors/vscode/extensions/ackee-blockchain.solidity-tools/default.nix
+++ b/packages/editors/vscode/extensions/ackee-blockchain.solidity-tools/default.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  vscode-utils,
+}: let
+  inherit (vscode-utils) buildVscodeMarketplaceExtension;
+in
+  buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "tools-for-solidity";
+      publisher = "AckeeBlockchain";
+      version = "1.8.0";
+      sha256 = "sha256-fVDldD4RJ5RocbBIT3VE1uWiv1Oc88g1cp5EkSvPphU=";
+    };
+
+    meta = {
+      description = "VS Code plugin implementing a language server for Solidity";
+      license = lib.licenses.mit;
+      platforms = ["x86_64-linux"];
+    };
+  }

--- a/packages/editors/vscode/extensions/consensys.vscode-solidity-auditor/default.nix
+++ b/packages/editors/vscode/extensions/consensys.vscode-solidity-auditor/default.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  vscode-utils,
+}: let
+  inherit (vscode-utils) buildVscodeMarketplaceExtension;
+in
+  buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "solidity-visual-auditor";
+      publisher = "tintinweb";
+      version = "0.1.5";
+      sha256 = "sha256-laCH+jeh8/2XFUwHOyAjjfXhoLpEWWoHA0sTFdsjJiY=";
+    };
+
+    meta = {
+      description = "Solidity language support and visual security auditor for Visual Studio Code";
+      license = lib.licenses.gpl3;
+      platforms = ["x86_64-linux"];
+    };
+  }


### PR DESCRIPTION
Adds support for some useful VSCode plugins:

- [Solidity Auditor](https://github.com/ConsenSys/vscode-solidity-auditor)
- [Tools for Solidity](https://github.com/Ackee-Blockchain/tools-for-solidity-vscode)

In the case of Tools for Solidity, also I'll include a new PR support for [woke](https://github.com/Ackee-Blockchain/woke).