### PR TITLE
chore: use hash instead of sha256 and addition of mainPogram in metadata

### DIFF
--- a/packages/clients/consensus/lighthouse/default.nix
+++ b/packages/clients/consensus/lighthouse/default.nix
@@ -42,7 +42,7 @@ in
       owner = "sigp";
       repo = pname;
       rev = "v${version}";
-      sha256 = "sha256-QVAFzV9sao8+eegI7bLfm+pPHyvDFhnADS80+nqqgtE=";
+      hash = "sha256-QVAFzV9sao8+eegI7bLfm+pPHyvDFhnADS80+nqqgtE=";
     };
 
     cargoSha256 = "sha256-KlTQF1iL2PYAk+nmQIm72guy2PxGkN/YzhgCNv1FZGM=";
@@ -96,12 +96,13 @@ in
     # LIGHTHOUSE_WEB3SIGNER_BIN = websignerSrc;
     # LIGHTHOUSE_WEB3SIGNER_VERSION = "${websignerVersion}";
 
-    # Some tests are failing and we need to know why
+    # TODO: Some tests are failing and we need to know why
     doCheck = false;
 
     meta = {
       description = "Ethereum consensus client in Rust";
       homepage = "https://github.com/sigp/lighthouse";
+      mainProgram = "lighthouse";
       platforms = ["x86_64-linux"];
     };
   }

--- a/packages/clients/consensus/prysm/default.nix
+++ b/packages/clients/consensus/prysm/default.nix
@@ -32,6 +32,7 @@ buildGo119Module rec {
   meta = {
     description = "Go implementation of Ethereum proof of stake";
     homepage = "https://github.com/prysmaticlabs/prysm";
+    mainProgram = "beacon-chain";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/clients/consensus/teku/default.nix
+++ b/packages/clients/consensus/teku/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.consensys.net/public/${pname}/raw/names/${pname}.tar.gz/versions/${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-hrPmc2gvQQw8kRHf8AWzT/anh3V9zOu4k6XrzPXLeqI=";
+    hash = "sha256-hrPmc2gvQQw8kRHf8AWzT/anh3V9zOu4k6XrzPXLeqI=";
   };
 
   nativeBuildInputs = [makeWrapper];
@@ -28,7 +28,8 @@ stdenv.mkDerivation rec {
     description = "Java Implementation of the Ethereum 2.0 Beacon Chain";
     homepage = "https://github.com/ConsenSys/teku";
     license = licenses.asl20;
-    sourceProvenance = with sourceTypes; [binaryBytecode];
+    mainProgram = "teku";
     platforms = ["x86_64-linux"];
+    sourceProvenance = with sourceTypes; [binaryBytecode];
   };
 }

--- a/packages/clients/execution/besu/default.nix
+++ b/packages/clients/execution/besu/default.nix
@@ -28,7 +28,8 @@ stdenv.mkDerivation rec {
     description = "Besu is an Apache 2.0 licensed, MainNet compatible, Ethereum client written in Java";
     homepage = "https://github.com/hyperledger/besu";
     license = licenses.asl20;
-    sourceProvenance = with sourceTypes; [binaryBytecode];
+    mainProgram = "besu";
     platforms = ["x86_64-linux"];
+    sourceProvenance = with sourceTypes; [binaryBytecode];
   };
 }

--- a/packages/clients/execution/erigon/default.nix
+++ b/packages/clients/execution/erigon/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner = "ledgerwatch";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-3o7vu2bA8lB1CiVaSF6YU9WjwNliQAK5AcGl82GCqFg=";
+    hash = "sha256-3o7vu2bA8lB1CiVaSF6YU9WjwNliQAK5AcGl82GCqFg=";
     fetchSubmodules = true;
   };
 
@@ -30,8 +30,9 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/ledgerwatch/erigon/";
     description = "Ethereum node implementation focused on scalability and modularity";
+    homepage = "https://github.com/ledgerwatch/erigon/";
+    mainProgram = "erigon";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/clients/execution/geth-sealer/default.nix
+++ b/packages/clients/execution/geth-sealer/default.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
     owner = "manifoldfinance";
     repo = "geth-sealer";
     rev = "${version}";
