### PR TITLE
fix: revert to build packages manually in flake check

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,22 +16,6 @@
         "type": "github"
       }
     },
-    "devour-flake_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1694098737,
-        "narHash": "sha256-O51F4YFOzlaQAc9b6xjkAqpvrvCtw/Os2M7TU0y4SKQ=",
-        "owner": "srid",
-        "repo": "devour-flake",
-        "rev": "30a34036b29b0d12989ef6c8be77aa949d85aef5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "devour-flake",
-        "type": "github"
-      }
-    },
     "devshell": {
       "inputs": {
         "nixpkgs": [
@@ -197,7 +181,9 @@
     },
     "mynixpkgs": {
       "inputs": {
-        "devour-flake": "devour-flake_2",
+        "devour-flake": [
+          "devour-flake"
+        ],
         "devshell": [
           "devshell"
         ],
@@ -219,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700152649,
-        "narHash": "sha256-hr69KASr/uWyQJ9dfGk1b/o58h8MB+N9eBOqpxRx7no=",
+        "lastModified": 1701258184,
+        "narHash": "sha256-RAmIb5DVd4I4jn0Nzwd0iPmO4YZwzsx7Wno5a30k8IM=",
         "owner": "aldoborrero",
         "repo": "mynixpkgs",
-        "rev": "e376efd8ead02ce897c25cc496805de64f9d2222",
+        "rev": "0d415cfc494dfc105a0fd5ebf83411be82a4d9b3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
       inputs.lib-extras.follows = "lib-extras";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
       inputs.treefmt-nix.follows = "treefmt-nix";
+      inputs.devour-flake.follows = "devour-flake";
     };
 
     foundry-nix = {
@@ -189,7 +190,7 @@
             # };
           }
           # merge in the package derivations to force a build of all packages during a `nix flake check`
-          // (with lib; mapAttrs' (n: nameValuePair "package-${n}") self'.packages)
+          // (with lib; mapAttrs' (n: nameValuePair "package-${n}") (filterAttrs (n: _: ! builtins.elem n ["docs"]) self'.packages))
           # mix in tests
           // config.testing.checks;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,7 @@
         pkgs,
         pkgsUnstable,
         system,
+        self',
         ...
       }: {
         # pkgs
@@ -169,25 +170,26 @@
         };
 
         # checks
-        checks = let
-          devour-flake = pkgs.callPackage inputs.devour-flake {};
-        in
+        checks =
           {
-            nix-build-all = pkgs.writeShellApplication {
-              name = "nix-build-all";
-              runtimeInputs = [
-                pkgs.nix
-                devour-flake
-              ];
-              text = ''
-                # Make sure that flake.lock is sync
-                nix flake lock --no-update-lock-file
-
-                # Do a full nix build (all outputs)
-                devour-flake . "$@"
-              '';
-            };
+            # TODO: Restore this check whenever buildbot supports more specific checks
+            # nix-build-all = pkgs.writeShellApplication {
+            #   name = "nix-build-all";
+            #   runtimeInputs = [
+            #     pkgs.nix
+            #     devour-flake
+            #   ];
+            #   text = ''
+            #     # Make sure that flake.lock is sync
+            #     nix flake lock --no-update-lock-file
+            #
+            #     # Do a full nix build (all outputs)
+            #     devour-flake . "$@"
+            #   '';
+            # };
           }
+          # merge in the package derivations to force a build of all packages during a `nix flake check`
+          // (with lib; mapAttrs' (n: nameValuePair "package-${n}") self'.packages)
           # mix in tests
           // config.testing.checks;
       };

--- a/mkdocs.nix
+++ b/mkdocs.nix
@@ -76,6 +76,8 @@
 
           ${lib.getExe mkdocs-custom} serve
         '';
+
+        meta.platforms = ["x86_64-linux"];
       };
 
     devshells.default.commands = let

