### PR TITLE
update(packages/nimbus-eth2): Update `nimbus-eth2` to v23.6.1

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -15,6 +15,7 @@
       ./prysm-beacon
       ./prysm-validator
       ./restore
+      ./nimbus-eth2
     ];
   };
 }

--- a/modules/erigon/default.nix
+++ b/modules/erigon/default.nix
@@ -87,6 +87,11 @@ in {
               ${concatStringsSep " \\\n" args} \
               ${lib.escapeShellArgs cfg.extraArgs}
             '';
+
+            package =
+              if cfg.blst-portable
+              then pkgs.erigon-blst-portable
+              else cfg.package;
           in
             nameValuePair serviceName (mkIf cfg.enable {
               description = "Erigon Ethereum node (${erigonName})";
@@ -102,7 +107,7 @@ in {
                   ExecStartPre = mkIf cfg.subVolume (mkBefore [
                     "+${scripts.setupSubVolume} /var/lib/private/${serviceName}"
                   ]);
-                  ExecStart = "${cfg.package}/bin/erigon ${scriptArgs}";
+                  ExecStart = "${package}/bin/erigon ${scriptArgs}";
                 }
               ];
             })

--- a/modules/erigon/options.nix
+++ b/modules/erigon/options.nix
@@ -19,6 +19,12 @@
         default = [];
       };
 
+      blst-portable = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc "Make blst library used by erigon build in portable mode. When this option is enabled, the package option is ignored.";
+      };
+
       package = mkOption {
         type = types.package;
         default = pkgs.erigon;

--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -97,7 +97,7 @@ lib: let
   };
 in {
   inherit baseServiceConfig;
-  inherit mkArg mkArgs defaultPathReducer dotPathReducer;
+  inherit mkArg mkArgs defaultPathReducer defaultArgReducer defaultArgFormatter dotPathReducer;
 
   findEnabled = with lib;
     tree: let

--- a/modules/nimbus-eth2/args.nix
+++ b/modules/nimbus-eth2/args.nix
@@ -1,0 +1,115 @@
+lib:
+with lib; {
+  network = mkOption {
+    type = types.nullOr (types.enum ["goerli" "prater" "ropsten" "sepolia" "nimbus"]);
+    default = null;
+    description = mdDoc "The network to connect to. Mainnet (null) is the default ethereum network.";
+  };
+
+  jwt-secret = mkOption {
+    type = types.path;
+    default = null;
+    example = "/var/run/nimbus/jwtsecret";
+    description = mdDoc ''
+      Path of file with 32 bytes long JWT secret for Auth RPC endpoint.
+      Can be generated using 'openssl rand -hex 32'.
+    '';
+  };
+
+  udp-port = mkOption {
+    type = types.port;
+    default = 12000;
+    description = mdDoc "The port used by discv5.";
+  };
+
+  tcp-port = mkOption {
+    type = types.port;
+    default = 13000;
+    description = mdDoc "The port used by libp2p.";
+  };
+
+  subscribe-all-subnets = mkOption {
+    type = types.bool;
+    default = false;
+    description = mdDoc "Subscribe to all attestation subnet topics.";
+  };
+
+  doppelganger-detection = mkOption {
+    type = types.bool;
+    default = true;
+    description = mdDoc ''
+      Protection against slashing due to double-voting.
+      Means you will miss two attestations when restarting.
+    '';
+  };
+
+  suggested-fee-recipient = mkOption {
+    type = types.nullOr types.str;
+    default = null;
+    description = mdDoc ''
+      Wallet address where transaction fee tips - priority fees,
+      unburnt portion of gas fees - will be sent.
+    '';
+  };
+
+  nat = mkOption {
+    type = types.str;
+    default = "any";
+    example = "extip:12.34.56.78";
+    description = mdDoc ''
+      Method for determining public address. (any, none, upnp, pmp, extip:IP)
+    '';
+  };
+
+  metrics = {
+    enable = lib.mkEnableOption (mdDoc "Nimbus beacon node metrics endpoint");
+    address = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = mdDoc "Metrics address for beacon node.";
+    };
+    port = mkOption {
+      type = types.port;
+      default = 9100;
+      description = mdDoc "Metrics port for beacon node.";
+    };
+  };
+
+  rest = {
+    enable = lib.mkEnableOption (mdDoc "Nimbus beacon node REST API");
+    address = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = mdDoc "Listening address of the REST API server.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 5052;
+      description = mdDoc "Port for the REST API server.";
+    };
+  };
+
+  log = {
+    level = mkOption {
+      type = types.enum ["trace" "debug" "info" "notice" "warn" "error" "fatal" "none"];
+      default = "info";
+      example = "debug";
+      description = mdDoc "Logging level.";
+    };
+
+    format = mkOption {
+      type = types.enum ["auto" "colors" "nocolors" "json"];
+      default = "auto";
+      example = "json";
+      description = mdDoc "Logging formatting.";
+    };
+  };
+
+  web3-urls = mkOption {
+    type = types.listOf types.str;
+    default = [];
+    example = ["http://localhost:8551/"];
+    description = mdDoc "Mandatory URL(s) for the Web3 RPC endpoints.";
+  };
+}

