### PR TITLE
Fix prysm build when nix env is go 1.2x

### DIFF
--- a/packages/clients/consensus/prysm/default.nix
+++ b/packages/clients/consensus/prysm/default.nix
@@ -1,11 +1,11 @@
 {
   bls,
   blst,
-  buildGoModule,
+  buildGo119Module,
   fetchFromGitHub,
   libelf,
 }:
-buildGoModule rec {
+buildGo119Module rec {
   pname = "prysm";
   version = "4.0.1";
 


### PR DESCRIPTION
* Prysm currently builds on go 1.19: https://github.com/prysmaticlabs/prysm/blob/08d6eccfb3bca915ff7d6369677b3f9ab9bacb55/.github/workflows/go.yml
* If using unstable or staging-next packages in Nix, you could end up with go 1.2x, which breaks Prysm due to this: https://github.com/trailofbits/go-mutexasserts/pull/2 (this fix is merged, but not yet in prysm)