### PR TITLE
feat(slither): update slither and add a crytic-compile as a lib

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -9,13 +9,14 @@
 
   perSystem = {
     self',
+    inputs',
     pkgs,
     system,
     ...
   }: let
     inherit (pkgs) callPackage;
     inherit (lib.flake) platformPkgs platformApps;
-    #callPackageUnstable = inputs'.nixpkgs-unstable.legacyPackages.callPackage;
+    callPackageUnstable = inputs'.nixpkgs-unstable.legacyPackages.callPackage;
   in {
     packages = platformPkgs system rec {
       # Consensus Clients
@@ -69,13 +70,14 @@
       vscode-plugin-consensys-vscode-solidity-visual-editor = callPackage ./editors/vscode/extensions/consensys.vscode-solidity-auditor {};
 
       # Solidity
-      slither = callPackage ./solidity/analyzers/slither {};
+      slither = callPackageUnstable ./solidity/analyzers/slither {inherit crytic-compile;};
 
       # Libs
       evmc = callPackage ./libs/evmc {};
       mcl = callPackage ./libs/mcl {};
       bls = callPackage ./libs/bls {};
       blst = callPackage ./libs/blst {};
+      crytic-compile = callPackageUnstable ./libs/crytic-compile {};
     };
 
     apps = platformApps self'.packages {

--- a/packages/libs/crytic-compile/default.nix
+++ b/packages/libs/crytic-compile/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+python3.pkgs.buildPythonPackage rec {
+  pname = "crytic-compile";
+  version = "0.3.3";
+  format = "setuptools";
+
+  disabled = python3.pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "crytic";
+    repo = "crytic-compile";
+    rev = "refs/tags/${version}";
+    hash = "sha256-Nx3eKy/0BLg82o3qDHjxcHXtpX3KDdnBKYwCuTLWRUE=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    cbor2
+    pycryptodome
+    setuptools
+    solc-select
+  ];
+
+  # Test require network access
+  doCheck = false;
+
+  # required for import check to work
+  # PermissionError: [Errno 13] Permission denied: '/homeless-shelter'
+  env.HOME = "/tmp";
+  pythonImportsCheck = [
+    "crytic_compile"
+  ];
+
+  meta = with lib; {
+    description = "Abstraction layer for smart contract build systems";
+    homepage = "https://github.com/crytic/crytic-compile";
+    license = licenses.agpl3Plus;
+    platforms = ["x86_64-linux"];
+  };
+}

--- a/packages/solidity/analyzers/slither/default.nix
+++ b/packages/solidity/analyzers/slither/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   python3,
+  crytic-compile,
 }:
 python3.pkgs.buildPythonPackage rec {
   pname = "slither";
@@ -30,6 +31,12 @@ python3.pkgs.buildPythonPackage rec {
     packaging
     prettytable
   ];
+
+  # required for import check to work
+  # PermissionError: [Errno 13] Permission denied: '/homeless-shelter'
+  env.HOME = "/tmp";
+  # Test require network access
+  doCheck = false;
 
   pythonImportsCheck = ["slither"];
 


### PR DESCRIPTION
We couldn't update `slither` because unstable nixpkgs has a `0.3.0` crytic-compile version, but the latest `slither` needs at least `0.3.3`. I added `crytic-compile` as a package dependency until nixpkgs will merge [this PR](https://github.com/NixOS/nixpkgs/pull/230067)