--- a/modules/nimbus-eth2/args.nix
+++ b/modules/nimbus-eth2/args.nix
@@ -112,4 +112,11 @@ with lib; {
     example = ["http://localhost:8551/"];
     description = mdDoc "Mandatory URL(s) for the Web3 RPC endpoints.";
   };
+
+  trusted-node-url = mkOption {
+    type = types.nullOr types.str;
+    default = null;
+    example = "http://localhost:5052/";
+    description = mdDoc "URL for Trusted Node Sync.";
+  };
 }

--- a/modules/nimbus-eth2/args.nix
+++ b/modules/nimbus-eth2/args.nix
@@ -119,4 +119,10 @@ with lib; {
     example = "http://localhost:5052/";
     description = mdDoc "URL for Trusted Node Sync.";
   };
+
+  backfill = mkOption {
+    type = types.nullOr types.bool;
+    default = true;
+    description = mdDoc "History backfill.";
+  };
 }

--- a/modules/nimbus-eth2/default.nix
+++ b/modules/nimbus-eth2/default.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }: let
-  modulesLib = import ../lib.nix {inherit lib pkgs;};
+  modulesLib = import ../lib.nix lib;
 
   inherit (lib.lists) findFirst sublist last;
   inherit (lib.strings) hasPrefix;

--- a/modules/nimbus-eth2/default.nix
+++ b/modules/nimbus-eth2/default.nix
@@ -1,0 +1,143 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  modulesLib = import ../lib.nix {inherit lib pkgs;};
+
+  inherit (lib.lists) findFirst sublist last;
+  inherit (lib.strings) hasPrefix;
+  inherit (lib.attrsets) zipAttrsWith;
+  inherit
+    (lib)
+    concatStringsSep
+    filterAttrs
+    flatten
+    mapAttrs'
+    mapAttrsToList
+    mkIf
+    mkMerge
+    nameValuePair
+    types
+    ;
+  inherit (modulesLib) mkArgs baseServiceConfig defaultArgReducer;
+
+  eachBeacon = config.services.ethereum.nimbus-eth2;
+in {
+  ###### interface
+  inherit (import ./options.nix {inherit lib pkgs;}) options;
+
+  ###### implementation
+
+  config = mkIf (eachBeacon != {}) {
+    # configure the firewall for each service
+    networking.firewall = let
+      openFirewall = filterAttrs (_: cfg: cfg.openFirewall) eachBeacon;
+      perService =
+        mapAttrsToList
+        (
+          _: cfg:
+            with cfg.args; {
+              allowedUDPPorts = [udp-port];
+              allowedTCPPorts = [tcp-port];
+            }
+        )
+        openFirewall;
+    in
+      zipAttrsWith (_name: flatten) perService;
+
+    systemd.services =
+      mapAttrs'
+      (
+        beaconName: let
+          serviceName = "nimbus-eth2";
+        in
+          cfg: let
+            scriptArgs = let
+              # generate args
+              args = let
+                opts = import ./args.nix lib;
+
+                pathReducer = path: let
+                  p =
+                    if (last path == "enable")
+                    then sublist 0 ((builtins.length path) - 1) path
+                    else path;
+                in "--${concatStringsSep "-" p}";
+
+                argFormatter = {
+                  opt,
+                  path,
+                  value,
+                  argReducer ? defaultArgReducer,
+                  pathReducer ? defaultArgReducer,
+                }: let
+                  arg = pathReducer path;
+                in
+                  if (opt.type == types.bool)
+                  then
+                    (
+                      if value
+                      then "${arg}"
+                      else ""
+                    )
+                  else "${arg}=${argReducer value}";
+              in
+                mkArgs {
+                  inherit opts;
+                  inherit (cfg) args;
+                  inherit argFormatter;
+                  inherit pathReducer;
+                };
+
+              # filter out certain args which need to be treated differently
+              specialArgs = ["--network" "--jwt-secret" "--web3-urls"];
+              isNormalArg = name: (findFirst (arg: hasPrefix arg name) null specialArgs) == null;
+              filteredArgs = builtins.filter isNormalArg args;
+
+              network =
+                if cfg.args.network != null
+                then "--network=${cfg.args.network}"
+                else "";
+
+              jwtSecret =
+                if cfg.args.jwt-secret != null
+                then ''--jwt-secret="%d/jwt-secret"''
+                else "";
+
+              web3Url =
+                if cfg.args.web3-urls != null
+                then ''--web3-url=${concatStringsSep " --web3-url=" cfg.args.web3-urls}''
+                else "";
+            in ''
+              ${network} ${jwtSecret} \
+              ${web3Url} \
+              --data-dir="%S/${serviceName}" \
+              ${concatStringsSep " \\\n" filteredArgs} \
+              ${lib.escapeShellArgs cfg.extraArgs}
+            '';
+          in
+            nameValuePair serviceName (mkIf cfg.enable {
+              after = ["network.target"];
+              wantedBy = ["multi-user.target"];
+              description = "Nimbus Beacon Node (${beaconName})";
+
+              # create service config by merging with the base config
+              serviceConfig = mkMerge [
+                baseServiceConfig
+                {
+                  User = serviceName;
+                  StateDirectory = serviceName;
+                  ExecStart = "${cfg.package}/bin/nimbus_beacon_node ${scriptArgs}";
+                  MemoryDenyWriteExecute = "false"; # causes a library loading error
+                }
+                (mkIf (cfg.args.jwt-secret != null) {
+                  LoadCredential = ["jwt-secret:${cfg.args.jwt-secret}"];
+                })
+              ];
+            })
+      )
+      eachBeacon;
+  };
+}

