### PR TITLE
feat: add eth2-val-tools

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -54,6 +54,7 @@
 
       # Utils
       eth2-testnet-genesis = callPackage ./utils/eth2-testnet-genesis {inherit bls;};
+      eth2-val-tools = callPackage ./utils/eth2-val-tools {inherit bls mcl;};
       ethdo = callPackage ./utils/ethdo {inherit bls mcl;};
       ethereal = callPackage ./utils/ethereal {inherit bls mcl;};
       sedge = callPackage ./utils/sedge {inherit bls mcl;};
@@ -152,6 +153,7 @@
       slither.bin = "slither";
 
       # utils
+      eth2-val-tools.bin = "eth2-val-tools";
       eth2-testnet-genesis.bin = "eth2-testnet-genesis";
       ethdo.bin = "ethdo";
       ethereal.bin = "ethereal";

--- a/packages/utils/eth2-val-tools/default.nix
+++ b/packages/utils/eth2-val-tools/default.nix
@@ -1,0 +1,36 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  clang,
+  mcl,
+  bls,
+  lib,
+  ...
+}:
+buildGoModule rec {
+  pname = "eth2-val-tools";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "protolambda";
+    repo = "eth2-val-tools";
+    rev = "v${version}";
+    hash = "sha256-PkdkS0pRu2W2s9We022VzjXWZkIuuBCKMJNVkn12SWE=";
+  };
+
+  runVend = true;
+  vendorHash = "sha256-ICHc5l+hMl6YgAWfwLbY/zLAgGCBjqwwGNydm/UXELM=";
+
+  nativeBuildInputs = [clang];
+  buildInputs = [mcl bls];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Some experimental tools to manage validators";
+    homepage = "https://github.com/protolambda/eth2-val-tools";
+    license = licenses.mit;
+    mainProgram = "eth2-val-tools";
+    platforms = ["x86_64-linux" "aarch64-darwin"];
+  };
+}


### PR DESCRIPTION
Current [holesky genesis onboarding guide](https://notes.ethereum.org/@ethpandaops/Holesky-onboarding) mentions [eth2-val-tools](https://github.com/protolambda/eth2-val-tools) very often, so I decided to add it too