### PR TITLE
chore(workflows/update-packages): blacklist some packages

### DIFF
--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -15,9 +15,9 @@ jobs:
         id: update
         uses: selfuryon/nix-update-action@v1.0.0
         with:
-          # TODO: remove nethermind and erigon after we fix build for them
+          # TODO: remove nethermind after we fix build for them
           # TODO: remove mev-boost after they make a new release tag
-          blacklist: "staking-deposit-cli,dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,mev-boost,nethermind,erigon"
+          blacklist: "staking-deposit-cli,dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,mev-boost,nethermind"
           sign-commits: true
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -15,7 +15,9 @@ jobs:
         id: update
         uses: selfuryon/nix-update-action@v1.0.0
         with:
-          blacklist: "staking-deposit-cli,dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools"
+          # TODO: remove nethermind and erigon after we fix build for them
+          # TODO: remove mev-boost after they make a new release tag
+          blacklist: "staking-deposit-cli,dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,mev-boost,nethermind,erigon"
           sign-commits: true
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
Consider to disable auto update for these packages:
* mev-boost: until they will make a new release tag. Actually, it's very strange that `nix-update` try to update it to a pre-release version (1.6.0 -> 1.6.4844-dev2)
* erigon: until we fix its build #370 [Done]
* nethermind: until we fix build with Package Source Mapping #345 