### PR TITLE
Add ReadWritePaths for datadir

### DIFF
--- a/modules/erigon/default.nix
+++ b/modules/erigon/default.nix
@@ -103,6 +103,7 @@ in {
                 {
                   User = serviceName;
                   StateDirectory = serviceName;
+                  ReadWritePaths = [ cfg.args.datadir ];
                   ExecStartPre = mkIf cfg.subVolume (mkBefore [
                     "+${scripts.setupSubVolume} /var/lib/private/${serviceName}"
                   ]);

--- a/modules/erigon/default.nix
+++ b/modules/erigon/default.nix
@@ -103,7 +103,7 @@ in {
                 {
                   User = serviceName;
                   StateDirectory = serviceName;
-                  ReadWritePaths = [ cfg.args.datadir ];
+                  ReadWritePaths = [cfg.args.datadir];
                   ExecStartPre = mkIf cfg.subVolume (mkBefore [
                     "+${scripts.setupSubVolume} /var/lib/private/${serviceName}"
                   ]);

--- a/modules/lighthouse-beacon/default.nix
+++ b/modules/lighthouse-beacon/default.nix
@@ -117,7 +117,7 @@ in {
                     then cfg.args.user
                     else user;
                   StateDirectory = user;
-                  ReadWritePaths = [ cfg.args.datadir ];
+                  ReadWritePaths = [cfg.args.datadir];
                   ExecStart = "${cfg.package}/bin/lighthouse beacon ${scriptArgs}";
                 }
                 (mkIf (cfg.args.execution-jwt != null) {

--- a/modules/lighthouse-beacon/default.nix
+++ b/modules/lighthouse-beacon/default.nix
@@ -117,6 +117,7 @@ in {
                     then cfg.args.user
                     else user;
                   StateDirectory = user;
+                  ReadWritePaths = [ cfg.args.datadir ];
                   ExecStart = "${cfg.package}/bin/lighthouse beacon ${scriptArgs}";
                 }
                 (mkIf (cfg.args.execution-jwt != null) {

--- a/modules/lighthouse-validator/default.nix
+++ b/modules/lighthouse-validator/default.nix
@@ -116,7 +116,7 @@ in {
                     then cfg.args.user
                     else user;
                   StateDirectory = user;
-                  ReadWritePaths = [ cfg.args.datadir ];
+                  ReadWritePaths = [cfg.args.datadir];
                   ExecStart = "${cfg.package}/bin/lighthouse validator ${scriptArgs}";
                 }
               ];

--- a/modules/lighthouse-validator/default.nix
+++ b/modules/lighthouse-validator/default.nix
@@ -116,6 +116,7 @@ in {
                     then cfg.args.user
                     else user;
                   StateDirectory = user;
+                  ReadWritePaths = [ cfg.args.datadir ];
                   ExecStart = "${cfg.package}/bin/lighthouse validator ${scriptArgs}";
                 }
               ];

--- a/modules/nethermind/default.nix
+++ b/modules/nethermind/default.nix
@@ -136,7 +136,7 @@ in {
                 {
                   User = serviceName;
                   StateDirectory = serviceName;
-                  ReadWritePaths = [ cfg.args.datadir ];
+                  ReadWritePaths = [cfg.args.datadir];
                   ExecStart = "${cfg.package}/bin/Nethermind.Runner ${scriptArgs}";
                 }
                 (mkIf (cfg.args.modules.JsonRpc.JwtSecretFile != null) {

--- a/modules/nethermind/default.nix
+++ b/modules/nethermind/default.nix
@@ -136,6 +136,7 @@ in {
                 {
                   User = serviceName;
                   StateDirectory = serviceName;
+                  ReadWritePaths = [ cfg.args.datadir ];
                   ExecStart = "${cfg.package}/bin/Nethermind.Runner ${scriptArgs}";
                 }
                 (mkIf (cfg.args.modules.JsonRpc.JwtSecretFile != null) {

--- a/modules/nimbus-beacon/default.nix
+++ b/modules/nimbus-beacon/default.nix
@@ -168,6 +168,7 @@ in {
                     then cfg.args.user
                     else user;
                   StateDirectory = user;
+                  ReadWritePaths = [ cfg.args.datadir ];
                   ExecStartPre = "${cfg.package}/bin/nimbus_beacon_node trustedNodeSync ${checkpointSyncArgs}";
                   ExecStart = "${cfg.package}/bin/nimbus_beacon_node ${scriptArgs}";
                 }

--- a/modules/nimbus-beacon/default.nix
+++ b/modules/nimbus-beacon/default.nix
@@ -168,7 +168,7 @@ in {
                     then cfg.args.user
                     else user;
                   StateDirectory = user;
-                  ReadWritePaths = [ cfg.args.datadir ];
+                  ReadWritePaths = [cfg.args.datadir];
                   ExecStartPre = "${cfg.package}/bin/nimbus_beacon_node trustedNodeSync ${checkpointSyncArgs}";
                   ExecStart = "${cfg.package}/bin/nimbus_beacon_node ${scriptArgs}";
                 }

--- a/modules/prysm-beacon/default.nix
+++ b/modules/prysm-beacon/default.nix
@@ -112,7 +112,7 @@ in {
                     then cfg.args.user
                     else serviceName;
                   StateDirectory = serviceName;
-                  ReadWritePaths = [ cfg.args.datadir ];
+                  ReadWritePaths = [cfg.args.datadir];
                   ExecStart = "${cfg.package}/bin/beacon-chain ${scriptArgs}";
                   MemoryDenyWriteExecute = "false"; # causes a library loading error
                 }

--- a/modules/prysm-beacon/default.nix
+++ b/modules/prysm-beacon/default.nix
@@ -112,6 +112,7 @@ in {
                     then cfg.args.user
                     else serviceName;
                   StateDirectory = serviceName;
+                  ReadWritePaths = [ cfg.args.datadir ];
                   ExecStart = "${cfg.package}/bin/beacon-chain ${scriptArgs}";
                   MemoryDenyWriteExecute = "false"; # causes a library loading error
                 }

--- a/modules/prysm-validator/default.nix
+++ b/modules/prysm-validator/default.nix
@@ -104,7 +104,7 @@ in {
                     then cfg.args.user
                     else beaconServiceName;
                   StateDirectory = serviceName;
-                  ReadWritePaths = [ cfg.args.datadir ];
+                  ReadWritePaths = [cfg.args.datadir];
                   ExecStart = "${cfg.package}/bin/validator ${scriptArgs}";
                   MemoryDenyWriteExecute = "false"; # causes a library loading error
                 }

--- a/modules/prysm-validator/default.nix
+++ b/modules/prysm-validator/default.nix
@@ -104,6 +104,7 @@ in {
                     then cfg.args.user
                     else beaconServiceName;
                   StateDirectory = serviceName;
+                  ReadWritePaths = [ cfg.args.datadir ];
                   ExecStart = "${cfg.package}/bin/validator ${scriptArgs}";
                   MemoryDenyWriteExecute = "false"; # causes a library loading error
                 }


### PR DESCRIPTION
I had issues running lighthouse with its datadir on a separate ssd `/mnt/extra/`. Adding `ReadWritePaths` solved it but I only verified it for lighthouse but might be useful for the others as well.