### PR TITLE
feat(erigon): update  to v2.46.0

### DIFF
--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -15,7 +15,7 @@ jobs:
         id: update
         uses: selfuryon/nix-update-action@v1.0.0
         with:
-          blacklist: "dreamboat,bls,blst,evmc,mcl,besu,teku,erigon,docs,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,geth-sealer"
+          blacklist: "dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,geth-sealer"
           sign-commits: true
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/packages/clients/execution/erigon/default.nix
+++ b/packages/clients/execution/erigon/default.nix
@@ -4,17 +4,17 @@
 }:
 buildGoModule rec {
   pname = "erigon";
-  version = "2.45.2";
+  version = "2.46.0";
 
   src = fetchFromGitHub {
     owner = "ledgerwatch";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-XVfilScmN09t357Ria90qEhHNpRDDxTttZ59bjeg0Tk=";
+    hash = "sha256-xeyjKq9B2Sy3mMgXpysVveeYNtVGFjtCu58AmckLaNI=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-Yd78OW48HsOgxT5R3QT6/xDzPsRNFRE2nKocljTKKBA=";
+  vendorHash = "sha256-DYHL0hGXcsSY7bQsBgH03Wvip9hailHw5Z6/t2LpGqI=";
   proxyVendor = true;
 
   # Build errors in mdbx when format hardening is enabled:


### PR DESCRIPTION
Update erigon to [v2.46.0](https://github.com/ledgerwatch/erigon/releases/tag/v2.46.0) and remove erigon from blacklist (they do normal semver tags again)

Close #264 