--- a/mkdocs.nix
+++ b/mkdocs.nix
@@ -6,31 +6,29 @@
     ...
   }: let
     inherit (pkgs) stdenv runCommand;
-
-    mkdocs-custom =
-      runCommand "mkdocs-custom" {
-        buildInputs = [
-          pkgs.python311
-          pkgs.python311Packages.mkdocs
-          pkgs.python311Packages.mkdocs-material
-          inputs.mynixpkgs.packages.${system}.mkdocs-plugins
-        ];
-
-        meta.mainProgram = "mkdocs";
-      } ''
-        mkdir -p $out/bin
-
-        cat <<MKDOCS > $out/bin/mkdocs
-        #!${pkgs.runtimeShell}
-        set -euo pipefail
-        export PYTHONPATH=$PYTHONPATH
-        exec ${pkgs.python311Packages.mkdocs}/bin/mkdocs "\$@"
-        MKDOCS
-
-        chmod +x $out/bin/mkdocs
-      '';
   in {
     packages.docs = let
+      mkdocs-custom =
+        pkgs.runCommand "mkdocs-custom" {
+          buildInputs = [
+            pkgs.python311
+            pkgs.python311Packages.mkdocs
+            pkgs.python311Packages.mkdocs-material
+            inputs.mynixpkgs.packages.${system}.mkdocs-plugins
+          ];
+          meta.mainProgram = "mkdocs";
+        } ''
+          mkdir -p $out/bin
+
+          cat <<MKDOCS > $out/bin/mkdocs
+          #!${pkgs.runtimeShell}
+          set -euo pipefail
+          export PYTHONPATH=$PYTHONPATH
+          exec ${pkgs.python311Packages.mkdocs}/bin/mkdocs "\$@"
+          MKDOCS
+
+          chmod +x $out/bin/mkdocs
+        '';
       docsPath = "./docs/nixos/modules";
       nixosMarkdownDocs = runCommand "nixos-options" {} ''
         mkdir $out
@@ -76,8 +74,6 @@
 
           ${lib.getExe mkdocs-custom} serve
         '';
-
-        meta.platforms = ["x86_64-linux"];
       };
 
     devshells.default.commands = let

--- a/packages/clients/consensus/lodestar/default.nix
+++ b/packages/clients/consensus/lodestar/default.nix
@@ -1,0 +1,25 @@
+{
+stdenv,
+fetchFromGitHub,
+fetchYarnDeps,
+nodePackages,
+}: let
+  name = "lodestar";
+  version = "1.12.0";
+
+  src = fetchFromGitHub {
+    owner = "ChainSafe";
+    repo = "lodestar";
+    ref = "refs/tags/v${version}";
+    hash = "";
+  };
+
+  yarnDeps = stdenv.mkDerivation {
+    yarnLock = "${src}/yarn.lock";
+    hash = "";
+
+  };
+in yarnDeps
+# in stdenv.mkDerivation {
+  # inherit name version src;
+# }

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -20,6 +20,7 @@
       prysm = callPackage ./clients/consensus/prysm {inherit bls blst;};
       teku = callPackage ./clients/consensus/teku {};
       nimbus = callPackageUnstable ./clients/consensus/nimbus {};
+      lodestar = callPackage ./clients/consensus/lodestar {};
 
       # Execution Clients
       erigon = callPackage ./clients/execution/erigon {};

--- a/packages/solidity/frameworks/wake/default.nix
+++ b/packages/solidity/frameworks/wake/default.nix
@@ -66,6 +66,10 @@ poetry2nix.mkPoetryApplication {
     changelog = "https://github.com/Ackee-Blockchain/wake/releases/tag/v${version}";
     mainProgram = "woke";
     license = licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     maintainers = with maintainers; [aldoborrero];
   };
 }


### PR DESCRIPTION
We have been using `devour-flake` to build all inputs but recently when we switched to `buildbot` it skipped building it as it's only a `shellApplication` that needs to be run. This restores what we used to have for building all packages inside the check.