-    sha256 = "sha256-aMIYxEfdOMhwN9pJEiqNPDLhEbFyFey6nq0spc+A1VE=";
+    hash = "sha256-aMIYxEfdOMhwN9pJEiqNPDLhEbFyFey6nq0spc+A1VE=";
   };
 
   vendorSha256 = "sha256-Y1srOcXZ4rQ0QIQx4LdYzYG6goGk6oO30C+OW+s81z4=";
@@ -27,9 +27,10 @@ buildGoModule rec {
   tags = ["urfave_cli_no_docs"];
 
   meta = with lib; {
-    homepage = "https://github.com/manifoldfinance/geth-sealer";
     description = "Geth Sealer implementation";
+    homepage = "https://github.com/manifoldfinance/geth-sealer";
     license = with licenses; [lgpl3Plus gpl3Plus];
+    mainProgram = "geth";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/clients/execution/geth/default.nix
+++ b/packages/clients/execution/geth/default.nix
@@ -60,9 +60,10 @@ in
     tags = ["urfave_cli_no_docs"];
 
     meta = with lib; {
-      homepage = "https://geth.ethereum.org/";
       description = "Official golang implementation of the Ethereum protocol";
+      homepage = "https://geth.ethereum.org/";
       license = with licenses; [lgpl3Plus gpl3Plus];
+      mainProgram = "geth";
       platforms = ["x86_64-linux"];
     };
   }

--- a/packages/clients/execution/nethermind/default.nix
+++ b/packages/clients/execution/nethermind/default.nix
@@ -18,7 +18,7 @@ buildDotnetModule rec {
     owner = "NethermindEth";
     repo = pname;
     rev = version;
-    sha256 = "sha256-wmXV6g4DfSd+lklnUFaUjzdUR9lu2SHMTvc0ECO4eU0=";
+    hash = "sha256-wmXV6g4DfSd+lklnUFaUjzdUR9lu2SHMTvc0ECO4eU0=";
     fetchSubmodules = true;
   };
 
@@ -54,6 +54,7 @@ buildDotnetModule rec {
     description = "Our flagship Ethereum client for Linux, Windows, and macOS—full and actively developed";
     homepage = "https://nethermind.io/nethermind-client";
     license = licenses.gpl3;
+    mainProgram = "Nethermind.Runner";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -142,6 +142,7 @@
       };
 
       # utils
+      eth2-testnet-genesis.bin = "eth2-testnet-genesis";
       ethdo.bin = "ethdo";
       ethereal.bin = "ethereal";
       sedge.bin = "sedge";

--- a/packages/dvt/charon/default.nix
+++ b/packages/dvt/charon/default.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
     owner = "ObolNetwork";
     repo = "${pname}";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-W7Sy/dsaYpZOpsEaGuHeTMi336RmKp0756TuUisM0IA=";
+    hash = "sha256-W7Sy/dsaYpZOpsEaGuHeTMi336RmKp0756TuUisM0IA=";
   };
 
   vendorSha256 = "sha256-MVEMI8BJnDogZVC7Kc2wVa2znqybqby2Zb9kuW+Lc44=";
@@ -26,6 +26,7 @@ buildGoModule rec {
   meta = {
     description = "Charon (pronounced 'kharon') is a Proof of Stake Ethereum Distributed Validator Client";
     homepage = "https://github.com/ObolNetwork/charon";
+    mainProgram = "charon";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/dvt/ssvnode/default.nix
+++ b/packages/dvt/ssvnode/default.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
     owner = "bloxapp";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "sha256-tMk91zKURbqREdeBnz6bc2UqKOBZA1TY6ueJdU0vAFM=";
+    hash = "sha256-tMk91zKURbqREdeBnz6bc2UqKOBZA1TY6ueJdU0vAFM=";
   };
 
   vendorSha256 = "sha256-u5/TVnpSBOdt3Hq3+JVVyfUwBy1iw51JRdtlB799nXY=";
@@ -25,5 +25,6 @@ buildGoModule rec {
     description = "Secret-Shared-Validator(SSV) for ethereum staking";
     homepage = "https://github.com/bloxapp/ssv";
     platforms = ["x86_64-linux"];
+    mainProgram = "ssvnode";
   };
 }

