### PR TITLE
chore: Add "holesky" testnet to enums

### DIFF
--- a/modules/erigon/args.nix
+++ b/modules/erigon/args.nix
@@ -21,6 +21,7 @@ with lib; {
       "mainnet"
       "rinkeby"
       "goerli"
+      "holesky"
       "sokol"
       "fermion"
       "mumbai"

--- a/modules/geth/args.nix
+++ b/modules/geth/args.nix
@@ -119,7 +119,7 @@ with lib; {
   };
 
   network = mkOption {
-    type = types.nullOr (types.enum ["goerli" "kiln" "rinkeby" "ropsten" "sepolia"]);
+    type = types.nullOr (types.enum ["goerli" "holesky" "kiln" "rinkeby" "ropsten" "sepolia"]);
     default = null;
     description = mdDoc "The network to connect to. Mainnet (null) is the default ethereum network.";
   };

--- a/modules/prysm-beacon/args.nix
+++ b/modules/prysm-beacon/args.nix
@@ -1,7 +1,7 @@
 lib:
 with lib; {
   network = mkOption {
-    type = types.nullOr (types.enum ["goerli" "prater" "ropsten" "sepolia"]);
+    type = types.nullOr (types.enum ["goerli" "holesky" "prater" "ropsten" "sepolia"]);
     default = null;
     description = mdDoc "The network to connect to. Mainnet (null) is the default ethereum network.";
   };

--- a/modules/prysm-validator/args.nix
+++ b/modules/prysm-validator/args.nix
@@ -1,7 +1,7 @@
 lib:
 with lib; {
   network = mkOption {
-    type = types.nullOr (types.enum ["goerli" "prater" "ropsten" "sepolia"]);
+    type = types.nullOr (types.enum ["goerli" "holesky" "prater" "ropsten" "sepolia"]);
     default = null;
     description = mdDoc "The network to connect to. Mainnet (null) is the default ethereum network.";
   };


### PR DESCRIPTION
Add `holesky` testnet to enum types for Prysm/Geth/Erigon. 
MEV-Boost is left untouched (no upstream support yet)