### PR TITLE
chore: bump bls version + add assembly.S to $out/include for blst

### DIFF
--- a/packages/clients/consensus/prysm/default.nix
+++ b/packages/clients/consensus/prysm/default.nix
@@ -29,6 +29,12 @@ buildGoModule rec {
 
   doCheck = false;
 
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/prysmaticlabs/prysm/v4/runtime/version.gitTag=v${version}"
+  ];
+
   meta = {
     description = "Go implementation of Ethereum proof of stake";
     homepage = "https://github.com/prysmaticlabs/prysm";

--- a/packages/libs/bls/default.nix
+++ b/packages/libs/bls/default.nix
@@ -6,14 +6,14 @@
 }:
 stdenv.mkDerivation rec {
   pname = "bls";
-  version = "1.35";
+  version = "1.86";
 
   src = fetchFromGitHub {
     owner = "herumi";
     repo = "bls";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-fHwNiZ0B5ow9GBWjO5c+rpK/jlziaMF5Bh+HQayIBUI=";
+    hash = "sha256-VIJi8sjDq40ecPnEWzFPDR2t5rCOUIWxfI4QAemfPPM=";
   };
 
   nativeBuildInputs = [cmake];

--- a/packages/libs/blst/builder.sh
+++ b/packages/libs/blst/builder.sh
@@ -8,6 +8,7 @@ installPhase() {
     mkdir -p $out/{include/elf,lib}
     cp libblst.a $out/lib/
     cp bindings/*.{h,hpp} $out/include/
+    cp build/assembly.S $out/include/
     cp build/elf/* $out/include/elf/
     cp src/*.h $out/include/
     cp src/*.c $out/include/


### PR DESCRIPTION
Hello!
I tried to compile a prysm version [v4.1.0-alpha.0](https://github.com/prysmaticlabs/prysm/releases/tag/v4.1.0-alpha.0), because only this version supports holesky, and I faced with issue in blst integration: 
```
# github.com/supranational/blst/bindings/go
cgo_assembly.S:1:10: fatal error: assembly.S: No such file or directory
    1 | #include "assembly.S"
      |          ^~~~~~~~~~~~
compilation terminated.
```

So I added `assembly.S` to output for blst and after that prysm build works fine.

In additional, I bumped a bls version + add a version setting for prysm during the build.