--- a/packages/libs/bls/default.nix
+++ b/packages/libs/bls/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     repo = "bls";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-fHwNiZ0B5ow9GBWjO5c+rpK/jlziaMF5Bh+HQayIBUI=";
+    hash = "sha256-fHwNiZ0B5ow9GBWjO5c+rpK/jlziaMF5Bh+HQayIBUI=";
   };
 
   nativeBuildInputs = [cmake];

--- a/packages/libs/evmc/default.nix
+++ b/packages/libs/evmc/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "ethereum";
     repo = "evmc";
     rev = "v${version}";
-    sha256 = "sha256-e6V7lNszvR8mmLhPk7pvFMh2LQUl/VHupzVgMfsNlsM=";
+    hash = "sha256-e6V7lNszvR8mmLhPk7pvFMh2LQUl/VHupzVgMfsNlsM=";
   };
 
   nativeBuildInputs = [cmake];

--- a/packages/libs/mcl/default.nix
+++ b/packages/libs/mcl/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "herumi";
     repo = "mcl";
     rev = "v${version}";
-    sha256 = "sha256-aVuBt5T+tNjrK1QahzaCxuimUDQVtoKfK/v0LTT3hy8=";
+    hash = "sha256-aVuBt5T+tNjrK1QahzaCxuimUDQVtoKfK/v0LTT3hy8=";
   };
 
   buildInputs = [gmpxx];

--- a/packages/mev/dreamboat/default.nix
+++ b/packages/mev/dreamboat/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner = "blocknative";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "sha256-Hqsx4zP0KB3rXXC7aYk3G4qS9sQfCqXP5ODFAP1TLoE=";
+    hash = "sha256-Hqsx4zP0KB3rXXC7aYk3G4qS9sQfCqXP5ODFAP1TLoE=";
   };
 
   vendorSha256 = "sha256-fjkBek1/AdBlm4plN0zPLLiqh3jHg8MA2FJs06SXkFQ=";
