### PR TITLE
Remove nonexistent ws.port value from Erigon allowedTCPPorts

### DIFF
--- a/modules/erigon/default.nix
+++ b/modules/erigon/default.nix
@@ -285,7 +285,6 @@ in {
               allowedTCPPorts =
                 [port authrpc.port torrent.port]
                 ++ (optionals http.enable [http.port])
-                ++ (optionals ws.enable [ws.port])
                 ++ (optionals metrics.enable [metrics.port]);
             }
         )


### PR DESCRIPTION
Currently the module for Erigon adds the value of the `ws.port` option to `allowedTCPPorts`, but this option does not exist either as an option in the module, nor on the Erigon command line.  Because the option does not exist, starting Erigon with `openFirewall = true` currently fails.  This PR removes the reference to `ws.port` in `allowedTCPPorts`.