### PR TITLE
fix: remove easyOverlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,6 @@
     {
       imports = [
         inputs.devshell.flakeModule
-        inputs.flake-parts.flakeModules.easyOverlay
         inputs.flake-root.flakeModule
         inputs.treefmt-nix.flakeModule
         ./mkdocs.nix

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -1,8 +1,15 @@
 {
+  self,
   inputs,
   lib,
   ...
 }: {
+  # add all our packages based on host platform
+  flake.overlays.default = _final: prev: let
+    inherit (prev.stdenv.hostPlatform) system;
+  in
+    self.packages.${system};
+
   perSystem = {
     self',
     pkgs,
@@ -171,7 +178,5 @@
       tx-fuzz.bin = "tx-fuzz";
       zcli.bin = "zcli";
     };
-
-    overlayAttrs = self'.packages;
   };
 }


### PR DESCRIPTION
Create the default overlay manually as https://github.com/NixOS/nixpkgs/pull/269551 seems to have caused some issues with easyOverlay where it's trying to touch an i686 package when that system is not in the listed systems.
