### PR TITLE
feat(eigenlayer-cli): add eigenlayer-cli

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -49,6 +49,7 @@
       ssvnode = callPackage ./dvt/ssvnode {inherit bls mcl;};
 
       # Utils
+      eigenlayer-cli = callPackageUnstable ./utils/eigenlayer-cli {};
       eth2-testnet-genesis = callPackage ./utils/eth2-testnet-genesis {inherit bls;};
       eth2-val-tools = callPackage ./utils/eth2-val-tools {inherit bls mcl;};
       ethdo = callPackage ./utils/ethdo {inherit bls mcl;};

--- a/packages/utils/eigenlayer-cli/default.nix
+++ b/packages/utils/eigenlayer-cli/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGo121Module,
+  fetchFromGitHub,
+}:
+buildGo121Module rec {
+  pname = "eigenlayer-cli";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "NethermindEth";
+    repo = "eigenlayer";
+    rev = "v${version}";
+    hash = "sha256-VO56mMkUVeZN+YJ/cxPyZQ5dGvVDirslH4jhV5hpufQ=";
+  };
+
+  vendorHash = "sha256-DDGMprfryWj9Td4PX/j5Fsjm+bGGiDgnCXmm2IhRSMo=";
+
+  ldflags = ["-s" "-w"];
+  subPackages = ["cmd/eigenlayer"];
+
+  # Can't pass tests with mockgen and go generate ./...
+  # preBuild = ''
+  #   go generate ./...
+  # '';
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/eigenlayer $out/bin/eigenlayer-cli
+  '';
+
+  meta = with lib; {
+    description = "Utility manages core operator functionalities like local key management, operator registration and updates";
+    homepage = "https://www.eigenlayer.xyz/";
+    license = licenses.bsl11;
+    mainProgram = "eigenlayer-cli";
+    platforms = ["x86_64-linux" "aarch64-darwin"];
+  };
+}


### PR DESCRIPTION
EigenLayer has a [cli utility](https://github.com/NethermindEth/eigenlayer/tree/develop) to manage operator settings. I think it would be helpful to have it here