### PR TITLE
nimbus: Also build nimbus_validator_client

### DIFF
--- a/packages/clients/consensus/nimbus/default.nix
+++ b/packages/clients/consensus/nimbus/default.nix
@@ -7,7 +7,7 @@
   cmake,
   pkgs,
   writeShellScriptBin,
-  buildFlags ? ["nimbus_beacon_node"],
+  buildFlags ? ["nimbus_beacon_node" "nimbus_validator_client"],
 }: let
   nim1 = pkgs.nim-unwrapped-1.overrideAttrs rec {
     version = "1.6.16";

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -97,7 +97,10 @@
       lighthouse.bin = "lighthouse";
 
       # consensus / nimbus
-      nimbus.bin = "nimbus_beacon_node";
+      nimbus = {
+        nimbus-beacon-node.bin = "nimbus_beacon_node";
+        nimbus-validator-client.bin = "nimbus_validator_client";
+      };
 
       # execution clients
       besu.bin = "besu";


### PR DESCRIPTION
This commit make the nimbus package build the stand-alone validator client by default. The stand-alone validator is documented here: https://nimbus.guide/validator-client.html.