### PR TITLE
prysm: build with go 1.20

### DIFF
--- a/packages/clients/consensus/prysm/default.nix
+++ b/packages/clients/consensus/prysm/default.nix
@@ -1,11 +1,11 @@
 {
   bls,
   blst,
-  buildGoModule,
+  buildGo120Module,
   fetchFromGitHub,
   libelf,
 }:
-buildGoModule rec {
+buildGo120Module rec {
   pname = "prysm";
   version = "4.1.1";
 


### PR DESCRIPTION
Prysm has dependencies which prevent it from being built with Go 1.21 (now default on unstable), so we have to pin it to Go 1.20.

Error message:
```
> vendor/github.com/quic-go/quic-go/internal/qtls/go121.go:5:13: cannot use "The version of quic-go you're using can't be built on Go1.21 yet. For more details, please see https://github.com/quic-go/quic-go/wiki/quic-go-and-Go-versions." (untyped string constant "The version of quic-go you're using can't be built on Go 1.21 yet. F...) as int value in variable declaration
```