@@ -25,6 +25,7 @@ buildGoModule rec {
   meta = {
     description = "An Ethereum 2.0 Relay for proposer-builder separation (PBS) with MEV-boost";
     homepage = "https://github.com/blocknative/dreamboat";
+    mainProgram = "dreamboat";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/mev/mev-boost-builder/default.nix
+++ b/packages/mev/mev-boost-builder/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner = "flashbots";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "sha256-UbbsL1qzitBCp7t8uDPPFhB8PjK3zan6BNdKrHA+bY0=";
+    hash = "sha256-UbbsL1qzitBCp7t8uDPPFhB8PjK3zan6BNdKrHA+bY0=";
   };
 
   vendorSha256 = "sha256-Fh72oZNSJrglW3TiZDd8aHQixmZfipB0e2gQMXUaZzI=";
@@ -28,6 +28,7 @@ buildGoModule rec {
   meta = {
     description = "Flashbots mev-boost block builder";
     homepage = "https://github.com/flashbots/builder";
+    mainProgram = "geth";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/mev/mev-boost-prysm/default.nix
+++ b/packages/mev/mev-boost-prysm/default.nix
@@ -29,6 +29,7 @@ buildGoModule rec {
   meta = {
     description = "Our custom Prysm fork for boost relay and builder CL. Sends payload attributes for block building on every slot to trigger building";
     homepage = "https://github.com/flashbots/prysm";
+    mainProgram = "beacon-chain";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/mev/mev-boost-relay/default.nix
+++ b/packages/mev/mev-boost-relay/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner = "flashbots";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "sha256-pi0wTdzN0HM7w+4QBFvNRNUM+vQd2pwfWh0s0YmSIow=";
+    hash = "sha256-pi0wTdzN0HM7w+4QBFvNRNUM+vQd2pwfWh0s0YmSIow=";
   };
 
   vendorSha256 = "sha256-89GkgA4CREcqm9kYhw/mYM67/9qqyo7Bw+42Tfv3jIY=";
@@ -29,6 +29,7 @@ buildGoModule rec {
   meta = {
     description = "MEV-Boost Relay for Ethereum proposer/builder separation (PBS)";
     homepage = "https://github.com/flashbots/mev-boost-relay";
+    mainProgram = "mev-boost-relay";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/mev/mev-boost/default.nix
+++ b/packages/mev/mev-boost/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner = "flashbots";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "sha256-GAi55+BtYtqhB83TKAF/AVeR7T9/F1fkX6el5Tw6OrI=";
+    hash = "sha256-GAi55+BtYtqhB83TKAF/AVeR7T9/F1fkX6el5Tw6OrI=";
   };
 
   vendorSha256 = "sha256-+6h6q+AOQII9TxI595LKdoT6T75q/8zlARE868YsBdw=";
@@ -21,10 +21,9 @@ buildGoModule rec {
   subPackages = ["cmd/mev-boost"];
 
   meta = {
-    description = ''
-      MEV-Boost allows proof-of-stake Ethereum consensus clients to source blocks from a competitive builder marketplace
-    '';
+    description = "MEV-Boost allows proof-of-stake Ethereum consensus clients to source blocks from a competitive builder marketplace";
     homepage = "https://github.com/flashbots/mev-boost";
+    mainProgram = "mev-boost";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/mev/mev-rs/default.nix
+++ b/packages/mev/mev-rs/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     owner = "ralexstokes";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-d8HIZx33ZRcZgdEBAuCa21/ivh/XKlQf+Sn2aZbth4E=";
+    hash = "sha256-d8HIZx33ZRcZgdEBAuCa21/ivh/XKlQf+Sn2aZbth4E=";
   };
 
   cargoSha256 = "sha256-XwJDis7lfmlYFSRVesusa9jHUGoAoDOsFo8DCFiQMzU=";
@@ -25,8 +25,9 @@ rustPlatform.buildRustPackage rec {
   OPENSSL_DIR = "${lib.getDev openssl}";
 
   meta = {
-    homepage = "https://github.com/ralexstokes/mev-rs";
     description = "A gateway to a network of block builders";
+    homepage = "https://github.com/ralexstokes/mev-rs";
+    mainProgram = "mev";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/signers/dirk/default.nix
+++ b/packages/signers/dirk/default.nix
@@ -25,6 +25,7 @@ buildGoModule rec {
   meta = {
     description = "An Ethereum 2 distributed remote keymanager, focused on security and long-term performance of signing operations";
     homepage = "https://github.com/attestantio/dirk";
+    mainProgram = "dirk";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/signers/web3signer/default.nix
+++ b/packages/signers/web3signer/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     url = "https://artifacts.consensys.net/public/${pname}/raw/names/${pname}.tar.gz/versions/${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-IBDwa7ukQt4gWmgY2GW8a4HXTakbL2yEU8Gdda7GDtY=";
+    hash = "sha256-IBDwa7ukQt4gWmgY2GW8a4HXTakbL2yEU8Gdda7GDtY=";
   };
 
   nativeBuildInputs = [makeWrapper];
@@ -28,7 +28,8 @@ stdenv.mkDerivation rec {
     description = "Web3Signer is an open-source signing service capable of signing on multiple platforms (Ethereum1 and 2, Filecoin) using private keys stored in an external vault, or encrypted on a disk";
     homepage = "https://github.com/ConsenSys/web3signer";
     license = licenses.apsl20;
-    sourceProvenance = with sourceTypes; [binaryBytecode];
+    mainProgram = "web3signer";
     platforms = ["x86_64-linux"];
+    sourceProvenance = with sourceTypes; [binaryBytecode];
   };
 }

--- a/packages/utils/eth2-testnet-genesis/default.nix
+++ b/packages/utils/eth2-testnet-genesis/default.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
     owner = "protolambda";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-vhpC1ewBMDCgzK0aIiyzNofUSmY39xyJ1BJkJ3ZJAqc=";
+    hash = "sha256-vhpC1ewBMDCgzK0aIiyzNofUSmY39xyJ1BJkJ3ZJAqc=";
   };
 
   vendorSha256 = "sha256-iXJDZtm68Qk1Za8+Bsk140hyl/GeyXlj47PBEZw1tro=";
@@ -24,8 +24,9 @@ buildGoModule rec {
   ldflags = ["-s" "-w"];
 
   meta = with lib; {
-    homepage = "https://github.com/protolambda/eth2-testnet-genesis";
     description = "Create a genesis state for an Eth2 testnet";
+    homepage = "https://github.com/protolambda/eth2-testnet-genesis";
+    mainProgram = "eth2-testnet-genesis";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/utils/ethdo/default.nix
+++ b/packages/utils/ethdo/default.nix
@@ -30,6 +30,7 @@ buildGoModule rec {
     description = "A command-line tool for managing common tasks in Ethereum 2";
     homepage = "https://github.com/wealdtech/ethdo";
     license = licenses.apsl20;
+    mainProgram = "ethdo";
     platforms = ["x86_64-linux" "aarch64-darwin"];
   };
 }

--- a/packages/utils/ethereal/default.nix
+++ b/packages/utils/ethereal/default.nix
@@ -23,6 +23,7 @@ buildGoModule rec {
     description = "A command-line tool for managing common tasks in Ethereum";
     homepage = "https://github.com/wealdtech/ethereal/";
     license = licenses.apsl20;
+    mainProgram = "ethereal";
     platforms = ["x86_64-linux" "aarch64-darwin"];
   };
 }

--- a/packages/utils/sedge/default.nix
+++ b/packages/utils/sedge/default.nix
@@ -35,8 +35,9 @@ in
     subPackages = ["cmd/sedge"];
 
     meta = {
-      homepage = "https://docs.sedge.nethermind.io/";
       description = "A one-click setup tool for PoS network/chain validators and nodes.";
+      homepage = "https://docs.sedge.nethermind.io/";
+      mainProgram = "sedge";
       platforms = ["x86_64-linux"];
     };
   }

--- a/packages/utils/staking-deposit-cli/default.nix
+++ b/packages/utils/staking-deposit-cli/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "https://github.com/ethereum/staking-deposit-cli";
     description = "Secure key generation for deposits";
+    homepage = "https://github.com/ethereum/staking-deposit-cli";
     mainProgram = "deposit";
     platforms = ["x86_64-linux"];
   };

--- a/packages/utils/zcli/default.nix
+++ b/packages/utils/zcli/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     owner = "protolambda";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-uQ67Gp1Gs7Fl1fPDe2jHc84DV9RtBRz0EaD8WIn113c=";
+    hash = "sha256-uQ67Gp1Gs7Fl1fPDe2jHc84DV9RtBRz0EaD8WIn113c=";
   };
 
   vendorSha256 = "sha256-+5l35M7wsCOOLdVUY8nr+O7693TmiuVHD+2AFCltFRc=";
@@ -19,8 +19,9 @@ buildGoModule rec {
   subPackages = ["."];
 
   meta = with lib; {
-    homepage = "https://github.com/protolambda/zcli";
     description = "Eth2 CLI debugging tool";
+    homepage = "https://github.com/protolambda/zcli";
+    mainProgram = "zcli";
     platforms = ["x86_64-linux"];
   };
 }

--- a/packages/validators/vouch/default.nix
+++ b/packages/validators/vouch/default.nix
@@ -25,6 +25,7 @@ buildGoModule rec {
   meta = {
     description = "An Ethereum 2 multi-node validator client";
     homepage = "https://github.com/attestantio/vouch";
+    mainProgram = "vouch";
     platforms = ["x86_64-linux"];
   };
 }


### PR DESCRIPTION
This PR brings two minor improvements:

- Use sri `hash` instead of `sha256`
- Addition of `meta.mainProgram` so, when using `lib.getExe` the correct or default main binary is selected. 