### PR TITLE
fix: nimbus-beacon rest.allow-origin bad default

### DIFF
--- a/modules/nimbus-beacon/default.nix
+++ b/modules/nimbus-beacon/default.nix
@@ -124,6 +124,8 @@ in {
                   "--rest"
                   "--rest-address=${cfg.args.rest.address}"
                   "--rest-port=${toString cfg.args.rest.port}"
+                ])
+                ++ (optionals (cfg.args.rest.allow-origin != null) [
                   "--rest-allow-origin=${cfg.args.rest.allow-origin}"
                 ])
                 ++ (optionals cfg.args.metrics.enable [

--- a/modules/nimbus-beacon/default.nix
+++ b/modules/nimbus-beacon/default.nix
@@ -105,6 +105,7 @@ in {
               # filter out certain args which need to be treated differently
               specialArgs = [
                 "--jwt-secret"
+                "--data-dir"
                 "--user" # Not a CLI Flag, only used in systemd service
                 "--rest-enable"
                 "--rest-address"


### PR DESCRIPTION
If `rest.enable` is true and `rest.allow-origin` is not set, `allow-origin` defaults to null which can't be coerced to a string when building CLI flags for Nimbus. This MR fixes this behavior by adding a null check before building the flag. 