### PR TITLE
fix: remove default cachix substituter from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,8 @@
   description = "A reproducible Nix package set for Ethereum clients and utilities";
 
   nixConfig = {
-    extra-substituters = [
-      "https://cache.nixos.org"
-      "https://nix-community.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-    ];
+    extra-substituters = ["https://nix-community.cachix.org"];
+    extra-trusted-public-keys = ["nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="];
   };
 
   inputs = {


### PR DESCRIPTION
Repeat #221, still wait a signed commit there

Close #221 