### PR TITLE
reth: 0.1.0-alpha.13 -> 0.1.0-alpha.16

### DIFF
--- a/packages/clients/execution/reth/default.nix
+++ b/packages/clients/execution/reth/default.nix
@@ -1,7 +1,9 @@
 {
-  lib,
+  darwin,
   fetchFromGitHub,
+  lib,
   rustPlatform,
+  stdenv,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "reth";
@@ -29,6 +31,10 @@ rustPlatform.buildRustPackage rec {
     rustPlatform.bindgenHook
   ];
 
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
   # Some tests fail due to I/O that is unfriendly with nix sandbox.
   checkFlags = [
     "--skip=builder::tests::block_number_node_config_test"
@@ -38,11 +44,12 @@ rustPlatform.buildRustPackage rec {
     "--skip=cli::tests::parse_env_filter_directives"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol, in Rust";
     homepage = "https://github.com/paradigmxyz/reth";
-    license = [lib.licenses.mit lib.licenses.asl20];
+    license = with licenses; [mit asl20];
     mainProgram = "reth";
-    platforms = ["x86_64-linux"];
+    # `x86_64-darwin` seems to have issues with jemalloc, but these are fine.
+    platforms = ["aarch64-darwin" "aarch64-linux" "x86_64-linux"];
   };
 }

--- a/packages/clients/execution/reth/default.nix
+++ b/packages/clients/execution/reth/default.nix
@@ -1,39 +1,42 @@
 {
-  clang,
   lib,
-  llvmPackages,
   fetchFromGitHub,
   rustPlatform,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "reth";
-  version = "0.1.0-alpha.13";
+  version = "0.1.0-alpha.16";
 
   src = fetchFromGitHub {
     owner = "paradigmxyz";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-RE40KzOCjPCCTTepZ630BlLDeXc7KITb2MDBjU6ij2M=";
+    hash = "sha256-5iYGNj+IC63lhgVPZf4U0yOWFDDH+x+a5M5eFpnfQYU=";
   };
 
-  cargoHash = "";
   cargoLock = {
     lockFile = "${src}/Cargo.lock";
     outputHashes = {
+      "alloy-genesis-0.1.0" = "sha256-JwUtwx9WK/CcMDHcahc65f1thsLg5/Tnifjwipv/bmE=";
       "discv5-0.3.1" = "sha256-Z/Yl/K6UKmXQ4e0anAJZffV9PmWdBg/ROnNBrB8dABE=";
       "igd-0.12.0" = "sha256-wjk/VIddbuoNFljasH5zsHa2JWiOuSW4VlcUS+ed5YY=";
-      "revm-3.5.0" = "sha256-odaNHGw7RfJHJInQ/zRQYBev4vsJeyx6pGERgOSD/24=";
+      "revm-3.5.0" = "sha256-mI+tecvC9BHXl4+ju4VfYUD3mKO+jp0/KC9KjiyzD+Q=";
+      "revm-inspectors-0.1.0" = "sha256-yBqeANijUCBRhOU7XjQvo4H8dbFPFFKErzmZ+Lw4OSA=";
     };
   };
 
-  nativeBuildInputs = [clang rustPlatform.bindgenHook];
-
-  checkFlags = [
-    "--skip=cli::tests::override_trusted_setup_file"
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
   ];
 
-  # Needed by libmdx
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  # Some tests fail due to I/O that is unfriendly with nix sandbox.
+  checkFlags = [
+    "--skip=builder::tests::block_number_node_config_test"
+    "--skip=builder::tests::launch_multiple_nodes"
+    "--skip=builder::tests::rpc_handles_none_without_http"
+    "--skip=cli::tests::override_trusted_setup_file"
+    "--skip=cli::tests::parse_env_filter_directives"
+  ];
 
   meta = {
     description = "Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol, in Rust";

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -35,7 +35,7 @@
       geth = callPackage ./clients/execution/geth {};
       geth-sealer = callPackage ./clients/execution/geth-sealer {};
       nethermind = callPackage ./clients/execution/nethermind {};
-      reth = callPackage ./clients/execution/reth {};
+      reth = callPackageUnstable ./clients/execution/reth {};
 
       # Signers
       web3signer = callPackage ./signers/web3signer {};


### PR DESCRIPTION
Also removes some redundant deps and switches to `callPackageUnstable` as the latest `reth` requires rust `1.75`.