### PR TITLE
erigon: 2.43.0 -> 2.43.1

### DIFF
--- a/packages/clients/execution/erigon/default.nix
+++ b/packages/clients/execution/erigon/default.nix
@@ -5,13 +5,13 @@
 }:
 buildGoModule rec {
   pname = "erigon";
-  version = "2.43.0";
+  version = "2.43.1";
 
   src = fetchFromGitHub {
     owner = "ledgerwatch";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-3o7vu2bA8lB1CiVaSF6YU9WjwNliQAK5AcGl82GCqFg=";
+    hash = "sha256-WkUWfOXhdg/xUFhCaXkN/ob2AEDWwVAcuuNxqfbyPHI=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Diff: https://github.com/ledgerwatch/erigon/compare/v2.43.0...v2.43.1
