### PR TITLE
chore: ignore repl-results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Nix build output
 /result*
+/repl-result*
 
 # IDE
 .idea/


### PR DESCRIPTION
Just ignore `repl-result` when using `nix repl` and `:bl <derivation>` command.