--- a/modules/nimbus-eth2/default.nix
+++ b/modules/nimbus-eth2/default.nix
@@ -69,6 +69,11 @@ in {
               then ''--trusted-node-url="${cfg.args.trusted-node-url}"''
               else "";
 
+            backfilling =
+              if cfg.args.trusted-node-url != null
+              then ''--backfill=${lib.boolToString cfg.args.backfill}''
+              else "";
+
             web3Url =
               if cfg.args.web3-urls != null
               then ''--web3-url=${concatStringsSep " --web3-url=" cfg.args.web3-urls}''
@@ -113,7 +118,7 @@ in {
                   inherit pathReducer;
                 };
               # filter out certain args which need to be treated differently
-              specialArgs = ["--network" "--jwt-secret" "--web3-urls" "--trusted-node-url"];
+              specialArgs = ["--network" "--jwt-secret" "--web3-urls" "--trusted-node-url" "--backfill"];
               isNormalArg = name: (findFirst (arg: hasPrefix arg name) null specialArgs) == null;
               filteredArgs = builtins.filter isNormalArg args;
             in ''
@@ -127,7 +132,8 @@ in {
             nodeSyncArgs = ''
               ${network} \
               ${dataDir} \
-              ${trustedNodeUrl}
+              ${trustedNodeUrl} \
+              ${backfilling}
             '';
 
             entrypoint =

--- a/modules/nimbus-eth2/options.nix
+++ b/modules/nimbus-eth2/options.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  args = import ./args.nix lib;
+  nimbusOpts = with lib; {
+    options = {
+      enable = mkEnableOption (mdDoc "Nimbus Beacon Node service");
+
+      inherit args;
+
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = ["--num-threads=1" "--graffiti=1337_h4x0r"];
+        description = mdDoc "Additional arguments passed to node.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.nimbus-eth2;
+        defaultText = literalExpression "pkgs.nimbus-eth2";
+        description = mdDoc "Package to use for Nimbus Beacon Node binary";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc "Open ports in the firewall for any enabled networking services";
+      };
+
+      # mixin backup options
+      backup = let
+        inherit (import ../backup/lib.nix lib) options;
+      in
+        options;
+
+      # mixin restore options
+      restore = let
+        inherit (import ../restore/lib.nix lib) options;
+      in
+        options;
+    };
+  };
+in {
+  options.services.ethereum.nimbus-eth2 = with lib;
+    mkOption {
+      type = types.attrsOf (types.submodule nimbusOpts);
+      default = {};
+      description = mdDoc "Specification of one or more Nimbus Beacon Node instances.";
+    };
+}

--- a/packages/clients/consensus/nimbus-eth2/default.nix
+++ b/packages/clients/consensus/nimbus-eth2/default.nix
@@ -1,0 +1,79 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  darwin,
+  lib,
+  nim,
+  cmake,
+  which,
+  writeScriptBin,
+  # Options: nimbus_light_client, nimbus_validator_client, nimbus_signing_node
+  makeTargets ? ["all"],
+  # These are the only platforms tested in CI and considered stable.
+  stablePlatforms ? [
+    "x86_64-linux"
+    "aarch64-linux"
+    "armv7a-linux"
+    "x86_64-darwin"
+    "aarch64-darwin"
+    "x86_64-windows"
+  ],
+}:
+# Version 1.6.12 is known to be stable and overriden in top-level.
+assert nim.version == "1.6.12";
+  stdenv.mkDerivation rec {
+    pname = "nimbus";
+    rev = "499b870a1a8e6688ff03b958709955075064b7e5";
+    version = "23.3.2.dev";
+
+    src = fetchFromGitHub {
+      owner = "status-im";
+      repo = "nimbus-eth2";
+      inherit rev;
+      hash = "sha256-0w9XGXxCAhBAuMkQ42Wh67Lmetn7Ihbdoq3iBOSx71k=";
+      fetchSubmodules = true;
+    };
+
+    # Fix for Nim compiler calling 'git rev-parse' and 'lsb_release'.
+    nativeBuildInputs = let
+      fakeGit = writeScriptBin "git" "echo $commit";
+      fakeLsbRelease = writeScriptBin "lsb_release" "echo nix";
+    in
+      [fakeGit fakeLsbRelease nim which cmake]
+      ++ lib.optionals stdenv.isDarwin [darwin.cctools];
+
+    enableParallelBuilding = true;
+
+    # Disable CPU optmizations that make binary not portable.
+    NIMFLAGS = "-d:disableMarchNative -d:git_revision_override=${rev}";
+
+    makeFlags = makeTargets ++ ["USE_SYSTEM_NIM=1"];
+
+    # Generate the nimbus-build-system.paths file.
+    configurePhase = ''
+      patchShebangs scripts vendor/nimbus-build-system/scripts
+      make nimbus-build-system-paths
+    '';
+
+    installPhase = ''
+      mkdir -p $out/bin
+      rm build/generate_makefile
+      cp build/* $out/bin
+    '';
+
+    meta = with lib; {
+      homepage = "https://nimbus.guide/";
+      downloadPage = "https://github.com/status-im/nimbus-eth2/releases";
+      changelog = "https://github.com/status-im/nimbus-eth2/blob/stable/CHANGELOG.md";
+      description = "Nimbus is a lightweight client for the Ethereum consensus layer";
+      longDescription = ''
+        Nimbus is an extremely efficient consensus layer client implementation.
+        While it's optimised for embedded systems and resource-restricted devices --
+        including Raspberry Pis, its low resource usage also makes it an excellent choice
+        for any server or desktop (where it simply takes up fewer resources).
+      '';
+      license = with licenses; [asl20 mit];
+      mainProgram = "nimbus_beacon_node";
+      platforms = stablePlatforms;
+    };
+  }

--- a/packages/clients/consensus/nimbus-eth2/default.nix
+++ b/packages/clients/consensus/nimbus-eth2/default.nix
@@ -6,6 +6,7 @@
   nim,
   cmake,
   which,
+  fetchpatch,
   writeScriptBin,
   # Options: nimbus_light_client, nimbus_validator_client, nimbus_signing_node
   makeTargets ? ["all"],
@@ -19,20 +20,29 @@
     "x86_64-windows"
   ],
 }:
-# Version 1.6.12 is known to be stable and overriden in top-level.
-assert nim.version == "1.6.12";
+# Nim version(s) that are known to be stable
+assert nim.version == "1.6.12" || nim.version == "1.6.14";
   stdenv.mkDerivation rec {
     pname = "nimbus";
-    rev = "1bc9f3a67ac519ab4f889ca19abfd74f5e07c205";
-    version = "23.6.0";
+    rev = "187e1a06335e36bbc508fff38729833d154edbaa";
+    version = "23.6.1";
 
     src = fetchFromGitHub {
       owner = "status-im";
       repo = "nimbus-eth2";
       inherit rev;
-      hash = "sha256-uAaKKLMlQRklUfTyYmdwI+27evmEEGVE2TFkKuCgAes=";
+      hash = "sha256-O7jxRuJZkrdNZVZ3jMOPjTh/tWk3XgPwx5A0xgELvAU=";
       fetchSubmodules = true;
     };
+
+    patches = [
+      # Nim 1.6.14 support
+      (fetchpatch {
+        name = "nim-v1.6.14-support.patch";
+        url = "https://github.com/status-im/nimbus-eth2/commit/41b93ae57a7bb32758f453a09259ae44b37e3db9.patch";
+        hash = "sha256-yvXREhqc/C0Yo2ioTaOFFw7KAc0WgDkoM5SXXnaIjrQ=";
+      })
+    ];
 
     # Fix for Nim compiler calling 'git rev-parse' and 'lsb_release'.
     nativeBuildInputs = let

--- a/packages/clients/consensus/nimbus-eth2/default.nix
+++ b/packages/clients/consensus/nimbus-eth2/default.nix
@@ -23,14 +23,14 @@
 assert nim.version == "1.6.12";
   stdenv.mkDerivation rec {
     pname = "nimbus";
-    rev = "499b870a1a8e6688ff03b958709955075064b7e5";
-    version = "23.3.2.dev";
+    rev = "1bc9f3a67ac519ab4f889ca19abfd74f5e07c205";
+    version = "23.6.0";
 
     src = fetchFromGitHub {
       owner = "status-im";
       repo = "nimbus-eth2";
       inherit rev;
-      hash = "sha256-0w9XGXxCAhBAuMkQ42Wh67Lmetn7Ihbdoq3iBOSx71k=";
+      hash = "sha256-uAaKKLMlQRklUfTyYmdwI+27evmEEGVE2TFkKuCgAes=";
       fetchSubmodules = true;
     };
 

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -26,6 +26,9 @@
 
       # Execution Clients
       erigon = callPackage ./clients/execution/erigon {};
+      erigon-blst-portable = erigon.overrideAttrs (_finalAttrs: _previousAttrs: {
+        CGO_CFLAGS = "-O -D__BLST_PORTABLE__";
+      });
       besu = callPackage ./clients/execution/besu {};
       geth = callPackage ./clients/execution/geth {};
       geth-sealer = callPackage ./clients/execution/geth-sealer {};

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -22,7 +22,7 @@
       lighthouse = callPackage ./clients/consensus/lighthouse {inherit foundry;};
       prysm = callPackage ./clients/consensus/prysm {inherit bls blst;};
       teku = callPackage ./clients/consensus/teku {};
-      nimbus = callPackage ./clients/consensus/nimbus {};
+      nimbus-eth2 = callPackage ./clients/consensus/nimbus-eth2 {};
 
       # Execution Clients
       erigon = callPackage ./clients/execution/erigon {};
@@ -93,8 +93,8 @@
       # consensus / lighthouse
       lighthouse.bin = "lighthouse";
 
-      # consensus / nimbus
-      nimbus.bin = "nimbus_beacon_node";
+      # consensus / nimbus-eth2
+      nimbus-eth2.bin = "nimbus_beacon_node";
 
       # execution clients
       besu.bin = "besu";


### PR DESCRIPTION
- feat(packages/clients/consensus/nimbus-eth2): Init package at 23.3.2.dev
- feat(modules/nimbus-eth2): Init `Nimbus Beacon Node` Module
- feat(modules/nimbus-eth2): Add `trusted-node-url` argument
- feat(modules/nimbus-eth2): Add `backfill` argument
- update(packages/nimbus-eth2): Update `nimbus-eth2` to the newest version
- config(modules/nimbus-eth2): Fix problem with trustedNodeSync
- build(erigon-portable): Add variant that compiles BLST in portable mode
- update(packages/nimbus-eth2): Update `nimbus-eth2` to v23.6.1
