### PR TITLE
feat: Allow configurable erigon, geth, nethermind datadir

### DIFF
--- a/modules/erigon/args.nix
+++ b/modules/erigon/args.nix
@@ -1,5 +1,11 @@
 lib:
 with lib; {
+  datadir = mkOption {
+    type = types.nullOr types.str;
+    default = null;
+    description = mdDoc "Data directory for Erigon. Defaults to '%S/erigon-\<name\>', which generally resolves to /var/lib/erigon-\<name\>.";
+  };
+
   port = mkOption {
     type = types.port;
     default = 30303;

--- a/modules/erigon/default.nix
+++ b/modules/erigon/default.nix
@@ -82,8 +82,12 @@ in {
                   inherit pathReducer opts;
                   inherit (cfg) args;
                 };
+              datadir =
+                if cfg.args.datadir != null
+                then "--datadir ${cfg.args.datadir}"
+                else "--datadir %S/${serviceName}";
             in ''
-              --datadir %S/${serviceName} \
+              ${datadir} \
               ${concatStringsSep " \\\n" args} \
               ${lib.escapeShellArgs cfg.extraArgs}
             '';

--- a/modules/geth/args.nix
+++ b/modules/geth/args.nix
@@ -173,4 +173,10 @@ with lib; {
     default = 50;
     description = mdDoc "Maximum peers to connect to.";
   };
+
+  datadir = mkOption {
+    type = types.nullOr types.str;
+    default = null;
+    description = mdDoc "Data directory for Geth. Defaults to '%S/geth-\<name\>', which generally resolves to /var/lib/geth-\<name\>.";
+  };
 }

--- a/modules/geth/default.nix
+++ b/modules/geth/default.nix
@@ -95,9 +95,14 @@ in {
                 if cfg.args.authrpc.jwtsecret != null
                 then "--authrpc.jwtsecret %d/jwtsecret"
                 else "";
+
+              datadir =
+                if cfg.args.datadir != null
+                then "--datadir ${cfg.args.datadir}"
+                else "--datadir %S/${serviceName}";
             in ''
+              ${datadir} \
               --ipcdisable ${network} ${jwtSecret} \
-              --datadir %S/${serviceName} \
               ${concatStringsSep " \\\n" filteredArgs} \
               ${lib.escapeShellArgs cfg.extraArgs}
             '';

--- a/modules/nethermind/args.nix
+++ b/modules/nethermind/args.nix
@@ -19,6 +19,12 @@ with lib; {
     description = mdDoc "Changes the source directory of your configuration files.";
   };
 
+  datadir = mkOption {
+    type = types.nullOr types.str;
+    default = null;
+    description = mdDoc "Data directory for Nethermind. Defaults to '%S/nethermind-\<name\>', which generally resolves to /var/lib/nethermind-\<name\>.";
+  };
+
   log = mkOption {
     type = types.enum [
       "OFF"

--- a/modules/nethermind/default.nix
+++ b/modules/nethermind/default.nix
@@ -94,6 +94,10 @@ in {
                 if cfg.args.modules.JsonRpc.JwtSecretFile != null
                 then "--JsonRpc.JwtSecretFile %d/jwtsecret"
                 else "";
+              datadir =
+                if cfg.args.datadir != null
+                then "--datadir ${cfg.args.datadir}"
+                else "--datadir %S/${serviceName}";
 
               # generate flags
               args = let
@@ -110,7 +114,7 @@ in {
 
               filteredArgs = builtins.filter isNormalArg args;
             in ''
-              --datadir %S/${serviceName} \
+              ${datadir}
               ${jwtSecret} \
               ${concatStringsSep " \\\n" filteredArgs} \
               ${lib.escapeShellArgs cfg.extraArgs}


### PR DESCRIPTION
This MR adds an optional`datadir` argument to the nethermind, geth, and erigon modules to better match other module behavior (lighthouse, prysm). 