### PR TITLE
erigon: 2.54.0 -> 2.57.0

### DIFF
--- a/packages/clients/execution/erigon/default.nix
+++ b/packages/clients/execution/erigon/default.nix
@@ -5,18 +5,21 @@
 }:
 buildGoModule rec {
   pname = "erigon";
-  version = "2.54.0";
+  version = "2.57.0";
 
   src = fetchFromGitHub {
     owner = "ledgerwatch";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-1kgbIg/3SvVT83UfwAYUixs1RQk4PP1quiOcI1mzbZ0=";
+    hash = "sha256-JpTrJK6i+dxFtL6gbqE4M+MtVH1CTqeXFE76JjYEGHg=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-Gr9mrME8/ZDxp2ORKessNhfguklDf+jC4RSpzLOSBhQ=";
+  vendorHash = "sha256-zup5iMFLL8nYwJQ1oTyFQVHCcdRHN1jFDVTzHGE7N0E=";
   proxyVendor = true;
+
+  # Silkworm's .so fails to find libgmp when linking
+  tags = ["nosilkworm"];
 
   # Build errors in mdbx when format hardening is enabled:
   #   cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]


### PR DESCRIPTION
Also disable sandworm explicitly, as libsandworm_capi.so requires libgmp, which the Go linker fails to find.