### PR TITLE
heimdall: init at 0.7.3

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -63,6 +63,7 @@
       eth2-val-tools = callPackage ./utils/eth2-val-tools {inherit bls mcl;};
       ethdo = callPackage ./utils/ethdo {inherit bls mcl;};
       ethereal = callPackage ./utils/ethereal {inherit bls mcl;};
+      heimdall = callPackage ./utils/heimdall {};
       rocketpool = callPackage ./utils/rocketpool {};
       sedge = callPackage ./utils/sedge {inherit bls mcl;};
       staking-deposit-cli = callPackage ./utils/staking-deposit-cli {};

--- a/packages/utils/heimdall/default.nix
+++ b/packages/utils/heimdall/default.nix
@@ -1,9 +1,11 @@
 {
+  darwin,
   fetchFromGitHub,
   lib,
   openssl,
   pkg-config,
   rustPlatform,
+  stdenv,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "heimdall";
@@ -24,9 +26,14 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  buildInputs = [
-    openssl
-  ];
+  buildInputs =
+    [
+      openssl
+    ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+      Security
+      SystemConfiguration
+    ]);
 
   # Loads of tests do some kind of I/O incompatible with nix sandbox, but are
   # tested in upstream CI.

--- a/packages/utils/heimdall/default.nix
+++ b/packages/utils/heimdall/default.nix
@@ -1,0 +1,42 @@
+{
+  fetchFromGitHub,
+  lib,
+  openssl,
+  pkg-config,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "heimdall";
+  version = "0.7.3";
+
+  src = fetchFromGitHub {
+    owner = "jon-becker";
+    repo = "${pname}-rs";
+    rev = version;
+    hash = "sha256-E3WFJ+1ps5UiA+qzJAjouBR4wJbzxrJfvcW6Kany/jU=";
+  };
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  # Loads of tests do some kind of I/O incompatible with nix sandbox, but are
+  # tested in upstream CI.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A toolkit for EVM bytecode analysis";
+    homepage = "https://heimdall.rs";
+    license = [licenses.mit];
+    mainProgram = "heimdall";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
A handy toolkit for EVM bytecode analysis.

Confirmed working on `x86_64-linux`, ~it *should* work on darwin but haven't tested.~

---

Edit: OK just tested locally on `aarch64-darwin` too and added a commit to add some missing deps - should be good to go :ok_hand: 