### PR TITLE
Fix erigon --ws

### DIFF
--- a/modules/erigon/default.nix
+++ b/modules/erigon/default.nix
@@ -285,7 +285,7 @@ in {
               allowedTCPPorts =
                 [port authrpc.port torrent.port]
                 ++ (optionals http.enable [http.port])
-                ++ (optionals ws.enable [ws.port])
+                ++ (optionals ws.enable [ ])
                 ++ (optionals metrics.enable [metrics.port]);
             }
         )


### PR DESCRIPTION
Using websockets breaks because the module expects `ws.port` but doesn't define an arg for it... which is correct since Erigon doesn't have a `ws.port` flag.