### PR TITLE
fix: switch to go 1.20 for mev-boost-builder building

### DIFF
--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -15,7 +15,7 @@ jobs:
         id: update
         uses: selfuryon/nix-update-action@v1.0.0
         with:
-          blacklist: "bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,sedge,mev-boost-prysm,mev-boost-builder,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,geth-sealer"
+          blacklist: "bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,sedge,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,geth-sealer"
           sign-commits: true
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -42,7 +42,7 @@
       # MEV
       dreamboat = callPackage ./mev/dreamboat {inherit blst;};
       mev-boost = callPackage ./mev/mev-boost {inherit blst;};
-      mev-boost-builder = callPackage ./mev/mev-boost-builder {inherit blst;};
+      mev-boost-builder = callPackageUnstable ./mev/mev-boost-builder {inherit blst;};
       mev-boost-prysm = callPackage ./mev/mev-boost-prysm {inherit bls blst;};
       mev-boost-relay = callPackage ./mev/mev-boost-relay {inherit blst;};
 

--- a/packages/mev/mev-boost-builder/default.nix
+++ b/packages/mev/mev-boost-builder/default.nix
@@ -5,16 +5,16 @@
 }:
 buildGoModule rec {
   pname = "builder";
-  version = "1.11.5-0.2.0";
+  version = "1.11.5-0.2.1";
 
   src = fetchFromGitHub {
     owner = "flashbots";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "sha256-BpyPxOu9iITGBibjusSQMu6tSJeTXRLSy8Ubb759Gfg=";
+    sha256 = "sha256-xCxBj4eUtRRkZYMUlzZ/PUGbqyBixyUEJzSF6EWS7SM=";
   };
 
-  vendorSha256 = "sha256-nja2HGl1Qk3pDYXT+mPo5r+HJKCCZeGEy02AN+byvbE=";
+  vendorSha256 = "sha256-Fh72oZNSJrglW3TiZDd8aHQixmZfipB0e2gQMXUaZzI=";
 
   buildInputs = [blst];
 


### PR DESCRIPTION
Found that `build/ci.go` [downloads](https://github.com/flashbots/builder/blob/main/build/ci.go#L142) go v1.20.2 by default, so I switched to an unstable nixpkgs to use go 1.20 in builds

Close #223 