### PR TITLE
fix: darwin libusb issues with foundry

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -61,7 +61,9 @@
 
       # Dev
       foundry = inputs.foundry-nix.defaultPackage.${system}.overrideAttrs (_oldAttrs: {
-        meta.platforms = [system];
+        # TODO: Uncomment when https://github.com/shazow/foundry.nix/issues/23
+        # meta.platforms = [system];
+        meta.platforms = ["x86_64-linux" "aarch64-linux"];
       });
 
       # Editors


### PR DESCRIPTION
This solves the upstream issue of foundry not finding libusb on darwing architectures by just commenting the platforms.
