### PR TITLE
chore(geth-sealer): update geth sealer

### DIFF
--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -15,7 +15,7 @@ jobs:
         id: update
         uses: selfuryon/nix-update-action@v1.0.0
         with:
-          blacklist: "dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,geth-sealer"
+          blacklist: "dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools"
           sign-commits: true
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/packages/clients/execution/geth-sealer/default.nix
+++ b/packages/clients/execution/geth-sealer/default.nix
@@ -6,16 +6,16 @@
 }:
 buildGoModule rec {
   pname = "geth-sealer";
-  version = "geth-sealer-v1.11.5";
+  version = "geth-sealer-v1.12.0";
 
   src = fetchFromGitHub {
     owner = "manifoldfinance";
     repo = "geth-sealer";
     rev = "${version}";
-    hash = "sha256-aMIYxEfdOMhwN9pJEiqNPDLhEbFyFey6nq0spc+A1VE=";
+    hash = "sha256-0Ym06RshDzn6+DEoBkjAAlvkWkMKSWcKF0xVR2KJWX8=";
   };
 
-  vendorHash = "sha256-Y1srOcXZ4rQ0QIQx4LdYzYG6goGk6oO30C+OW+s81z4=";
+  vendorHash = "sha256-k5MbOiJDvWFnaAPViNRHeqFa64XPZ3ImkkvkmTTscNA=";
 
   ldflags = ["-s" "-w"];
 


### PR DESCRIPTION
Update geth-sealer to [v1.12.0](https://github.com/manifoldfinance/geth-sealer/releases/tag/geth-sealer-v1.12.0) and remove it from blacklist (I updated it via `nix-update` successfully) 

Close #248 