### PR TITLE
fix nixConfig in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,9 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://cache.nixos.org"
       "https://nix-community.cachix.org"
     ];
     extra-trusted-public-keys = [
-      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     ];
   };


### PR DESCRIPTION
- It is unnecessary to put cache.nixos.org into the `extra-substituters` as it is already part of `substituters`.