### PR TITLE
foundry: init at nightly-0688b5a

### DIFF
--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           # TODO: remove nethermind after we fix build for them
           # TODO: remove mev-boost after they make a new release tag
-          blacklist: "staking-deposit-cli,dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,mev-boost,nethermind"
+          blacklist: "staking-deposit-cli,dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry-bin,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,mev-boost,nethermind"
           sign-commits: true
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -71,7 +71,8 @@
       zcli = callPackage ./utils/zcli {};
 
       # Dev
-      foundry = inputs.foundry-nix.defaultPackage.${system}.overrideAttrs (_oldAttrs: {
+      foundry = callPackageUnstable ./dev/foundry {};
+      foundry-bin = inputs.foundry-nix.defaultPackage.${system}.overrideAttrs (_oldAttrs: {
         # TODO: Uncomment when https://github.com/shazow/foundry.nix/issues/23
         # meta.platforms = [system];
         meta.platforms = ["x86_64-linux" "aarch64-linux"];

--- a/packages/dev/foundry/default.nix
+++ b/packages/dev/foundry/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  darwin,
+  fetchFromGitHub,
+  installShellFiles,
+  libusb1,
+  pkg-config,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "foundry";
+  version = "nightly-${builtins.substring 0 7 src.rev}";
+
+  src = fetchFromGitHub {
+    owner = "foundry-rs";
+    repo = "foundry";
+    rev = "0688b5ad19a637303c038d1a66aec62a73713e20";
+    hash = "sha256-OIsUzJVNcb2nVCYU/BdGGGICEg9Cr9LXc8zzN2JSb8g=";
+  };
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      "alloy-consensus-0.1.0" = "sha256-rHDLt0N6VIAlg2EKEdF0S2S8XqJebRlIB7owyGQ04aA=";
+      "ethers-2.0.11" = "sha256-ySrCZOiqOcDVH5T7gbimK6Bu7A2OCcU64ZL1RfFPrBc=";
+      "revm-3.5.0" = "sha256-gdDJq2ZyIkMhTgMNz45YJXnopF/xxt3CaSd/eYSDGcY=";
+      "revm-inspectors-0.1.0" = "sha256-mH6On3cjKLT14S+5dxB1G5lcf5PBtz0KcusMxOtRRWA=";
+    };
+  };
+
+  env = {
+    # Make svm-rs use local release list rather than fetching from non-reproducible URL.
+    # Run the `update-svm-lists.sh` script to update these lists.
+    SVM_RELEASES_LIST_JSON =
+      if stdenv.isDarwin
+      then "${./svm-lists/macosx-amd64.json}"
+      else "${./svm-lists/linux-amd64.json}";
+  };
+
+  nativeBuildInputs =
+    [
+      installShellFiles
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.DarwinTools
+    ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.AppKit
+    libusb1
+  ];
+
+  postInstall = let
+    binsWithCompletions = ["anvil" "cast" "forge"];
+  in ''
+    ${lib.concatMapStringsSep "\n" (bin: ''
+        installShellCompletion --cmd ${bin} \
+          --bash <($out/bin/${bin} completions bash) \
+          --fish <($out/bin/${bin} completions fish) \
+          --zsh <($out/bin/${bin} completions zsh)
+      '')
+      binsWithCompletions}
+  '';
+
+  # Tests are run upstream, and many perform I/O
+  # incompatible with the nix build sandbox.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A portable, modular toolkit for Ethereum application development written in Rust.";
+    homepage = "https://github.com/foundry-rs/foundry";
+    license = with licenses; [asl20 mit];
+    maintainers = with maintainers; [mitchmindtree];
+    # For now, solc binaries are only built for x86_64.
+    # Track darwin-aarch64 here:
+    # https://github.com/ethereum/solidity/issues/12291
+    platforms = ["x86_64-linux" "x86_64-darwin"];
+  };
+}

--- a/packages/dev/foundry/svm-lists/linux-amd64.json
+++ b/packages/dev/foundry/svm-lists/linux-amd64.json
@@ -1,0 +1,1047 @@
+{
+  "builds": [
+    {
+      "path": "solc-linux-amd64-v0.4.10+commit.9e8cc01b",
+      "version": "0.4.10",
+      "build": "commit.9e8cc01b",
+      "longVersion": "0.4.10+commit.9e8cc01b",
+      "keccak256": "0x66bd5478b31c7ad1ec9b148618945dc8b7d0dc9ca4a2469992b9728daf672f9f",
+      "sha256": "0xf3638225df24f444a72123956033f5743079118f0e1195ce6969aa16a7ef2283",
+      "urls": [
+        "bzzr://9d3ea309ce8ece74f89babfd3e55035f6164e5a0f9ab7d839c0493fe10e915de",
+        "dweb:/ipfs/QmUGR45KnfMmJUSGvZyNiB9c9Cpf7FLTHdK8X3bZQb1GaS"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.11+commit.68ef5810",
+      "version": "0.4.11",
+      "build": "commit.68ef5810",
+      "longVersion": "0.4.11+commit.68ef5810",
+      "keccak256": "0xf27dfded17794053f0e9144a35a9a9e2fcc1c7b34f46f593b87000d00aa39eb5",
+      "sha256": "0x0a8d138ee245039e6f8312edc024ba3c4739cc3c013b47dc7fc9196a2e327fea",
+      "urls": [
+        "bzzr://f88f5572e75465633a2a1fad99e4ab329f854b73aa8c9d2f1a7a14011e32df6d",
+        "dweb:/ipfs/QmenL4RpDaBXFcY8HHH5rzieMGE9KFWcbHZzG1ypC4pGLr"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.12+commit.194ff033",
+      "version": "0.4.12",
+      "build": "commit.194ff033",
+      "longVersion": "0.4.12+commit.194ff033",
+      "keccak256": "0x6cffb262a3498b98e59baa4f579ba92c9496c960ca37f675fbd17d179a31dbd1",
+      "sha256": "0x221ae33e12bda5c8b796c9abae2b2eb73e46d9b12128bfee451b12856f8b47ee",
+      "urls": [
+        "bzzr://246480c5502c5daea350af895c79213971672c5fdb85b7de93d27b20406c89a8",
+        "dweb:/ipfs/QmTTW8RScz5F9W9fyYMafyQKYP2y1XN5ZeJE89N55LU122"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.13+commit.0fb4cb1a",
+      "version": "0.4.13",
+      "build": "commit.0fb4cb1a",
+      "longVersion": "0.4.13+commit.0fb4cb1a",
+      "keccak256": "0x7d2ee23b3ecbc3a178e7fbdb50eb52e5d2637289b92c0c370dbf69be20e58031",
+      "sha256": "0x791ee3a20adf6c5ab76cc889f13cca102f76eb0b7cf0da4a0b5b11dc46edf349",
+      "urls": [
+        "bzzr://d6182ecde7e8d10659176cb59b60d3fffdae0f87ae8f3ff79d758fa22c03ebc0",
+        "dweb:/ipfs/QmPBGiJHDCyqFaqbtfPbSozFBtiF8cpL1mMDvumpSNYDEt"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.14+commit.c2215d46",
+      "version": "0.4.14",
+      "build": "commit.c2215d46",
+      "longVersion": "0.4.14+commit.c2215d46",
+      "keccak256": "0xd952abd8839609ebc5a42350419cdac388d39fa0def02cd2b0c2c559dc2598e8",
+      "sha256": "0x28ce35a0941d9ecd59a2b1a377c019110e79a6b38bdbf5a3bffea811f9c2a13b",
+      "urls": [
+        "bzzr://948ebc4b72e2e5705512ec441b3a3055e522a8cf46bd82cfad42aefb1c1c25d4",
+        "dweb:/ipfs/QmeDMVjzcKysgVrEj2W7ewtNtDwut4xHknP79jqbdZMpBL"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.15+commit.8b45bddb",
+      "version": "0.4.15",
+      "build": "commit.8b45bddb",
+      "longVersion": "0.4.15+commit.8b45bddb",
+      "keccak256": "0xba3b29e25b9e9b5082832bb27b0d1bafe2ce3a78aaad85a7ebbeba5edc825447",
+      "sha256": "0xc71ac6c28bf3b1a425e77e97f5df67a80da3e4c047261875206561c0a110c0cb",
+      "urls": [
+        "bzzr://f5f436b729b8c3a4e31d607f3ad0256de8b970b207fd83ae7552a34570e5071e",
+        "dweb:/ipfs/QmcEoM1BbxFoUs1PrxkK42JiWbW8YS3ZsFNUgsthFaypZc"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.16+commit.d7661dd9",
+      "version": "0.4.16",
+      "build": "commit.d7661dd9",
+      "longVersion": "0.4.16+commit.d7661dd9",
+      "keccak256": "0xc0c1df80393ca97d89bdfb435cd66027ccdbe4f88ca70b0c94afa1d243c99268",
+      "sha256": "0x78e0da6cad24ab145a8d17420c4f094c8314418ca23cff4b050bb2bfd36f3af2",
+      "urls": [
+        "bzzr://24f7c4bccb3711985253911fd2df23be1bc92cf3629b238d4ba7aaa433cb5251",
+        "dweb:/ipfs/QmVSF192Nbgqh9zA1JQYyCVbzyxqYhYPFXBunzyHtxJRZ5"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.17+commit.bdeb9e52",
+      "version": "0.4.17",
+      "build": "commit.bdeb9e52",
+      "longVersion": "0.4.17+commit.bdeb9e52",
+      "keccak256": "0x91c51381736ad2bc23e2a29423f786c8da5f9a7e13d6cfade90e9bced0636026",
+      "sha256": "0x13414bf86f80319e6f5863b4ca4af786956d188f5f9b99dda6439362c6d91115",
+      "urls": [
+        "bzzr://e4b2755454fdc9ab73ba013f0d646fb2735f7d7f1c696b0d38be593ad68752ce",
+        "dweb:/ipfs/QmYezLj4Qky7HXv5iZLzBc7itTV1xhnh3kPuFGMhohCkZj"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.18+commit.9cf6e910",
+      "version": "0.4.18",
+      "build": "commit.9cf6e910",
+      "longVersion": "0.4.18+commit.9cf6e910",
+      "keccak256": "0x5f35f3ababcda47bcfbb7aefea8dc3ccda06bb12690e047a8330e895f2682e61",
+      "sha256": "0x898a5e05d3ac08d726b019d2415c1c087a9ae87866cdfa551c08b36b6b45321d",
+      "urls": [
+        "bzzr://63bee56c93171ea27e96e35f54411b79d12bc6c398f8451229919707e93a33a3",
+        "dweb:/ipfs/QmcZajAm1bVSyGRmAxq3yNbF31M6yMuNX9tVkFzmarHn4p"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.19+commit.c4cbbb05",
+      "version": "0.4.19",
+      "build": "commit.c4cbbb05",
+      "longVersion": "0.4.19+commit.c4cbbb05",
+      "keccak256": "0x7310233685fca42969a942384662203fe3150098c20a3285ed702f769873661b",
+      "sha256": "0x07f89753cdda28054bb6f159a21911716caeb43b3c7659a25f1f2d9dd17bc827",
+      "urls": [
+        "bzzr://0fea8889d30bb35a31805e59382bf15fc6321c39358a16d0a7eb5a28b79b24db",
+        "dweb:/ipfs/QmQBKWnNXJyVjBVsTLmbNosfScV3eoGDfz81L9inC4SJEZ"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.20+commit.3155dd80",
+      "version": "0.4.20",
+      "build": "commit.3155dd80",
+      "longVersion": "0.4.20+commit.3155dd80",
+      "keccak256": "0x6ac0e06558f9c1e28497da8e7b1aec808a85ad59862a13a42d537dc9e5608165",
+      "sha256": "0xd966b8215a4f83377ce9d622c9198fe91e5b93300652bf081aaf2f6aa3ac6a16",
+      "urls": [
+        "bzzr://bfe04eb5a64c0be572bb03df2a53d8bdef52db767cfecc963ddca4b584138105",
+        "dweb:/ipfs/QmXfGHL16gtaDFTkk4GT5RXmxp8ciyMz4Yt5YARE8PoRUx"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.21+commit.dfe3193c",
+      "version": "0.4.21",
+      "build": "commit.dfe3193c",
+      "longVersion": "0.4.21+commit.dfe3193c",
+      "keccak256": "0x18830ee60c27e630558ed4dc26543800ecd1189aab3d42f3ef0bcba9ced97a26",
+      "sha256": "0x905228505420cd31e6393e09ea685b87585b62c4339d3addc0a3049bebbc4332",
+      "urls": [
+        "bzzr://28cbeae79e05b0b72b7a22247124071a3881b09886ee716acf2024038a5c52aa",
+        "dweb:/ipfs/Qma2XrmazW6bsiEma64uUmpjfJMDXCsirP72nw8nuEPpKX"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.22+commit.4cb486ee",
+      "version": "0.4.22",
+      "build": "commit.4cb486ee",
+      "longVersion": "0.4.22+commit.4cb486ee",
+      "keccak256": "0x7fb2ce6341df972568b9987542f17c72f0f8481b6d6544df9464541dcd48ce07",
+      "sha256": "0xfade9ba6dd489ffc3f73e53a13d5f1031325779708e448224970979b8cc86ba7",
+      "urls": [
+        "bzzr://1ad67b6130be54ad37b3ed7d4024d8277e5abe01fd2ba3b4a1db8d7d95c743d2",
+        "dweb:/ipfs/QmWzkuv48UJnPwNdDFKN2A5yejZYizckwX4FdD2A6sXcGs"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.23+commit.124ca40d",
+      "version": "0.4.23",
+      "build": "commit.124ca40d",
+      "longVersion": "0.4.23+commit.124ca40d",
+      "keccak256": "0xbab9657147aef06499bf9b016671754be7233ca08bbfc056c260fa888789d044",
+      "sha256": "0xc648d299bd21f4c74ce17954706cfc5a7a9fbbd1e8739546ed8754cacd8ca7c2",
+      "urls": [
+        "bzzr://17f4e7bea5718a310c7a59b6bdce8e33e32e6569f186116e44b49c83e394ab71",
+        "dweb:/ipfs/QmeYUkb7mzaKxgHsTszv7FnSC4wSrMk73BxJrwsuwisYgo"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.24+commit.e67f0147",
+      "version": "0.4.24",
+      "build": "commit.e67f0147",
+      "longVersion": "0.4.24+commit.e67f0147",
+      "keccak256": "0x9dc72f961d7dbe7c3d3cc380955b994dd5fffdf4020d217cbe45d349d25aadb5",
+      "sha256": "0x665675b9e0431c2572d59d6a7112afbdc752732ea0ce9aecf1a1855f28e02a09",
+      "urls": [
+        "bzzr://8472dab7460f19869b64c3462bd17f689a77bb9ebb178cf7ace5c887e5c0985d",
+        "dweb:/ipfs/QmQRjyb894sQXHy7izsj9D7g6UNn6WapQUnemRiqiNRucC"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.25+commit.59dbf8f1",
+      "version": "0.4.25",
+      "build": "commit.59dbf8f1",
+      "longVersion": "0.4.25+commit.59dbf8f1",
+      "keccak256": "0x3daf486a85a9ed33b63c7e9f89e40f46c528340b3d096f3ccd84bce60a9d1d59",
+      "sha256": "0xc9b268750506b88fe71371100050e9dd1e7edcf8f69da34d1cd09557ecb24580",
+      "urls": [
+        "bzzr://9d44af75f7b3d0a8b1079814c9e78e07efe9ffc7b42c7ef379e3453ae7b49f3b",
+        "dweb:/ipfs/QmcBqre2ncDfq1SRX3SzXtP54FJXbD4smmWVhhwvWGrs8E"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.4.26+commit.4563c3fc",
+      "version": "0.4.26",
+      "build": "commit.4563c3fc",
+      "longVersion": "0.4.26+commit.4563c3fc",
+      "keccak256": "0x5ee9bf00d10e712f1d43b94df82a17c4a2382a622f41ef67757f83fcbb0a604c",
+      "sha256": "0x5d577b3f7918dd735ab157e2f37a21d06c90469f13868359874f15184f2fa4d0",
+      "urls": [
+        "bzzr://ec7ce34dca7075d994468cfc407b0cddd2fd5d6426d5ba3bc7b9f0471304e11d",
+        "dweb:/ipfs/QmbVDnn2V5uvBZk6vBXSELYvQLZQfegQUNygn3nXMyfrTU"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.0+commit.1d4f565a",
+      "version": "0.5.0",
+      "build": "commit.1d4f565a",
+      "longVersion": "0.5.0+commit.1d4f565a",
+      "keccak256": "0x7189e393d88774aa4b82ea081f871fa50812c85eaa46f5555169dbcb6d0aff66",
+      "sha256": "0xc1bb15b520f5076aebd7aa9ef4ce5fa245b6f210a91cbd2064b9e383e6510e08",
+      "urls": [
+        "bzzr://b041cea8f6345b61b95e46edb2fe259fddde1f54314c8ccc4ddb6f50fbbd2f84",
+        "dweb:/ipfs/QmYWyPLHYcgptU2PTffmycrSYdpvnx2xssjKoKvEuugH5C"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.1+commit.c8a2cb62",
+      "version": "0.5.1",
+      "build": "commit.c8a2cb62",
+      "longVersion": "0.5.1+commit.c8a2cb62",
+      "keccak256": "0x622e30657718674c5c9a1175c432eb3e2873ad15307bc7083c2539de6184565d",
+      "sha256": "0x6275d481f23180e00b38996848534db78b4f73caaca15435ad861df545bb71d0",
+      "urls": [
+        "bzzr://702c4fd0cfaa35c3f55578208ad49256a94e16949bde4e0abd3a908fd5042dfe",
+        "dweb:/ipfs/QmTigsgEim4YBrRd4XWo4zR2nyFewLBEu7H9mgq1PmVxH4"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.2+commit.1df8f40c",
+      "version": "0.5.2",
+      "build": "commit.1df8f40c",
+      "longVersion": "0.5.2+commit.1df8f40c",
+      "keccak256": "0x636748ef7a5915f5ceacf3d4ae173b66deb129db22b1b6b6e2e502efe7a0e302",
+      "sha256": "0x87146a7b284b1c9067a915930c0c6af7c99ff9dd1807e3680367fc03a59e83bf",
+      "urls": [
+        "bzzr://c9a3d6a2b2324f8c47a00ac071c4c79181c28892342124342d66b350056a7bc8",
+        "dweb:/ipfs/QmPTVaEGr5RWyNa6ULXbuYQtGW1qyEWbiy6AGqrk4qSQMH"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.3+commit.10d17f24",
+      "version": "0.5.3",
+      "build": "commit.10d17f24",
+      "longVersion": "0.5.3+commit.10d17f24",
+      "keccak256": "0x6013590701af06ff53c10861ade4d52eec3005e6d730155f28fd04e3115d2d9e",
+      "sha256": "0xbe08eb95cb3a1da52e918cf51a0c0397fbe7f0693145eb31835bf2924209f1e0",
+      "urls": [
+        "bzzr://aec5fb36baf59e8f06e7dc721a1e27c3c59ff29a83d601cd971962fe3b6babba",
+        "dweb:/ipfs/QmbDNEV2Nvrro3S5LZ5CwhcErd1vY7md715Rrsn6JBNTYr"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.4+commit.9549d8ff",
+      "version": "0.5.4",
+      "build": "commit.9549d8ff",
+      "longVersion": "0.5.4+commit.9549d8ff",
+      "keccak256": "0xccd306bccc95abb2eacb561fe3580de72c08a3be138c82b6962850f6fe4db564",
+      "sha256": "0x0fde347db5e632fc3aef3ca8da74896d8df7a35287646e7fbdee829fe236054a",
+      "urls": [
+        "bzzr://c93b2d5ff975e9213a9d2d2bfd3060bf36f4e4b6a9a569b09a2eb3f51345197f",
+        "dweb:/ipfs/QmZU87uh8XYDvADWmkayr4kQ2sPmRD6E7kyrpanQzRgJfM"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.5+commit.47a71e8f",
+      "version": "0.5.5",
+      "build": "commit.47a71e8f",
+      "longVersion": "0.5.5+commit.47a71e8f",
+      "keccak256": "0x3657b60cb1f6a25ed8698b3b4de1720e71e35c3e5ee48fdedc6aca23e2eaff7d",
+      "sha256": "0x718c7cc5818a9179d360ca5422c9f13a312a2baf8884f3dd8bbe3287ecaef0c6",
+      "urls": [
+        "bzzr://ba603014c72546dbdf82c93ee3919418d5e36f34c8e46cdcb0ae5ef8b1688820",
+        "dweb:/ipfs/QmWvL7waFJgJv2Mb74mzeHvM6px1QDs1P6TFyFxxacKm5v"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.6+commit.b259423e",
+      "version": "0.5.6",
+      "build": "commit.b259423e",
+      "longVersion": "0.5.6+commit.b259423e",
+      "keccak256": "0x5653c7311b09a6b04060e5b68bf28bb8d45d3179894f6ff3526c02c70c050ee7",
+      "sha256": "0xf3c70a4d716b7b4e811ef5204b3ae6a16497ae701a2b86260d1bdee7e4484b53",
+      "urls": [
+        "bzzr://ac1025b53049d2ecd2cce1e12ff2f4c1dcbb0855c1c90e470b5d40bdb0a21438",
+        "dweb:/ipfs/QmTVw4eKdJZgc6m6RZutt6jkz1N6VkeMGg2XjoMqmudvrs"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.7+commit.6da8b019",
+      "version": "0.5.7",
+      "build": "commit.6da8b019",
+      "longVersion": "0.5.7+commit.6da8b019",
+      "keccak256": "0x7b32dc1532f3813dfa8500f956c80d66c03f82ac220aff0156b8fc62b4d796d9",
+      "sha256": "0x810c52cff29511f95c44f9a1ae2b11c04598d413d6ffa37bdb19415926fb5b37",
+      "urls": [
+        "bzzr://85af46ad75bebc7a45987d0460c0de075b3e0161abd1b78d91733d5ff10a8852",
+        "dweb:/ipfs/QmQxKe3R7iia439pkZEVA11TJLummjLQkZRvXkEHmj13gn"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.8+commit.23d335f2",
+      "version": "0.5.8",
+      "build": "commit.23d335f2",
+      "longVersion": "0.5.8+commit.23d335f2",
+      "keccak256": "0xb389dda6ab00851f358e3cbc63225446ad25e040d41aa5f6d0e9652c091eb8f2",
+      "sha256": "0x58fbe9bbb709277957fd12b922530f03cf558cf803b72333a2d76d54757885d1",
+      "urls": [
+        "bzzr://f7d73e9b221345383d49629aee97feb49a454339b8c31a3ff135fd57685eaa3a",
+        "dweb:/ipfs/QmaDkx6JGoXGe6u5Qc5k3JJfgUULnMUuppPNqCcEzxwLYu"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.9+commit.c68bc34e",
+      "version": "0.5.9",
+      "build": "commit.c68bc34e",
+      "longVersion": "0.5.9+commit.c68bc34e",
+      "keccak256": "0x26b8447660363201da6eeb1bc385c787665e021b10d030880652451310342fff",
+      "sha256": "0x390d14ac47b4a01e4f804a57159ffa526c2329a0eb08b9e20dee00649efb3461",
+      "urls": [
+        "bzzr://b439b715fae73a8c2471d8315575e4c79b541b0185e4f0da9a78ee08a903794d",
+        "dweb:/ipfs/QmU8DmfWBdwWgTb5AZtkJeHBrxHkBV5dGprXvSVdh1kH2h"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.10+commit.5a6ea5b1",
+      "version": "0.5.10",
+      "build": "commit.5a6ea5b1",
+      "longVersion": "0.5.10+commit.5a6ea5b1",
+      "keccak256": "0x2b6c452b238ccc907e9522591e4716bb5413ee8cfa7c4e086a82c16487959011",
+      "sha256": "0x3c9b2e8eb98d4294fc45326dafcbccb46a70993c346c7d3b55aa0292b3ca0334",
+      "urls": [
+        "bzzr://eb8e321524b2f48894c1668da98f2aecbfd79204544ddc07353dbff57792c18f",
+        "dweb:/ipfs/QmeWo82KNFgwHCyVe6Cqj6G8XJcMbEM7UXMdSNviaaMRmh"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.11+commit.22be8592",
+      "version": "0.5.11",
+      "build": "commit.22be8592",
+      "longVersion": "0.5.11+commit.22be8592",
+      "keccak256": "0xbf509bbb99e6ef89500b4f7ae7d7a7c4b85228ae71da485fe7d1c57d5533f78f",
+      "sha256": "0x350d5abc5862dca43292426b6d4e592f81f40b02cda833f38406ba0047b6b9d0",
+      "urls": [
+        "bzzr://318190b038a3eeaaa27cb5436fdcd27d27aa0bdd35c8462baf4e5cb2d6add544",
+        "dweb:/ipfs/QmPAZqF436X578buawLseywFbvBQo54A76jaau9h9GEbZE"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.12+commit.7709ece9",
+      "version": "0.5.12",
+      "build": "commit.7709ece9",
+      "longVersion": "0.5.12+commit.7709ece9",
+      "keccak256": "0x3087e10734e9af721d84795d384f4485927dadfa5e65aa0e648b2eb51dfec881",
+      "sha256": "0x70b6f0a355385c5aea26c761b2e58b3216aa564f41e4e156813be3c47a66ae9c",
+      "urls": [
+        "bzzr://caa56d91c1184ca7983dd9c6aa143de3f57f03290c5c8377de06cea4b61f68d1",
+        "dweb:/ipfs/QmSFtnXbPxR5mJbZwrydD6ABPLJ3hNuBBux2hBtVen4yi6"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.13+commit.5b0b510c",
+      "version": "0.5.13",
+      "build": "commit.5b0b510c",
+      "longVersion": "0.5.13+commit.5b0b510c",
+      "keccak256": "0x98b18283a9a1da352430e948499d5d548acc760b84f8a56d1830c4ec8e4304c3",
+      "sha256": "0x5b62105e89c229f5951d05f2b19af81163599c7f0decc04af81e253996366aaf",
+      "urls": [
+        "bzzr://3370e2d53cbccc0e70ddf342bd7fdddfbd6c583fa4b2c335597a0ab73c06e81d",
+        "dweb:/ipfs/QmNboEZDcAnbuHki5Apz9G1nYnaeMRrmpazGT3p72jb8Z1"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.14+commit.01f1aaa4",
+      "version": "0.5.14",
+      "build": "commit.01f1aaa4",
+      "longVersion": "0.5.14+commit.01f1aaa4",
+      "keccak256": "0xb440f4b7c3255a977c55e8cb920777a97ce92ad565cb016eab6ebedd43a54d46",
+      "sha256": "0x48454e290effd1b9b2aa860013deff09a79b4d7472875a07f3e7d547df297ecc",
+      "urls": [
+        "bzzr://d392a01d93bd53fca27da9126452b7240577e1541144521d76616232665ce4ed",
+        "dweb:/ipfs/QmX7eboJmijaznyXcBERoc64rWVwXQseoBuemAz7TieUta"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.15+commit.6a57276f",
+      "version": "0.5.15",
+      "build": "commit.6a57276f",
+      "longVersion": "0.5.15+commit.6a57276f",
+      "keccak256": "0x43f5c0bd6454961553e545545b01f63cd211bdf4c1bff904236c308b1caa0456",
+      "sha256": "0xbc816f2104d0e316179bce69afcf24a48b5c6c7203cb72becad7d9e7b66990b4",
+      "urls": [
+        "bzzr://6eb5b621d876347c431700fbed4853eb598d3506c5911df918283ec4452afef9",
+        "dweb:/ipfs/QmYMz5h8r9mu29uYtdLSqB2E8mw9CxHs43f9KNmUwQVAGF"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.16+commit.9c3226ce",
+      "version": "0.5.16",
+      "build": "commit.9c3226ce",
+      "longVersion": "0.5.16+commit.9c3226ce",
+      "keccak256": "0x6b11bfff1870b2b6410a4a9d97c9142325770c80e3620b05b7f78a7fa1fcdecc",
+      "sha256": "0xa15f01700ec7e02f91bbdfd4b6ff4450b3c2decae173e4f41910a3cfbaf5d3d3",
+      "urls": [
+        "bzzr://259dcd9c09bb9fbb50fbb3fb4b97a03cfcd47c3fb99fd7b75be10bf4c59835d0",
+        "dweb:/ipfs/QmdyLZQ1LWwx4joeUYMN7rxPkDp4wDdMCgmUoDNQU2J6KC"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.5.17+commit.d19bba13",
+      "version": "0.5.17",
+      "build": "commit.d19bba13",
+      "longVersion": "0.5.17+commit.d19bba13",
+      "keccak256": "0x7e3f9626d004adbe0b835b08ebec2c0373f46dbccc0b2b36119c545ec27ff701",
+      "sha256": "0xc35ce7a4d3ffa5747c178b1e24c8541b2e5d8a82c1db3719eb4433a1f19e16f3",
+      "urls": [
+        "bzzr://f9f1f3d03d7caca5683f5206ea2439d85183d086668bba688fd095ac9d67384d",
+        "dweb:/ipfs/QmT3q4iWxzcF8X5ArX6vQpQue6f6rBP86cvti4udk6gMbC"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.0+commit.26b70077",
+      "version": "0.6.0",
+      "build": "commit.26b70077",
+      "longVersion": "0.6.0+commit.26b70077",
+      "keccak256": "0xb93ada00cffdf9bedc152f8a095c7694cbf16f9f0d0be5d27ec44814fb4b67b8",
+      "sha256": "0x5c4b30da18b0fa5f1ae3183127a4dcd64a279fcc15e16a477b0841d576770283",
+      "urls": [
+        "bzzr://ebe627323633c0fd23bbfb17ced455db9786dff2d30d9be30232d0076660a8a5",
+        "dweb:/ipfs/QmYZEbZxXVZbapmzXdea86J4e6RAADa3kyFTNrqCWoiiJk"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.1+commit.e6f7d5a4",
+      "version": "0.6.1",
+      "build": "commit.e6f7d5a4",
+      "longVersion": "0.6.1+commit.e6f7d5a4",
+      "keccak256": "0xe2087f40f53b10f8c28d84c5062da1659d99ad299a4d1549ba676163d7d682ff",
+      "sha256": "0x499c2aad132ffdf7a59ce87d88e4fece2ccd63f5ab7e283b1be4c722b06206cb",
+      "urls": [
+        "bzzr://c04235c5dedee430f9013641993ac5ebc7d76c94b656ec4d94333217e3aab066",
+        "dweb:/ipfs/QmVgKp1VC2vpGcdGtEgopvSiefLKzqHzKEnUf2gqcUzQj1"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.2+commit.bacdbe57",
+      "version": "0.6.2",
+      "build": "commit.bacdbe57",
+      "longVersion": "0.6.2+commit.bacdbe57",
+      "keccak256": "0x876d2cf22bbd0e036ad1d5ec15b7d611907319014d27832356001944dfcd19e9",
+      "sha256": "0x109ca8c6b92f4548e78c72a64c47c614617d7b2b5e4b6f8b9e7d654fc5186365",
+      "urls": [
+        "bzzr://4cd19e2db58f63d3bf597a478aa7152e44c9c25284d7d0f8ab140ddd5920d931",
+        "dweb:/ipfs/QmbUMYf94qPgf4yypkmCgDdkUwViDpQJ6Wk5GAdmcoAwse"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.3+commit.8dda9521",
+      "version": "0.6.3",
+      "build": "commit.8dda9521",
+      "longVersion": "0.6.3+commit.8dda9521",
+      "keccak256": "0x69fba2b6f43131c1a1ad71bd79938a83c320bfe58066f1b8c3de5c53b17d2c21",
+      "sha256": "0x601f874e2a52c759ddcc1074cb75c12848e2ce899a8746a43e2affbd28a655e1",
+      "urls": [
+        "bzzr://0c4192b681918edb569a86c907f1e7efcb11b0cc1243c743fd58540cf4952bb7",
+        "dweb:/ipfs/QmczLgpsCYbhNEVkcm3A8XsussFXBa3rBd4cP5N8n7thoZ"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.4+commit.1dca32f3",
+      "version": "0.6.4",
+      "build": "commit.1dca32f3",
+      "longVersion": "0.6.4+commit.1dca32f3",
+      "keccak256": "0x6caf7161a0fc98f00aa278f8adc243e2945282a5f9a64cb7ad215dcbf862116c",
+      "sha256": "0x96ddd81ea7d94d6e7f1135f7b11ab1d0635ad5585ed94147f1fe39b1ab7266fb",
+      "urls": [
+        "bzzr://bbfeeb7c451be78c94f5c8bd0d5238bdd59fb48363bd7d7f07f7ed8c3000de8d",
+        "dweb:/ipfs/QmQsiknhp8sSbDa1Yz3Pxs2jJTAMBFnXTJke2YqsgJmFdL"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.5+commit.f956cc89",
+      "version": "0.6.5",
+      "build": "commit.f956cc89",
+      "longVersion": "0.6.5+commit.f956cc89",
+      "keccak256": "0xdf597805353d77648745b8fcd9280cf03bc9ccbadce9832df6a94dd63f2164cf",
+      "sha256": "0x33276adff8f0e620adf71c4ab66d748d0690c34360ce4f55e0d18c77fa13476d",
+      "urls": [
+        "bzzr://cd7ee6bcef98c2825cf62e5f1d9224c357c2977862d9aa504d30fd94fb1d0666",
+        "dweb:/ipfs/Qme5AoEsw1knaoGJk2GhwBbHpxFcaxJoRnvUip2qqqZMgh"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.6+commit.6c089d02",
+      "version": "0.6.6",
+      "build": "commit.6c089d02",
+      "longVersion": "0.6.6+commit.6c089d02",
+      "keccak256": "0x802424b83dc8a24e867dfb26b5e63ab553f01ab0529690c420b54d3517c5f953",
+      "sha256": "0x5d8cd4e0cc02e9946497db68c06d56326a78ff95a21c9265cfedb819a10a539d",
+      "urls": [
+        "bzzr://8ef79a241e86c95822e096d2fa48b990673cbb53102265d9ad6732238a8d3604",
+        "dweb:/ipfs/QmfUrBizg8wPJcY5VX166LEidWNyT2GWjqunEVJHY63o9E"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.7+commit.b8d736ae",
+      "version": "0.6.7",
+      "build": "commit.b8d736ae",
+      "longVersion": "0.6.7+commit.b8d736ae",
+      "keccak256": "0xb287de7e2847e25b8b07ce260ac6a69ff679b35e1657f29840abe29b07b1e1b6",
+      "sha256": "0x20263aa17c2e7ca8c10ecd3d4242df61db9d549bc1ddb72b9a387c0c1136c1cf",
+      "urls": [
+        "bzzr://e916a33d8b35fd712dcef219aeb08bdf17ff0f9e939c0765a5d83fa07e36c6e0",
+        "dweb:/ipfs/QmcR4mBvu2unSmwCD5AXGt1r8cPv3iSMM8cdHc8RKy919R"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.8+commit.0bbfe453",
+      "version": "0.6.8",
+      "build": "commit.0bbfe453",
+      "longVersion": "0.6.8+commit.0bbfe453",
+      "keccak256": "0x79a7f7af2d8730ccb11d9b21f20cd033c1c0dac58490976e202f0dec24587c58",
+      "sha256": "0x9f76167c78635cd048ca30e75d9dade57ea6f0d03b83384d640d5da38e8c580d",
+      "urls": [
+        "bzzr://77d79270a51ce044c8525d1de127a6f2c303751d558bec1bef59839f4a10aaf6",
+        "dweb:/ipfs/QmR5GGfqrm1cK6wg6h2D3RjqmV2Gn45emGXGVp6nxWSdyN"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.9+commit.3e3065ac",
+      "version": "0.6.9",
+      "build": "commit.3e3065ac",
+      "longVersion": "0.6.9+commit.3e3065ac",
+      "keccak256": "0x8a2ed47fa7e1df9ee005ef76ae177619c5f4e7ef2fca378d910787834edf66a4",
+      "sha256": "0xeb42bef5784a0dec0f1b54c260b376deb0495940bfd474c44b5be31c0b634603",
+      "urls": [
+        "bzzr://21ae78060cf6faa09fcf7823bab119e10d6fc8f89f2ea3f54bfc3092a394e28a",
+        "dweb:/ipfs/QmZuLUuX3FgzFLCiEtzHMeaaRqiyvhJRnezxGg6Tk2zNkQ"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.10+commit.00c0fcaf",
+      "version": "0.6.10",
+      "build": "commit.00c0fcaf",
+      "longVersion": "0.6.10+commit.00c0fcaf",
+      "keccak256": "0x21fcb7912ee577def32c50261fe40b7b5f47e31889a66eb24f5c0173b76430aa",
+      "sha256": "0x68c414ba78325570a34817a829b1f3c62a18985708a2509729b50f79829a374b",
+      "urls": [
+        "bzzr://07ca755f5c200e94effb587ddb9870618e5b8eff3cb2d4b6320db118e1ec70e8",
+        "dweb:/ipfs/QmeB2irmzLRG4ijqZepyVKzRptu8LXHisBUYsHD4xJxfqD"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.11+commit.5ef660b1",
+      "version": "0.6.11",
+      "build": "commit.5ef660b1",
+      "longVersion": "0.6.11+commit.5ef660b1",
+      "keccak256": "0xb86c9264dcf7f5c95fdae2152e585e0ae27cca7473eb3846a8529bd7f201b031",
+      "sha256": "0x2e091d5f13bea0bc445c7f674d5cf8c9e42a3d4e35e1e50f00f4dd44898505aa",
+      "urls": [
+        "bzzr://77cd25017a79f47a4a7d89ede8e6dbd444568da0434d6b23a562ada1d709526c",
+        "dweb:/ipfs/QmTeKeZRbb695CuVMFtxChsM2B7zLEb9Yc69bDLCerPtCU"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.6.12+commit.27d51765",
+      "version": "0.6.12",
+      "build": "commit.27d51765",
+      "longVersion": "0.6.12+commit.27d51765",
+      "keccak256": "0x29aa693df3ed607f8dad19d47eac620c3db0e3f80eca94500b22c0f9975e6cb7",
+      "sha256": "0xf6cb519b01dabc61cab4c184a3db11aa591d18151e362fcae850e42cffdfb09a",
+      "urls": [
+        "bzzr://9c92be120b892904eb7fb993724e9afcefe1acb49c8b53a71e6e154bf0df8fd8",
+        "dweb:/ipfs/QmW2QNCj3nqoBsNjJCQX5sg6pNKUoU6SjpVgvJ6j5P9Qsr"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.7.0+commit.9e61f92b",
+      "version": "0.7.0",
+      "build": "commit.9e61f92b",
+      "longVersion": "0.7.0+commit.9e61f92b",
+      "keccak256": "0x2835bcea8a4bd76205a1734604747c3418039a78395034be4e25323689c34921",
+      "sha256": "0x117454791903d34587b7b07626c03253c6d4472b6f09f72ee007cf1f220b49e9",
+      "urls": [
+        "bzzr://4c426ab9c8545eee06aeb8288430e6653c1325b858b0e9cba99e26753b1b80bf",
+        "dweb:/ipfs/QmUKUg8pGVUiSdcoZCKbk1dctFxvuGpMN9QjHb21RhUqYL"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.7.1+commit.f4a555be",
+      "version": "0.7.1",
+      "build": "commit.f4a555be",
+      "longVersion": "0.7.1+commit.f4a555be",
+      "keccak256": "0x2e51df133f8a2a242ba061662ab3eaeb4443b4d903ebfa2e73dd264bab06294a",
+      "sha256": "0xc0c49402eaf18353e6bfb8fdc72627eca5d2d63fb36a5ea787114dee949799aa",
+      "urls": [
+        "bzzr://f27ee269598fa41541b53d7346b679d2851c2425c000eced8c4734e5c50b3f41",
+        "dweb:/ipfs/QmTjxYdpykbUKJVMp8sCsdU6pLsYJuvthaGupRdu19TGVg"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.7.2+commit.51b20bc0",
+      "version": "0.7.2",
+      "build": "commit.51b20bc0",
+      "longVersion": "0.7.2+commit.51b20bc0",
+      "keccak256": "0x0f1fb44ffea640ecd278fbe68859391fafa076183e9e5d3a2684c7eada34a7d5",
+      "sha256": "0x759930b396cda0d17621dd6eca8aa16a3570145960254431e6c42e81626e5a10",
+      "urls": [
+        "bzzr://887fae3c92d4ddd0fb35f17a10060c20fdc953b95a602c1cec62bc84bf756f70",
+        "dweb:/ipfs/QmVBDrv9CPZBnucUNASqeV2gWdJzTcqDJZr1mutw4TKB2u"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.7.3+commit.9bfce1f6",
+      "version": "0.7.3",
+      "build": "commit.9bfce1f6",
+      "longVersion": "0.7.3+commit.9bfce1f6",
+      "keccak256": "0xbd9427ebf103bc57b76c2d58b56643251bf4070aa573cc53bf10b0e1046307eb",
+      "sha256": "0x2a17dea3b1785eac45e6af0ce328af68eb943a6463b36e03d31d99d7651a28b1",
+      "urls": [
+        "bzzr://14a344535f797bb68fcac5061834d2510c24a0ccf1be3029d8d9dd8d7a389a71",
+        "dweb:/ipfs/QmcrNXLFH9Q7t6L94ZHSpUC4oTgL9sp5qYM6Ws8zMP3TKi"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.7.4+commit.3f05b770",
+      "version": "0.7.4",
+      "build": "commit.3f05b770",
+      "longVersion": "0.7.4+commit.3f05b770",
+      "keccak256": "0xc0276f1a865e4403c24172c53a540b5c6177d1aa52e0631b2d4689c5347f51b5",
+      "sha256": "0xe0fa6a8347a52bc6ec351e22537e645be06eb5041894460b1a9114f3732e9d07",
+      "urls": [
+        "bzzr://825d909b0212b5c62a22315a29afd7ffc49e33efaafde190ad2cf5015b1387a5",
+        "dweb:/ipfs/QmbwNDaZBPRpcTKrw4ersHpidTuprKwc2A4Dub5hw2QsWr"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.7.5+commit.eb77ed08",
+      "version": "0.7.5",
+      "build": "commit.eb77ed08",
+      "longVersion": "0.7.5+commit.eb77ed08",
+      "keccak256": "0x843edb5865c0668a6c7047af388ab8d3a6286006fe8ea8b3c3b2da1a873fd633",
+      "sha256": "0x96fb22134c10939334c62c8c0a668b712696f8f81426e6fcf042f0e709e7aa1e",
+      "urls": [
+        "bzzr://37a486de05ca46f2214e89fc2fbf80bbd985e9a9f7af191350de517566444840",
+        "dweb:/ipfs/QmWuiwFpMVA6Fwnfmt75BHbJ2294P7ZTcSBH9iUxz1inux"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.7.6+commit.7338295f",
+      "version": "0.7.6",
+      "build": "commit.7338295f",
+      "longVersion": "0.7.6+commit.7338295f",
+      "keccak256": "0x995f7d67d87a936dca9922389e6bdbfd2febb3aabe52beed5a43f73fb45a5146",
+      "sha256": "0xbd69ea85427bf2f4da74cb426ad951dd78db9dfdd01d791208eccc2d4958a6bb",
+      "urls": [
+        "bzzr://dc89697408277a96a802a0f84f113a65cd0923206403d6c6cda9a99f9071c5f7",
+        "dweb:/ipfs/QmUr3dNEKNCvsALhMb9NAhiX6otFBGfNpSXniLUn87hSoC"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.0+commit.c7dfd78e",
+      "version": "0.8.0",
+      "build": "commit.c7dfd78e",
+      "longVersion": "0.8.0+commit.c7dfd78e",
+      "keccak256": "0xcbc4fc0c2aa7976afd378608aa5702e2d53d5df325c0c29c894386e5cfe7d327",
+      "sha256": "0x64016310a57caf1af76a3610f1f94c8848c04c9673e7fa268492e608918a4bdc",
+      "urls": [
+        "bzzr://a541fb3df5f6b7ebe0716a958e83dd540ef820ea7b40d9835962d219d4670cd8",
+        "dweb:/ipfs/Qmas3dcZXXHwBtPp9aKCxZfVoJL17ndUHSUdBc2cLzJkZh"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.1+commit.df193b15",
+      "version": "0.8.1",
+      "build": "commit.df193b15",
+      "longVersion": "0.8.1+commit.df193b15",
+      "keccak256": "0x0fbc7448fd94f69159e28505bd9afe1a6fd3659a4651884409f04f55cfbad754",
+      "sha256": "0xdaa7f6d6cc0a316beb2607533183b64904798677b0cb99bda0549ea70e8de61a",
+      "urls": [
+        "bzzr://b3f593c602c78873a90c3b558f1d5ee7587e1833b294630f4c9d03ba8850fcc7",
+        "dweb:/ipfs/QmdsHDR2fbRsfEo2oorumuRsdAGXwhgFyssHSqcWV2eqaR"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.2+commit.661d1103",
+      "version": "0.8.2",
+      "build": "commit.661d1103",
+      "longVersion": "0.8.2+commit.661d1103",
+      "keccak256": "0x1cd8e6d1f694fd6287882c57043a0ac6212788eae7c9ea10125b5ae85a3a0e27",
+      "sha256": "0xb6b9429d71d4395901795936a0aaee0b23082fcaee10d563d87b42e69c0e68c2",
+      "urls": [
+        "bzzr://bf4d50233cc84b7d827494fdcecdfa0b273811e02b6b920daee0440eed77f0a7",
+        "dweb:/ipfs/QmXb4CcPVvKfnst6xP7W8oeEY6XLCd9LAMzpKnk6PEu3gJ"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.3+commit.8d00100c",
+      "version": "0.8.3",
+      "build": "commit.8d00100c",
+      "longVersion": "0.8.3+commit.8d00100c",
+      "keccak256": "0x8544a5953ba29ded6dd78cba0343c15bb99f0994f8252527c1d8ab82d49f75fb",
+      "sha256": "0xfb33afd761d0d704671dad582d3b4a790d4d85a6370fe71b3f8935649681e292",
+      "urls": [
+        "bzzr://95d6a343a95590a185e7a34419ee0a55b1870979206f6d30bb1e780b33114d09",
+        "dweb:/ipfs/Qmb1AFeoZzpy32zDG1A4dqRXwk6idm5z6pnxkv3rU1toLV"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.4+commit.c7e474f2",
+      "version": "0.8.4",
+      "build": "commit.c7e474f2",
+      "longVersion": "0.8.4+commit.c7e474f2",
+      "keccak256": "0xd13637ffb69029cae89a865066e78772d3264c0d05674c973a637c768f588f61",
+      "sha256": "0xf7115ccaf11899dcf3aaa888949f8614421f2d10af65a74870bcfd67010da7f8",
+      "urls": [
+        "bzzr://2f553b9aa9558949b90795e49298cb74ccd99b71bf44f1b038bd4f9722f64328",
+        "dweb:/ipfs/QmaH93CFvM25yNszPFokJqsGhoEs38fT6ib6M2WQwhwxqg"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.5+commit.a4f2e591",
+      "version": "0.8.5",
+      "build": "commit.a4f2e591",
+      "longVersion": "0.8.5+commit.a4f2e591",
+      "keccak256": "0x81b1b9610c05be13dd2294f1419c095131763187914358501d85789c3c051ad6",
+      "sha256": "0xbd782007a7d50500d22703145ace6d44c916c853cd0d0fcb2caeab9fa5fa33e7",
+      "urls": [
+        "bzzr://9b2f9cf220a2e42f3f33e7fa473aeddfb31f30d0a2acd933c75a73a507fb974d",
+        "dweb:/ipfs/QmaVmPWbjGrVaS9H3XEKqR8J9cYfqAPobAMjzRGNVwK2Cb"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.6+commit.11564f7e",
+      "version": "0.8.6",
+      "build": "commit.11564f7e",
+      "longVersion": "0.8.6+commit.11564f7e",
+      "keccak256": "0xd82f930c3db5da803c7b634bfca624279967da3a53bee1e2cef5b74057438a2d",
+      "sha256": "0xabd5c4f3f262bc3ed7951b968c63f98e83f66d9a5c3568ab306eac49250aec3e",
+      "urls": [
+        "bzzr://4815ed102dbe75cde56e0c2d89a340c601c6b86e78485937bb2ee2b3a1951f2f",
+        "dweb:/ipfs/QmTVGXJndEL6a8XHyxqsdZBh36BV3GQzZtV327P5TD8pfp"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.7+commit.e28d00a7",
+      "version": "0.8.7",
+      "build": "commit.e28d00a7",
+      "longVersion": "0.8.7+commit.e28d00a7",
+      "keccak256": "0x0163c110432e288bef6ef2c7e7c043e887459f5aee018cfa8f5a95f1a5d32746",
+      "sha256": "0x003d75383e45212f9812d0b6add90329fd3b239e6c378d2882f61f9345896d99",
+      "urls": [
+        "bzzr://4f16ed229bfb441868ca5cacf6005671a0fc6715c098c9732b6cf306bae1ee5c",
+        "dweb:/ipfs/QmW3LxYgQHDcUQp1SYMmHNRoLDrKyY5hh4czR5ZoJ1ByQv"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.8+commit.dddeac2f",
+      "version": "0.8.8",
+      "build": "commit.dddeac2f",
+      "longVersion": "0.8.8+commit.dddeac2f",
+      "keccak256": "0xd2f57fd0233d9ba2bccfb29498da59ee02c0433e07b9a99bcbd789b0cadfe99b",
+      "sha256": "0xe677b1216b136c61e38934a3de3a8e67de3f733d7ab28f0f046bd4a078b0cbb0",
+      "urls": [
+        "bzzr://6354038df1fc237e1f501ad38f8270b70e05481de75ece157b316abd58656886",
+        "dweb:/ipfs/QmUfzeuKDqyhGtFK3SB7mNFth4jXnnaSA93tsiFWVQVro8"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.9+commit.e5eed63a",
+      "version": "0.8.9",
+      "build": "commit.e5eed63a",
+      "longVersion": "0.8.9+commit.e5eed63a",
+      "keccak256": "0xc3a70946c825ecd5d7ce2db1ff2e9a608f1319e8912cc10bd1be9d171617066e",
+      "sha256": "0xf851f11fad37496baabaf8d6cb5c057ca0d9754fddb7a351ab580d7fd728cb94",
+      "urls": [
+        "bzzr://50b453a11c6b9a1f944cec38d4fd803abb75a4eb4a592592a769c38d773b5415",
+        "dweb:/ipfs/QmXV9woKT7inPFZEMhp2QiSnR7uMavef9CnBJoMUMdWVcb"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.10+commit.fc410830",
+      "version": "0.8.10",
+      "build": "commit.fc410830",
+      "longVersion": "0.8.10+commit.fc410830",
+      "keccak256": "0x915372f0d78e22a4fd337d3b0f13a7fe5aac57ec120639e7ebd066571a8e4420",
+      "sha256": "0xc7effacf28b9d64495f81b75228fbf4266ac0ec87e8f1adc489ddd8a4dd06d89",
+      "urls": [
+        "bzzr://6303ebb014b5fefc0a72f8a0c034994f8ad65c0c7394e8ccca37ea780e6f2866",
+        "dweb:/ipfs/QmSq2hGDMwASXwvEgZVkaUcpfBMwzQEWDnPEFdPTyHabmm"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.11+commit.d7f03943",
+      "version": "0.8.11",
+      "build": "commit.d7f03943",
+      "longVersion": "0.8.11+commit.d7f03943",
+      "keccak256": "0x222e13f9ebf5119083e555823669a7e537475450986bd1d095124e240d98e21c",
+      "sha256": "0x717c239f3a1dc3a4834c16046a0b4b9f46964665c8ffa82051a6d09fe741cd4f",
+      "urls": [
+        "bzzr://4d8a2aeed9af85852274b64edb3b8512e5680e9ab219d712383e5bd1957efbdf",
+        "dweb:/ipfs/QmTz8D5wkVmW4jfMHMsi638XBXQc3fWZqk2QJPz2Hk5Jos"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.12+commit.f00d7308",
+      "version": "0.8.12",
+      "build": "commit.f00d7308",
+      "longVersion": "0.8.12+commit.f00d7308",
+      "keccak256": "0xe18e051fd3770fc0f2678ea2975b33212feba0f5bdbece0aef0ac96265a218a7",
+      "sha256": "0x556c3ec44faf8ff6b67933fa8a8a403abe82c978d6e581dbfec4bd07360bfbf3",
+      "urls": [
+        "bzzr://ccaf2bc010c8d3ae9dc3d2c83092a1ee67dd2fbb34fbed42a08c5b315e84cdf1",
+        "dweb:/ipfs/QmamYEMfG154iMNydETqvGnpQDWGXEmu7cg6YHmKWDbNqQ"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.13+commit.abaa5c0e",
+      "version": "0.8.13",
+      "build": "commit.abaa5c0e",
+      "longVersion": "0.8.13+commit.abaa5c0e",
+      "keccak256": "0x789ce72e01f83cf052b543d6f0508c2ed2adae7ed40ea37913d9bd90166040ce",
+      "sha256": "0xa805dffa86ccd8ed5c9cd18ffcfcca6ff46f635216aa7fc0246546f7be413d62",
+      "urls": [
+        "bzzr://73cb255e06cd0f1eb3abf03dcb915f4843728f2783e3535c76f547b87eeb829e",
+        "dweb:/ipfs/QmSrfbnJcgUXUjT1oEAMQ77LC1MeEDxVfMGYuCJVRnogTr"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.14+commit.80d49f37",
+      "version": "0.8.14",
+      "build": "commit.80d49f37",
+      "longVersion": "0.8.14+commit.80d49f37",
+      "keccak256": "0x73c9a363ad79aa396a706175521b9ccb41dce2a2eee9f04b58dbac87b1fc8614",
+      "sha256": "0xd5b027c86c0f8fecc024d5d4f95d8ea48d8a942d79970310e342370532b502f0",
+      "urls": [
+        "bzzr://a46ac2b6fa96c949a6f70c05b07f378d565ae51f0de1b6bfb5ee4dbd13820019",
+        "dweb:/ipfs/QmPpPcCq91ufSe3ZCNjWs26nuGEuuUNLcgX5Sa3y3wPiPk"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.15+commit.e14f2714",
+      "version": "0.8.15",
+      "build": "commit.e14f2714",
+      "longVersion": "0.8.15+commit.e14f2714",
+      "keccak256": "0x3811602585e07c5404735f5bd329b11619a855f40ff2e1428bf95cb10c1a57ff",
+      "sha256": "0x5189155ce322d57fb75e8518d9b39139627edea4fb25b5f0ebed0391c52e74cc",
+      "urls": [
+        "bzzr://151d8aa0efc4c02e7d5656b9d2b926dedd3207ca010f787bf2ecc0564eb3c3e4",
+        "dweb:/ipfs/QmWdaqCBgtJyXJS5R5CbUYzxqbBuPxkKnKNxVmUtFGf2Zd"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.16+commit.07a7930e",
+      "version": "0.8.16",
+      "build": "commit.07a7930e",
+      "longVersion": "0.8.16+commit.07a7930e",
+      "keccak256": "0x88dde999590940b17b34e657c40067918e0078b3d903548d4ea44fa259ff2b71",
+      "sha256": "0x1632786c6c1f856a4a899232ec975a12f305118f43cce90e724ed0b2eebfeee1",
+      "urls": [
+        "bzzr://3061e1e12ffcb7dbe9f7b198bffa3a3fbd0d484e27ca96888b9b944a384e8b2a",
+        "dweb:/ipfs/QmSzG1PQR93uiUs3ov12vetPkfvJzxQZyfpeVh5WMGW4Uk"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.17+commit.8df45f5f",
+      "version": "0.8.17",
+      "build": "commit.8df45f5f",
+      "longVersion": "0.8.17+commit.8df45f5f",
+      "keccak256": "0xca03e8f6474b5becc8c28ad61830a23761e28b0dd53a6c89d48be89ab82e3a34",
+      "sha256": "0x99f2070b776e9714f1f76c43c229cf99b8978a92938ee8d2364c6de11c1a03d4",
+      "urls": [
+        "bzzr://f564ec3270c16b1bc458d9162cf10f26dc5d0a5884912423167f973a6dd63f96",
+        "dweb:/ipfs/QmePhTsZLZJfEsMSWpB36NRx7vZQuwUoysGgKaEdZLtnHb"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.18+commit.87f61d96",
+      "version": "0.8.18",
+      "build": "commit.87f61d96",
+      "longVersion": "0.8.18+commit.87f61d96",
+      "keccak256": "0x932901581a2ef0795851363522811fa160db5561e34cbb306e7105b6bbc3834d",
+      "sha256": "0x95e6ed4949a63ad89afb443ecba1fb8302dd2860ee5e9baace3e674a0f48aa77",
+      "urls": [
+        "bzzr://61828ca55d703ddcd2ceff0e20a48ae6bca28a58b09725836893dc5f6b8e8018",
+        "dweb:/ipfs/Qmf68UBPAspGAh6TJ1F9zKLFy3WjvH6W43HvzWWGAUQXTv"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.19+commit.7dd6d404",
+      "version": "0.8.19",
+      "build": "commit.7dd6d404",
+      "longVersion": "0.8.19+commit.7dd6d404",
+      "keccak256": "0x8da560f93223e19fbd973f12a29f765869559274aaeed3f795738ac433130ab9",
+      "sha256": "0x7a5c1d3dc9a8eba62bb2ec37192c9178ae5fe8a54a56e5573fd3c9c17cd9eb48",
+      "urls": [
+        "bzzr://49229e5b39418fb70d9aac067baba0a745ad1ce4c01ce1a97fe6a73bc416140c",
+        "dweb:/ipfs/Qmdpou1M3LCvJNUihLD2cmopbpbeKdhro1YvkT7KfpaTvt"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.20+commit.a1b79de6",
+      "version": "0.8.20",
+      "build": "commit.a1b79de6",
+      "longVersion": "0.8.20+commit.a1b79de6",
+      "keccak256": "0xd68fa7092d5af50c1dca4d6318f8a2470b11a766794814e505e3cc6a587deebb",
+      "sha256": "0x0479d44fdf9c501c25337fdc540419f1593b884a87b47f023da4f1c700fda782",
+      "urls": [
+        "bzzr://ea20fb34f982032a6bc6dcaa895429b859d7cbba5f80ba2b3343df65c77f2d2e",
+        "dweb:/ipfs/QmVhca2opoR2DEY7v9ntXHETfytq1jRMnatid4UuLNCMyp"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.21+commit.d9974bed",
+      "version": "0.8.21",
+      "build": "commit.d9974bed",
+      "longVersion": "0.8.21+commit.d9974bed",
+      "keccak256": "0x00bebaa90cfcc8c807b6b48cd8e9423bdbe5b7054ca0e47cbe5d8dd1aa1dced3",
+      "sha256": "0xf2857a898be15c69e8de5598dcd3f3e169e94964a0ce9a0bbb1b111f145a81df",
+      "urls": [
+        "bzzr://b22588ecb5c35fe0754c755b50bd1a1a7533171138e04970fc9c4dd2fcc269cd",
+        "dweb:/ipfs/QmagT6RpAi56zzW3GiFED6q9ztbgrp5WXomBzisbbRTYPg"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.22+commit.4fc1097e",
+      "version": "0.8.22",
+      "build": "commit.4fc1097e",
+      "longVersion": "0.8.22+commit.4fc1097e",
+      "keccak256": "0x0e8190e07b0928bb7c9523cc5f992430fffec6bccc0dd4bec7937039ceac20b8",
+      "sha256": "0x8be0aeb74fc1b8213292a09a84cb524a403602526df87ecad5f5cd2a7ea7d089",
+      "urls": [
+        "bzzr://e51e0fc25e86d76b070a9e1f97fcbd16902f18cf77688782388a6731f1635d1c",
+        "dweb:/ipfs/QmNaGrJcjMiTU66QndCZMSHeTv2WbCvWyP1R5KankxeZHt"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.23+commit.f704f362",
+      "version": "0.8.23",
+      "build": "commit.f704f362",
+      "longVersion": "0.8.23+commit.f704f362",
+      "keccak256": "0xf105026f42acb32bdad8d3dac86bfb37db9d9efdb0c730ee509a9cf3fdb1ec1b",
+      "sha256": "0x28726a452290c70e1984f15c53ad3088e7d98783ee3070b11b3664da77415732",
+      "urls": [
+        "bzzr://57ffacd9e36ddad5f6716914cb652c6ceffe72c5539b39a7ee88941d6fe939ee",
+        "dweb:/ipfs/QmeC2pQS54j76BP85Akhsv1XEejqv2zxyK4mJvio7Pu9h4"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.24+commit.e11b9ed9",
+      "version": "0.8.24",
+      "build": "commit.e11b9ed9",
+      "longVersion": "0.8.24+commit.e11b9ed9",
+      "keccak256": "0x5a127e73ef8c90f2df60ff2fe9dd79709da9e90d2d075cf05784c9a3efee2528",
+      "sha256": "0xfb03a29a517452b9f12bcf459ef37d0a543765bb3bbc911e70a87d6a37c30d5f",
+      "urls": [
+        "bzzr://696eac6b03201fe1e090f793ff3abcf862d738195e3db0da14c1cae1dc9315f6",
+        "dweb:/ipfs/QmZ5YMZQfiLhjiXoPQBxJyY1KPVPzhUXDbD1B7bYQCVKjQ"
+      ]
+    }
+  ],
+  "releases": {
+    "0.8.24": "solc-linux-amd64-v0.8.24+commit.e11b9ed9",
+    "0.8.23": "solc-linux-amd64-v0.8.23+commit.f704f362",
+    "0.8.22": "solc-linux-amd64-v0.8.22+commit.4fc1097e",
+    "0.8.21": "solc-linux-amd64-v0.8.21+commit.d9974bed",
+    "0.8.20": "solc-linux-amd64-v0.8.20+commit.a1b79de6",
+    "0.8.19": "solc-linux-amd64-v0.8.19+commit.7dd6d404",
+    "0.8.18": "solc-linux-amd64-v0.8.18+commit.87f61d96",
+    "0.8.17": "solc-linux-amd64-v0.8.17+commit.8df45f5f",
+    "0.8.16": "solc-linux-amd64-v0.8.16+commit.07a7930e",
+    "0.8.15": "solc-linux-amd64-v0.8.15+commit.e14f2714",
+    "0.8.14": "solc-linux-amd64-v0.8.14+commit.80d49f37",
+    "0.8.13": "solc-linux-amd64-v0.8.13+commit.abaa5c0e",
+    "0.8.12": "solc-linux-amd64-v0.8.12+commit.f00d7308",
+    "0.8.11": "solc-linux-amd64-v0.8.11+commit.d7f03943",
+    "0.8.10": "solc-linux-amd64-v0.8.10+commit.fc410830",
+    "0.8.9": "solc-linux-amd64-v0.8.9+commit.e5eed63a",
+    "0.8.8": "solc-linux-amd64-v0.8.8+commit.dddeac2f",
+    "0.8.7": "solc-linux-amd64-v0.8.7+commit.e28d00a7",
+    "0.8.6": "solc-linux-amd64-v0.8.6+commit.11564f7e",
+    "0.8.5": "solc-linux-amd64-v0.8.5+commit.a4f2e591",
+    "0.8.4": "solc-linux-amd64-v0.8.4+commit.c7e474f2",
+    "0.8.3": "solc-linux-amd64-v0.8.3+commit.8d00100c",
+    "0.8.2": "solc-linux-amd64-v0.8.2+commit.661d1103",
+    "0.8.1": "solc-linux-amd64-v0.8.1+commit.df193b15",
+    "0.8.0": "solc-linux-amd64-v0.8.0+commit.c7dfd78e",
+    "0.7.6": "solc-linux-amd64-v0.7.6+commit.7338295f",
+    "0.7.5": "solc-linux-amd64-v0.7.5+commit.eb77ed08",
+    "0.7.4": "solc-linux-amd64-v0.7.4+commit.3f05b770",
+    "0.7.3": "solc-linux-amd64-v0.7.3+commit.9bfce1f6",
+    "0.7.2": "solc-linux-amd64-v0.7.2+commit.51b20bc0",
+    "0.7.1": "solc-linux-amd64-v0.7.1+commit.f4a555be",
+    "0.7.0": "solc-linux-amd64-v0.7.0+commit.9e61f92b",
+    "0.6.12": "solc-linux-amd64-v0.6.12+commit.27d51765",
+    "0.6.11": "solc-linux-amd64-v0.6.11+commit.5ef660b1",
+    "0.6.10": "solc-linux-amd64-v0.6.10+commit.00c0fcaf",
+    "0.6.9": "solc-linux-amd64-v0.6.9+commit.3e3065ac",
+    "0.6.8": "solc-linux-amd64-v0.6.8+commit.0bbfe453",
+    "0.6.7": "solc-linux-amd64-v0.6.7+commit.b8d736ae",
+    "0.6.6": "solc-linux-amd64-v0.6.6+commit.6c089d02",
+    "0.6.5": "solc-linux-amd64-v0.6.5+commit.f956cc89",
+    "0.6.4": "solc-linux-amd64-v0.6.4+commit.1dca32f3",
+    "0.6.3": "solc-linux-amd64-v0.6.3+commit.8dda9521",
+    "0.6.2": "solc-linux-amd64-v0.6.2+commit.bacdbe57",
+    "0.6.1": "solc-linux-amd64-v0.6.1+commit.e6f7d5a4",
+    "0.6.0": "solc-linux-amd64-v0.6.0+commit.26b70077",
+    "0.5.17": "solc-linux-amd64-v0.5.17+commit.d19bba13",
+    "0.5.16": "solc-linux-amd64-v0.5.16+commit.9c3226ce",
+    "0.5.15": "solc-linux-amd64-v0.5.15+commit.6a57276f",
+    "0.5.14": "solc-linux-amd64-v0.5.14+commit.01f1aaa4",
+    "0.5.13": "solc-linux-amd64-v0.5.13+commit.5b0b510c",
+    "0.5.12": "solc-linux-amd64-v0.5.12+commit.7709ece9",
+    "0.5.11": "solc-linux-amd64-v0.5.11+commit.22be8592",
+    "0.5.10": "solc-linux-amd64-v0.5.10+commit.5a6ea5b1",
+    "0.5.9": "solc-linux-amd64-v0.5.9+commit.c68bc34e",
+    "0.5.8": "solc-linux-amd64-v0.5.8+commit.23d335f2",
+    "0.5.7": "solc-linux-amd64-v0.5.7+commit.6da8b019",
+    "0.5.6": "solc-linux-amd64-v0.5.6+commit.b259423e",
+    "0.5.5": "solc-linux-amd64-v0.5.5+commit.47a71e8f",
+    "0.5.4": "solc-linux-amd64-v0.5.4+commit.9549d8ff",
+    "0.5.3": "solc-linux-amd64-v0.5.3+commit.10d17f24",
+    "0.5.2": "solc-linux-amd64-v0.5.2+commit.1df8f40c",
+    "0.5.1": "solc-linux-amd64-v0.5.1+commit.c8a2cb62",
+    "0.5.0": "solc-linux-amd64-v0.5.0+commit.1d4f565a",
+    "0.4.26": "solc-linux-amd64-v0.4.26+commit.4563c3fc",
+    "0.4.25": "solc-linux-amd64-v0.4.25+commit.59dbf8f1",
+    "0.4.24": "solc-linux-amd64-v0.4.24+commit.e67f0147",
+    "0.4.23": "solc-linux-amd64-v0.4.23+commit.124ca40d",
+    "0.4.22": "solc-linux-amd64-v0.4.22+commit.4cb486ee",
+    "0.4.21": "solc-linux-amd64-v0.4.21+commit.dfe3193c",
+    "0.4.20": "solc-linux-amd64-v0.4.20+commit.3155dd80",
+    "0.4.19": "solc-linux-amd64-v0.4.19+commit.c4cbbb05",
+    "0.4.18": "solc-linux-amd64-v0.4.18+commit.9cf6e910",
+    "0.4.17": "solc-linux-amd64-v0.4.17+commit.bdeb9e52",
+    "0.4.16": "solc-linux-amd64-v0.4.16+commit.d7661dd9",
+    "0.4.15": "solc-linux-amd64-v0.4.15+commit.8b45bddb",
+    "0.4.14": "solc-linux-amd64-v0.4.14+commit.c2215d46",
+    "0.4.13": "solc-linux-amd64-v0.4.13+commit.0fb4cb1a",
+    "0.4.12": "solc-linux-amd64-v0.4.12+commit.194ff033",
+    "0.4.11": "solc-linux-amd64-v0.4.11+commit.68ef5810",
+    "0.4.10": "solc-linux-amd64-v0.4.10+commit.9e8cc01b"
+  },
+  "latestRelease": "0.8.24"
+}

--- a/packages/dev/foundry/svm-lists/macosx-amd64.json
+++ b/packages/dev/foundry/svm-lists/macosx-amd64.json
@@ -1,0 +1,1190 @@
+{
+  "builds": [
+    {
+      "path": "solc-macosx-amd64-v0.3.6+commit.988fe5e5",
+      "version": "0.3.6",
+      "build": "commit.988fe5e5",
+      "longVersion": "0.3.6+commit.988fe5e5",
+      "keccak256": "0x662f94643bbc549d00fe7cfdbcdff504c78c697b10dcfca645d6082d464c1402",
+      "sha256": "0x02d581b5b373d8160b9e75d690dd2ee898c3e0f6a39bbda54cd0698224c09df4",
+      "urls": [
+        "bzzr://f8f4ef96514fda43ca31517a4f493aef6224d72ead70ac0b4cc36a5d341901a6",
+        "dweb:/ipfs/QmR59SfyA5TETyhBvxgZBvhedSZyA9Ka2NPBGVbV9CknYf"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.0+commit.acd334c9",
+      "version": "0.4.0",
+      "build": "commit.acd334c9",
+      "longVersion": "0.4.0+commit.acd334c9",
+      "keccak256": "0xe15cdf6bfd7a87c22aca862df0ed268c56d0a3aed404c56c92aaa1c02b4738c2",
+      "sha256": "0xbba6e2c33935259c478060501a7fb0ee1db4b0c56567356c9d01b6ec0491a558",
+      "urls": [
+        "bzzr://e130cfd6a4369d932e02220b164417ff025a6967ac2a4f4241140eb08793c8f9",
+        "dweb:/ipfs/QmWtKJmhaLmaLsqQW5Bptq6FADF7WCaZkmMQdKdzi8bdUw"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.1+commit.4fc6fc2c",
+      "version": "0.4.1",
+      "build": "commit.4fc6fc2c",
+      "longVersion": "0.4.1+commit.4fc6fc2c",
+      "keccak256": "0xd0142f44be7a230ff448237472451521abbabcb5d75d388346d1b7cd1e9e6962",
+      "sha256": "0x2de730163c80670b2f4c1ef78dc77ab13f757aad1ead044761821293275c382b",
+      "urls": [
+        "bzzr://441e085a6f97965273b9dc0cae1870fdf769473db11aab99a9fc1dbbe073e7b3",
+        "dweb:/ipfs/QmQhL9fPTox8eJsiSxzFyUjZ5G26sy2BVUSYXLya4KpcWT"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.2+commit.af6afb04",
+      "version": "0.4.2",
+      "build": "commit.af6afb04",
+      "longVersion": "0.4.2+commit.af6afb04",
+      "keccak256": "0x1b25df7ffcbd8bd77346482483164905ec57837bca8a6035aa4d32beb11434ca",
+      "sha256": "0x9882bb966b82c0f4847735dba20b517118cf5408ed2a872485750f6ff26cf98b",
+      "urls": [
+        "bzzr://5d6baebbb6372afa3c0d6185de44709dc9fa0a69b239bcc06612eccd44f80216",
+        "dweb:/ipfs/QmcjAyKwEdj93CTgL4DNYwgSzigb6ZhBtEzWpXBjs4xJvr"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.3+commit.2353da71",
+      "version": "0.4.3",
+      "build": "commit.2353da71",
+      "longVersion": "0.4.3+commit.2353da71",
+      "keccak256": "0x41d167822f3ab9cf03e4e3dcb800aff49a93cbd2b5ea37941777df80a5bef69e",
+      "sha256": "0x3ac02a93f4c7c20b9f17b6038af25b41acb8cfe178040be0f2246adc8bb8fe0a",
+      "urls": [
+        "bzzr://03a77f58631ae16e81aa85c6dacbc6bc2ca7c34c1073171e2562ef0738979570",
+        "dweb:/ipfs/QmaZZSYJV7pYHTDJTX44UsVrSS8UkCX2xBx3FhYyjzP8bn"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.4+commit.4633f3de",
+      "version": "0.4.4",
+      "build": "commit.4633f3de",
+      "longVersion": "0.4.4+commit.4633f3de",
+      "keccak256": "0x66721111ee0d4c3d718832ac2150fed55b3d61baa4fcf0f3bfcfd6d034f7515f",
+      "sha256": "0x38ceeea801b5952d74bdb79ae5bc6bbb4c187ee5941e2701de388fdf95322f58",
+      "urls": [
+        "bzzr://fe16871dbb1f5ae55e7fd4a2feb2e57f10fbe9ae240c408d74e4821544a71cfe",
+        "dweb:/ipfs/QmWcNcnW2NiHiY4Lm1DaEWGgiBnHcDh8NjAJzmxtEewHC1"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.5+commit.b318366e",
+      "version": "0.4.5",
+      "build": "commit.b318366e",
+      "longVersion": "0.4.5+commit.b318366e",
+      "keccak256": "0x5171e0d6ee047330e44c5b041a579aabe348482145405449cdcdf70c089db66c",
+      "sha256": "0x003b09c2f255d2a40c2b2a1798192f92e6a3f1b35bda1a35ba66675919be1555",
+      "urls": [
+        "bzzr://77fac88430da037b2559f5023168624a071f4ecadf5ea6c65d9689a2e1f829cb",
+        "dweb:/ipfs/QmTVDBJBqUyoJVXYYAYGsL3udgx8QrTcTMAADottWRCYpi"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.6+commit.2dabbdf0",
+      "version": "0.4.6",
+      "build": "commit.2dabbdf0",
+      "longVersion": "0.4.6+commit.2dabbdf0",
+      "keccak256": "0x6ad5195014b546f57e6dee05a5170dadbedde6f657893da05d9da1416e45e2f0",
+      "sha256": "0xaef1ebf2d2783a31742a612461f13e0ffc656c4a5ce25a0eeb747186ce03b276",
+      "urls": [
+        "bzzr://2aac1f5d260866e1707f750fcad9eb253afd35073a6a97aa1a62121fb78d6a0f",
+        "dweb:/ipfs/QmbrbFFvcCstpF8sVoSP8sPt3WYqHfvGmZ8zKHF1syx8uS"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.7+commit.822622cf",
+      "version": "0.4.7",
+      "build": "commit.822622cf",
+      "longVersion": "0.4.7+commit.822622cf",
+      "keccak256": "0xeeb96fbbe5b942c2c6ecf8a0ca4c0a88d290731a56782df8e52284aa3d48e754",
+      "sha256": "0xfc386d2547b6f764a0c1139487ed1d4a19e334c510a727614ff8ebeb1bd01a93",
+      "urls": [
+        "bzzr://518ea2503a211c4dbf511dee27dac4a367820273268103c14d0366400fe639da",
+        "dweb:/ipfs/QmWoWxZpANYVnTwSf9ef1BG597NVDkxVyJzdxMcp1qTKgs"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.8+commit.60cc1668",
+      "version": "0.4.8",
+      "build": "commit.60cc1668",
+      "longVersion": "0.4.8+commit.60cc1668",
+      "keccak256": "0x690ab93a9d9d5174e699cb58f4898391ea112850d95f5ecac25e259f36505dad",
+      "sha256": "0xebb64b8b8dd465bd53a52fa7063569115df176c7561ac4feb47004513e1df74b",
+      "urls": [
+        "bzzr://1a6089dc3d33e3bbec9f0a9ccd04872282b90da2563466200bea21eb72b8c7c3",
+        "dweb:/ipfs/QmRiR9xu9wV3sGmfQbiWjDHnbpa1HfqwSeudL831LqFBYt"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.9+commit.364da425",
+      "version": "0.4.9",
+      "build": "commit.364da425",
+      "longVersion": "0.4.9+commit.364da425",
+      "keccak256": "0x31fa8fa8b04ddb729490ca59fe1e212e8b1d25f9fb19de190864a1093d7c1609",
+      "sha256": "0xa5b4227ed259c474426d8a2ef380606766aa8ba7f65487ab177139b3a51f0dee",
+      "urls": [
+        "bzzr://06fdc632eda9b6916774ba35432bc0f02bbd2f48ca8c8675db24ec5a902b82b6",
+        "dweb:/ipfs/QmQTVdW8cyRGPXEWbpRvinZBDGBYhUAsSZSf7Khp5VQKNQ"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.10+commit.f0d539ae",
+      "version": "0.4.10",
+      "build": "commit.f0d539ae",
+      "longVersion": "0.4.10+commit.f0d539ae",
+      "keccak256": "0x7b642dedbe89b221e7ab15c1b67d18aa04e4de91f987c5d2b8ff90c0bc761e60",
+      "sha256": "0x40f179e4d27201ab726669dd26d594cfe10bf4dd6117495ee49d26f0dda9ef42",
+      "urls": [
+        "bzzr://79a004dab9401b9e45c882ef19929ad3141af89b3d3f9fd8c21f8cf3310703e9",
+        "dweb:/ipfs/Qmbsi7dJy45HyzkprNd3QuxARRedNH3akSLwcxibGghGaU"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.11+commit.68ef5810",
+      "version": "0.4.11",
+      "build": "commit.68ef5810",
+      "longVersion": "0.4.11+commit.68ef5810",
+      "keccak256": "0x230569faf79408fec44b931151f7113006e4b34038b55eecb2a2d1dba6407c60",
+      "sha256": "0x287eab0187dd4bdec50226f3173526bd8d247adeebdf64bc0b7448711abbea61",
+      "urls": [
+        "bzzr://9cd6f534ed307b73097d1efa92f1fa12c4d44ae45026549e3d6c968d8c351e97",
+        "dweb:/ipfs/QmZEGqT4RLTC6ngDzP22MAunduX537gdBD5FuHMRqWPzGi"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.12+commit.194ff033",
+      "version": "0.4.12",
+      "build": "commit.194ff033",
+      "longVersion": "0.4.12+commit.194ff033",
+      "keccak256": "0xd347f34d80512781730a88a35f54ea60cc8f22f41fa89a90fa23d6067e48e9c5",
+      "sha256": "0x65cc92c918d6334f533a7596f62916825fc722b2a7a235729ed87cfbec622bcd",
+      "urls": [
+        "bzzr://e6b9f049ff3fa866f1289081cd7696d0d60f5a6532d785c1453b8499244e24ee",
+        "dweb:/ipfs/QmUGFo9on7dTJZEU5JUZpUpgat2B9dhyawSMxYnYVTmuvP"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.13+commit.0fb4cb1a",
+      "version": "0.4.13",
+      "build": "commit.0fb4cb1a",
+      "longVersion": "0.4.13+commit.0fb4cb1a",
+      "keccak256": "0x0715c4a2295fae7c057d810535d83cd34b280a2296cd7fc83efdfa2f38d5fece",
+      "sha256": "0x701eebf0e37d172cb829dc1e65c74a46b3b96737f3866758f9894696a639b6b7",
+      "urls": [
+        "bzzr://2b54f83e600406898dc18ba2e43307c79c49f29f1d2fdfdae0afc9b8f20a3d0b",
+        "dweb:/ipfs/QmcTSjhWs8WCjqAoU8h5Wo5qCstmwxnNsDtGMzNu3F6MiV"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.14+commit.c2215d46",
+      "version": "0.4.14",
+      "build": "commit.c2215d46",
+      "longVersion": "0.4.14+commit.c2215d46",
+      "keccak256": "0x1fbb0477543b5d27102f095807bf68ec8f2ff23b65212869fea942bcfe6f1e4d",
+      "sha256": "0xa4ef22d9d36e75151bdd64720e69eddf57500883dd623c57805edb5ccb644a89",
+      "urls": [
+        "bzzr://826435367348f6ecab540323f9dbe55540a0d0aeb7336cf7dfee5c18bd0eccbe",
+        "dweb:/ipfs/QmdfbxCdhvrfL24y78KNzqUKGJzRHi5H8ckW9p6GLTZr72"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.15+commit.8b45bddb",
+      "version": "0.4.15",
+      "build": "commit.8b45bddb",
+      "longVersion": "0.4.15+commit.8b45bddb",
+      "keccak256": "0x64a70448467ddd8207ef0917b405ec5378a31b8b8e71b896f72c7b2721ea8366",
+      "sha256": "0xe449a4980db4ff18e7ffe704b40083cded96cccf33986bf6a6bb6fe925eb86c0",
+      "urls": [
+        "bzzr://d12223b8d998d355bb53aa8806ca68d64303521ec0bd33a263686b62ac47dcf2",
+        "dweb:/ipfs/QmQrFUVDkwGfDeLvnX6tyTeEQf4ivcNYEHBGUmhZan1jTg"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.16+commit.d7661dd9",
+      "version": "0.4.16",
+      "build": "commit.d7661dd9",
+      "longVersion": "0.4.16+commit.d7661dd9",
+      "keccak256": "0x05d5bbd0dad953327dad1fcce80e5c44dfb04995d8ad87a3e7078eef6b4a83ec",
+      "sha256": "0xa24512aee16652c4469979715bbdcaa6c4afabb94b717bb40980e4b2d25c4709",
+      "urls": [
+        "bzzr://f69b11c78859b4d63777a18ce8320989a814a75751e9a1e7e8c958574d9b7089",
+        "dweb:/ipfs/QmeHjMa2nfHsQkPHd2ameFYTEM7dRHtFvXRm1TzUakfRSA"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.17+commit.bdeb9e52",
+      "version": "0.4.17",
+      "build": "commit.bdeb9e52",
+      "longVersion": "0.4.17+commit.bdeb9e52",
+      "keccak256": "0x52b105a3d36e2fd2b99e1fa69e4366035810c93c92baeb27ad9d37a29391a23d",
+      "sha256": "0x458c3e2de2ffe609b79d9cdc4eb3080d6ed7662ef1bdd7c8a03fb18f1ca9a137",
+      "urls": [
+        "bzzr://caf9f5842fe15e713653a69236cf51f8cb2bba9b29f03915b6588fcce8b9267d",
+        "dweb:/ipfs/QmbNCaPHNdpaHBLYcAEHVFjms6TKfpo5maU9kS7fj2zF32"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.18+commit.9cf6e910",
+      "version": "0.4.18",
+      "build": "commit.9cf6e910",
+      "longVersion": "0.4.18+commit.9cf6e910",
+      "keccak256": "0x6ed8a169695fddb45e22975b416b6ac8bf5758f6765a5fc45a7708e266bd3eeb",
+      "sha256": "0xdddc86683d12d0f016b5d5799ed84f6f2a79f667ebb932b9a8e6bfe9a48c3190",
+      "urls": [
+        "bzzr://61696afc061612e49abd151286c3afef433f8d0a9e2eaf9527bc7fce7f3a5a2b",
+        "dweb:/ipfs/QmQBofdea6hmCFSurTKyiqVW3dLC5raFiucVG7k8tFq26y"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.19+commit.c4cbbb05",
+      "version": "0.4.19",
+      "build": "commit.c4cbbb05",
+      "longVersion": "0.4.19+commit.c4cbbb05",
+      "keccak256": "0xa291d2f1fb5d75e61c3f07e96093bce7fc0ac1607c609bf352b434bb9158170d",
+      "sha256": "0xace5107a68fa75634e26848d6d208b808a76cc4f9262e53e8a3622bcefd4dcaf",
+      "urls": [
+        "bzzr://9971fb2527a4627a4f74efec763417bfb80da2da2152a030d86112861378947e",
+        "dweb:/ipfs/QmevE3c2Bezj8ommRqtY35SjrwRHUEMbJM8LntWHzqB99n"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.20+commit.3155dd80",
+      "version": "0.4.20",
+      "build": "commit.3155dd80",
+      "longVersion": "0.4.20+commit.3155dd80",
+      "keccak256": "0x035cf886038fb4c4afe8014391c8432cf91997971f37d2cd509e8dd56a3f7f71",
+      "sha256": "0x47425e338b9461d3e6498a0b0d5c2b9cc7cf998e4aa69126ea9f64c0a176e605",
+      "urls": [
+        "bzzr://f07a63c06de8fbc236ae8e90d8e936656a1b1cb6d4009685e16382aa180ed6c0",
+        "dweb:/ipfs/QmUUkRBTZ5KF5yZi8yzPVn7wrMr1rL2NPE7xfyyBCsbGxS"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.21+commit.dfe3193c",
+      "version": "0.4.21",
+      "build": "commit.dfe3193c",
+      "longVersion": "0.4.21+commit.dfe3193c",
+      "keccak256": "0xf5cb6ae6e7ad8d7d33e0dfb310691eff9fa18f27fbe8db2c3a848812ce38e1bf",
+      "sha256": "0xe035cb9a81b5e3e11a7b99ead6f51a3ef7729794eebee470a964e2c08e30b857",
+      "urls": [
+        "bzzr://6bb86ad1929e0eb0c499b0863324cae9f2c74686bba8961b23acb39c324b574e",
+        "dweb:/ipfs/QmcgbaThT7VV5fJn3QrgMxXL5convCAccaopRX1yWii4CM"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.22+commit.4cb486ee",
+      "version": "0.4.22",
+      "build": "commit.4cb486ee",
+      "longVersion": "0.4.22+commit.4cb486ee",
+      "keccak256": "0x49ed59d22c36ff495a6167d4e34074dc0ad0c50806016fbb6e2dc111baf0ab09",
+      "sha256": "0xa9341add7a4f01c52dbb36bb4028104676c684b0b6003a2cd9dd84a2a9802b59",
+      "urls": [
+        "bzzr://e549af82db389897157316c7748c276d2b7706df4af04bd761e3f58b0b8efe85",
+        "dweb:/ipfs/QmURjSdCxu4e6qpmFPArWjR5zZGaZt4gMxooWgUmZjE5ih"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.23+commit.124ca40d",
+      "version": "0.4.23",
+      "build": "commit.124ca40d",
+      "longVersion": "0.4.23+commit.124ca40d",
+      "keccak256": "0x71f9c2c1eb71eaa97dc8cdeabb254f2bc460933bc59c2b3059aefab4942825a8",
+      "sha256": "0x502eddb177f9268d79b1e05e6acfb2f229471823bf6711eff411d2a23e8cc0b1",
+      "urls": [
+        "bzzr://8edd27d6b2a43ed0c8e4d3f4ab569d3bbaa58f18b7d69fe9c88913e2e074fd1c",
+        "dweb:/ipfs/QmPHfgmtFZXrwb2jWnKSh3hXESNcHx6rRSoWPoDdvgyzKq"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.24+commit.e67f0147",
+      "version": "0.4.24",
+      "build": "commit.e67f0147",
+      "longVersion": "0.4.24+commit.e67f0147",
+      "keccak256": "0x287dc3f7742980f494c95d7b70724133b7f49d51132eb47eaef1423c87a6edba",
+      "sha256": "0x7034c4048bc713d5c14cdd6681953c736e2adbdb9174f8bfbfb6a097109ffaaa",
+      "urls": [
+        "bzzr://d2778b5ba7cbcab0e9fbf9c8b0fdf689b3b680c145c6f949e47ec4f023bb2189",
+        "dweb:/ipfs/QmbPhCgU88uhyWjYF7CBvFiCK6etGssxUTNkV3QkBHgtMk"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.25+commit.59dbf8f1",
+      "version": "0.4.25",
+      "build": "commit.59dbf8f1",
+      "longVersion": "0.4.25+commit.59dbf8f1",
+      "keccak256": "0x857693802947544d326f294238bcffbade6a49acd2e1e7204d7b5c0577de21ca",
+      "sha256": "0x9dd7686975200be71ce731f153823e7ea0d68106f3354ea16fecd5975f5c98b7",
+      "urls": [
+        "bzzr://c1011a43e36ca050aa9a00b52e7ed0c42176439f781e4d59f45ee496f37d3e98",
+        "dweb:/ipfs/QmcaC5MrrbYP9jEHo4Pn4FLMMhSwL6z8RhheGaVPFvGJjB"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.4.26+commit.4563c3fc",
+      "version": "0.4.26",
+      "build": "commit.4563c3fc",
+      "longVersion": "0.4.26+commit.4563c3fc",
+      "keccak256": "0x0f75819686eab4238b1f662667cd55bde1f923d022e83a547f5b9d4753ca7147",
+      "sha256": "0xbc956645b792dcbb8f820b8010a8d4ec1e188f7b40c6af951a436da4c13ae677",
+      "urls": [
+        "bzzr://1928511f27ffe8f44c5cff04e0f4f2787b67c816da9ea869d34628f6f499c7af",
+        "dweb:/ipfs/QmaM4Fs6pzH8LvNFhFCbfgTfUo8nmZTKugfxmN7Ze6tT8U"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.0+commit.1d4f565a",
+      "version": "0.5.0",
+      "build": "commit.1d4f565a",
+      "longVersion": "0.5.0+commit.1d4f565a",
+      "keccak256": "0x0a89e22f8423a2ee551b4a7811c69321a06a70d8a00784deb712c6cf0757fca2",
+      "sha256": "0x9fa663fc427e8e9613815ad6b83783b4e4cb10439f16ca0dcb12fc002c45ab5a",
+      "urls": [
+        "bzzr://5f7b9658b980f95e54f2da92b39e02af3e1c81a8aca603955c3492b72651e51c",
+        "dweb:/ipfs/QmdHxa1Z4fM3mFxueHba257rxyxD8Vjqg6a3n8GzvMQqFz"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.1+commit.c8a2cb62",
+      "version": "0.5.1",
+      "build": "commit.c8a2cb62",
+      "longVersion": "0.5.1+commit.c8a2cb62",
+      "keccak256": "0x7135a9fd0c2e6cb403adbbd0534f22b8904bef330f5debaa4c240d7d5bdfd5ac",
+      "sha256": "0xf2bad43386065684b4e15b86a175410f5d1e4d234b052cba44eb50f4c74b021f",
+      "urls": [
+        "bzzr://060a48f64c36ec851b09dfa80af17a219db1945b1bd078e61e2e59287e5f5477",
+        "dweb:/ipfs/QmejDUR2dLS5h6nrqt7x1pJ7seBoo82SJpRYBRW2qN2VDa"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.2+commit.1df8f40c",
+      "version": "0.5.2",
+      "build": "commit.1df8f40c",
+      "longVersion": "0.5.2+commit.1df8f40c",
+      "keccak256": "0x7a87045680f25893ebd0d14c36113303ee36864c715dae6b6bf60eff7c6c6073",
+      "sha256": "0x9e7ee54f0bc2978fa8738b9603d636715a069d84771778d6195577bb91ecb9c8",
+      "urls": [
+        "bzzr://6f84855b70c094210e3e0edb4549d746135a441ea5fcc5f3ac0e6bdb3d64225d",
+        "dweb:/ipfs/QmPwnPkuf89E6H2U6mBjRUeMr6feD5YoAihnzd8a5HeQrF"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.3+commit.10d17f24",
+      "version": "0.5.3",
+      "build": "commit.10d17f24",
+      "longVersion": "0.5.3+commit.10d17f24",
+      "keccak256": "0xa3e5beb407a5396463e4bb17a100cd8e19d00aa8bc76496af4dd7e96787c53b2",
+      "sha256": "0x03a6cfa2d74e57ea38eee83ce9a3ea37a6e50928d7f109e74b37cae31319af2b",
+      "urls": [
+        "bzzr://b0a16ff7c23c5da577edcacad06972d6cb7fafaa5c9215699ad99f0b4be9f8c7",
+        "dweb:/ipfs/QmYvHkxeXXk8sPUsVtzmetE2osWfEYB85PNhtQ2d7uxFKe"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.4+commit.9549d8ff",
+      "version": "0.5.4",
+      "build": "commit.9549d8ff",
+      "longVersion": "0.5.4+commit.9549d8ff",
+      "keccak256": "0x6ac8af918e4121b072d51212a4648cbc3667f0aa7e50285cad1291577a08efb5",
+      "sha256": "0x32a8affa996d05c55257317cc700b9e5b4377d94919b59055564eb0b5f941773",
+      "urls": [
+        "bzzr://c7033e1e4fdf923304d28a5e188cb4f4a11bced6e3178c674cc843ed4c3583ed",
+        "dweb:/ipfs/QmUJFZ4To2PfV5rbqpjNCfBopZQ7VXzkLd4DiRYf5EFWN4"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.5+commit.47a71e8f",
+      "version": "0.5.5",
+      "build": "commit.47a71e8f",
+      "longVersion": "0.5.5+commit.47a71e8f",
+      "keccak256": "0x182fc3bd33895c32dbb0613113aecd72f59f4330e7e7bfe5c47646abbdd26cc7",
+      "sha256": "0x7fc0600cc150020402c9539ec0ad584eb9271b2d0e0bff9e3b4d4ca672be3452",
+      "urls": [
+        "bzzr://9bad36f6326e8adc929b3c95abd6c6580092e0a3508056773203ae34ca17830c",
+        "dweb:/ipfs/QmWp2yX7HF2sH61XsRkwqWmngXEdPnKtcz6Ah1pQopeMUj"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.6+commit.b259423e",
+      "version": "0.5.6",
+      "build": "commit.b259423e",
+      "longVersion": "0.5.6+commit.b259423e",
+      "keccak256": "0x29720ecdacb43bad240afea74e98c21ee106ddcf9fba81a2046bcff698e66346",
+      "sha256": "0x428f9c0873d88740242f6fc16a3ae6f91b35f73ddf7676b5d5b39687d9d9b7dc",
+      "urls": [
+        "bzzr://f704edde1884e85980ebb07b8fb9feb32adcd605c19cb78a1195aa4021354d2e",
+        "dweb:/ipfs/QmSsdA3d2CzD2cMrhid4yDsTy1USkBWDYySLSsKJGvtPAc"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.7+commit.6da8b019",
+      "version": "0.5.7",
+      "build": "commit.6da8b019",
+      "longVersion": "0.5.7+commit.6da8b019",
+      "keccak256": "0x02ffc634068a3930b72e9861207346ce033fc6710f11d288489f905b4c325815",
+      "sha256": "0xa7d6b8e3cb22d90789a79b484b721fe02943f89e9b7e996863edd2d40ba7b524",
+      "urls": [
+        "bzzr://dcf38cc06936a72f761c6b8eb77728d21d14e1130380a985893840c4f99fa140",
+        "dweb:/ipfs/QmamAAci8zMaxZ3zCdQMm3Hke5ChCqLbRR5zJiCCH27QQB"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.8+commit.23d335f2",
+      "version": "0.5.8",
+      "build": "commit.23d335f2",
+      "longVersion": "0.5.8+commit.23d335f2",
+      "keccak256": "0x0fc5f3026ac39048101bffae40a053f6da119e57c0154445cfabcea6dd716cb5",
+      "sha256": "0x9f383896c8506cd96ac5ef9c97d7ab1c385fb5f4772a5f3d2cf8715cae793554",
+      "urls": [
+        "bzzr://5256f697214601e713a377821707ab7aa81e00a86ba63cd0291683629d5c3db6",
+        "dweb:/ipfs/QmdqvCaENZmRPg6WCjh2hVhWTpnaU7yf2qvY5a3T4BMXXh"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.9+commit.c68bc34e",
+      "version": "0.5.9",
+      "build": "commit.c68bc34e",
+      "longVersion": "0.5.9+commit.c68bc34e",
+      "keccak256": "0x0d4aa467fe96d5c934201f5265a5c940e556551e10bb630481f88ff59070b8d5",
+      "sha256": "0x92e3688207c0c2b86bd9d10088340e4a585e29e3a88d1cf79c2043f4f9f121c4",
+      "urls": [
+        "bzzr://8b6991bceb463e4d1617c9e5bbb2f5fe40c435a5fcc76b8286f3581e56ae3cbd",
+        "dweb:/ipfs/QmYQEBMqCFzJAQgijj3AQUXx1b1UEEUmM6zHw3m8xQwrsA"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.10+commit.5a6ea5b1",
+      "version": "0.5.10",
+      "build": "commit.5a6ea5b1",
+      "longVersion": "0.5.10+commit.5a6ea5b1",
+      "keccak256": "0x001e08d9d1902a4f040e109b2b7e049371e687896409ad2de84dfe9b455bd547",
+      "sha256": "0x5082bb5c492ca35b68b0c3e24d5934b56d3add83f1400ba95654e8f163c741ff",
+      "urls": [
+        "bzzr://bae78448cfca3858a555580c0824271eabfd1bf808a15adc68fc00a861b98e53",
+        "dweb:/ipfs/QmeXwGRydas256VMavRw4kPcT3fX1MY6LjZP28qmsnWPwx"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.11+commit.22be8592",
+      "version": "0.5.11",
+      "build": "commit.22be8592",
+      "longVersion": "0.5.11+commit.22be8592",
+      "keccak256": "0x6f0de51d7773d7670b5db78e143fd55809cd4490759311e018ad82b9f10d58a3",
+      "sha256": "0x0e8ee89ddb1096b81c34e11bdb5985822e749d3a9dc4e7218ba2474afa6400cb",
+      "urls": [
+        "bzzr://83204b31d6fa5fafc94244922a04ff84a63d5089e61359aee3fcb76935d92f54",
+        "dweb:/ipfs/QmT4C8cecbPkS4vzkSYfA2KX1b4iqApEdQd4fswZr9K88u"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.12+commit.7709ece9",
+      "version": "0.5.12",
+      "build": "commit.7709ece9",
+      "longVersion": "0.5.12+commit.7709ece9",
+      "keccak256": "0x815157d38845c5127c3dd3ab399ef90c6139019f6bf2a807a08e612e74439d35",
+      "sha256": "0x3dfb97bc941492afaea7f404c3fb9c6fe215b3386aa6e0370791b571e4679548",
+      "urls": [
+        "bzzr://cdcd3c916db81ad1f05405220069ee136a17d0f51db613e627fc8a36897b5b03",
+        "dweb:/ipfs/QmQhhZKvjDQVwP6eaahfro5srD4jZ1JxQwgUUUowi6NkaL"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.13+commit.5b0b510c",
+      "version": "0.5.13",
+      "build": "commit.5b0b510c",
+      "longVersion": "0.5.13+commit.5b0b510c",
+      "keccak256": "0x472dab91d5bc4f7a4066a66869da74075dc587d48bd1cec55814b01f1126b9b9",
+      "sha256": "0x68a344d9de40b0d7482089ee7748e43088c52e3b108480d801b34c64020beb48",
+      "urls": [
+        "bzzr://9f15e79ade2f897c8a754887839c4aed352f37d3bbade568c269580c722563f6",
+        "dweb:/ipfs/QmXxM4YfZcq5np84wcCn762sm4XDxyjoMaKXtUaeunp6th"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.14+commit.01f1aaa4",
+      "version": "0.5.14",
+      "build": "commit.01f1aaa4",
+      "longVersion": "0.5.14+commit.01f1aaa4",
+      "keccak256": "0xcc9cddd6f0d0de2a39afaff31a063dc66eebe91b3c7bdd62e0152de4547bba07",
+      "sha256": "0x8afa926b6bb8ad492fb25078b1dce09fd05faa5765e4e2b2672b3c99cf71eeb1",
+      "urls": [
+        "bzzr://1bf2e4af9bebd83bf3dad7ff7bc6cfd1fa4571ea0627da66890cae3ae6f39c1d",
+        "dweb:/ipfs/QmQZsPrUCGcTnFiBgdvbAFhw5qoUp61Eer1Rxe71Eg7Db1"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.15+commit.6a57276f",
+      "version": "0.5.15",
+      "build": "commit.6a57276f",
+      "longVersion": "0.5.15+commit.6a57276f",
+      "keccak256": "0xf918ebb44bdc82a0129b4d0b2edeca7de44b5af66ded6765a784d23b2f344014",
+      "sha256": "0x9e05051c3d42a49c8470cbed1f2bfa89fe76e930a9e5558c52ce5653cf794e25",
+      "urls": [
+        "bzzr://ebb5a9f6594feb4096866be5f43fe1e780454d405efd07f891c411d1be7beb8a",
+        "dweb:/ipfs/QmY5eKeMgFVxGgyzbVsmeEUurZyfQVUZ9hVoACf46iyN8R"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.16+commit.9c3226ce",
+      "version": "0.5.16",
+      "build": "commit.9c3226ce",
+      "longVersion": "0.5.16+commit.9c3226ce",
+      "keccak256": "0xa8d1fa05cbf6d30c9d6cf4c0080d040c1518db7944ba943ec4a816f1b6f0b1bd",
+      "sha256": "0x9f6624e408497142bbd29efe0744ee25e445aeb7c932be401c0bc30478a6bb75",
+      "urls": [
+        "bzzr://407abc296f3a4fbf71fdc1f413c5f32cdd66a2b525081a21524a6ab5608e870b",
+        "dweb:/ipfs/QmRwNXSmQj5m522CJNC8d9DEMPQ2ut6kNmDZQr4oUdS4jw"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.5.17+commit.d19bba13",
+      "version": "0.5.17",
+      "build": "commit.d19bba13",
+      "longVersion": "0.5.17+commit.d19bba13",
+      "keccak256": "0x1142bf5e71342697a0786a0032838299c3e106afd5c54960c9b44b5f60ac0760",
+      "sha256": "0x35be28f68488b71f1de66148f915b91d64e062900e4fc175bf2eb8fb948810bd",
+      "urls": [
+        "bzzr://312c6aae351990e74291d8cdf9d732768c5bcc57fefae1a0aa3720d911a239d5",
+        "dweb:/ipfs/QmVXgA6QjWq8CTtvhysrru2QgjVdqx2Bd16iuADZ2eP9fC"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.0+commit.26b70077",
+      "version": "0.6.0",
+      "build": "commit.26b70077",
+      "longVersion": "0.6.0+commit.26b70077",
+      "keccak256": "0x7875c887df2e92df1163665db622d962e0336ccf9784549244f3595ed37e8570",
+      "sha256": "0x37beed8c8b947eba644cfd8c20446e1ba5d74055e6856b646dd6ad4bb470d9ae",
+      "urls": [
+        "bzzr://600161db2bf70cdd1b150e4e6dc5dd08b642092d75a96994290aa8c59134bba9",
+        "dweb:/ipfs/QmSuT85oAvJFVfWj6PBRHgSAC4iQQ5uPTJFDpxC84aGtq9"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.1+commit.e6f7d5a4",
+      "version": "0.6.1",
+      "build": "commit.e6f7d5a4",
+      "longVersion": "0.6.1+commit.e6f7d5a4",
+      "keccak256": "0xa60603c327514c2acedd1bc917e769b74739e711ee341cc08bdad6d065c3fa14",
+      "sha256": "0xf1649bfdb0e6e53be2758544836258cb4d02e0b381a9e43216aa2b2fad0c9b8e",
+      "urls": [
+        "bzzr://8932ec9fc8a9fe70346f4fdc2f92820cb620c596149ab63047b4e25c982a1953",
+        "dweb:/ipfs/QmTLGMSSAhzwhc7CEQphcZxdAEfUE5eVTFHeip6h8RCMEV"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.2+commit.bacdbe57",
+      "version": "0.6.2",
+      "build": "commit.bacdbe57",
+      "longVersion": "0.6.2+commit.bacdbe57",
+      "keccak256": "0x441fc0107c407d4bc18ab301c208cc8f3793f6d811627798283994d5cd74c985",
+      "sha256": "0x2bb19d8cd69a32854acce1245b4492cfc5b5e751d322d2c6556d4a521bfcc3c8",
+      "urls": [
+        "bzzr://d27138690388eafc0478a642bcfe12071f7478dac8ed4f270d53f064cb94f777",
+        "dweb:/ipfs/QmbuPyqt1XkE7UXP7WgKV7PTLCQJYQd3Ytg8yzsTVc3qFM"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.3+commit.8dda9521",
+      "version": "0.6.3",
+      "build": "commit.8dda9521",
+      "longVersion": "0.6.3+commit.8dda9521",
+      "keccak256": "0x48221990f9d74d82a093722f20706a2a43d79772552a6bef718752427259a792",
+      "sha256": "0xa09350d5a182b3da799c203d1dadc4ce0e6fe3b96dc9ee1c9d73e9a9d9592e2a",
+      "urls": [
+        "bzzr://c7ed1cfaf43061ae8e6760a949f4c1e43a2d961c9f4c867bed61eb3cd7390660",
+        "dweb:/ipfs/QmXv1gpDqj9iVZzRoYbVhwFo5j2ooptQAYz7vp9hnAB3bp"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.4+commit.1dca32f3",
+      "version": "0.6.4",
+      "build": "commit.1dca32f3",
+      "longVersion": "0.6.4+commit.1dca32f3",
+      "keccak256": "0xae0015245fb38b3b333339930ab635958ec00b4bb062ca1a5f346d6f51d88602",
+      "sha256": "0x082fd42cc96c28262459306f2854fe7049cc0d14473e126b2db6d30bf02f54d0",
+      "urls": [
+        "bzzr://e3aa6e6ccaade31d61c1c24df8cf03a5fd32a95a3c7fbf652ef2fdc8368d044b",
+        "dweb:/ipfs/QmeHkJw28pfTsVEpQXGJnaehKneXQUP2S6gwCDbmbmzAsn"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.5+commit.f956cc89",
+      "version": "0.6.5",
+      "build": "commit.f956cc89",
+      "longVersion": "0.6.5+commit.f956cc89",
+      "keccak256": "0x7c96df0411896e573a12852f40beb45c9c6d4006b0eb4e304665b83692064f1b",
+      "sha256": "0xa8129254b5247bbe003d6e54f35c0bba853694126744577289b6bdf1d35a1e4a",
+      "urls": [
+        "bzzr://743e1144947432ad10792fcd4213ee95cb6ce49ef0029bba0c1daa8313ae400f",
+        "dweb:/ipfs/QmRxqoK6QQPWcxqeYwN5GyE9SF71gcnW5UwRg9QPUjbmBg"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.6+commit.6c089d02",
+      "version": "0.6.6",
+      "build": "commit.6c089d02",
+      "longVersion": "0.6.6+commit.6c089d02",
+      "keccak256": "0xe7810e0e9d8bdb79087d4a8ae84ea88d33422a37906fad7114531675790fd0f8",
+      "sha256": "0x45c7f956197ce08b69f793ea610cf1ee65e12b6a518d6160cc28c8eeff41517c",
+      "urls": [
+        "bzzr://08164ef3f682e8963d150b40478c8321a1ea93f5db6e00f7b325896edea813ba",
+        "dweb:/ipfs/QmX2s1id8TC9Hdaemi6yWXMBaQbcT3pWdAU1gkda2PgNAM"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.7+commit.b8d736ae",
+      "version": "0.6.7",
+      "build": "commit.b8d736ae",
+      "longVersion": "0.6.7+commit.b8d736ae",
+      "keccak256": "0x0f348362eb3dbc20c7a6989a8d09adccb40e3f6ee731803d59992624fdf33992",
+      "sha256": "0xbb78b6de3df7db6115a1033346c3e9df8a6b9c4fd038cc12d6bdf16abd29c952",
+      "urls": [
+        "bzzr://3563864610d0b3402aed2f264298bf8efd5278337af9ddbf34800c58cf19fc11",
+        "dweb:/ipfs/QmWrPCuuXkGx6WxronttXLYDdoRyyvbxaJHuwJpd6wLZaJ"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.8+commit.0bbfe453",
+      "version": "0.6.8",
+      "build": "commit.0bbfe453",
+      "longVersion": "0.6.8+commit.0bbfe453",
+      "keccak256": "0x9bdbe9621aaa58357dc8695d5d13370fa9a89b3dd71a3f1702ae4ae50457b378",
+      "sha256": "0x801efaa3d0288637021667c0d116ee2b339e62cf26027f8c168259e0805e8b60",
+      "urls": [
+        "bzzr://8830f7671dd8b5e9def1397dd1b262a083598f38c931e8dc9e3aff855752acdc",
+        "dweb:/ipfs/QmcZSrp4jW4cYn8MskSs8VjHNGsTakgxiaHyFX4iqC9muG"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.9+commit.3e3065ac",
+      "version": "0.6.9",
+      "build": "commit.3e3065ac",
+      "longVersion": "0.6.9+commit.3e3065ac",
+      "keccak256": "0x6a34879f5ebf3e6405d18c1812aa540fe9903ad889cebc3dc0246d5a49cdf3cf",
+      "sha256": "0x98fbe10755638ad5ccc0683810b961a803450e94b642af112593248a685aa4dc",
+      "urls": [
+        "bzzr://4ffbd77aa5bdb73bec29e4d4e236a9dd907caff79296a3d94646760d8e5af78b",
+        "dweb:/ipfs/QmbjW4apLQwPd8ALgCNEBax1C4tgF5Eg7dHdLgqgjTkgnA"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.10+commit.00c0fcaf",
+      "version": "0.6.10",
+      "build": "commit.00c0fcaf",
+      "longVersion": "0.6.10+commit.00c0fcaf",
+      "keccak256": "0xc833a7ce648e47524699bfcff94bf0a5143f2f0ccca7b75703dc825fdd038c1d",
+      "sha256": "0x3773e66c3ef14e2e47bdd7d06f30f952c199856df240d164c91c1f00806fbbc7",
+      "urls": [
+        "bzzr://181a5c54edcc14ce2c5d5155c4efd56a204a49834409772ed85ad932857a9750",
+        "dweb:/ipfs/QmbQEy69AoRM3h5vCzxe4aDCAxKDPFYwGQSGVQNMpHHDKy"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.11+commit.5ef660b1",
+      "version": "0.6.11",
+      "build": "commit.5ef660b1",
+      "longVersion": "0.6.11+commit.5ef660b1",
+      "keccak256": "0xd289b8db3cd371f4a5df8e57b5382b361fcb8d5112536797ec2dd90dda1a079d",
+      "sha256": "0xa0a64aa092a616ae7145da908fc427fc3c296d3afdbfa8ea3468a22722d5d01c",
+      "urls": [
+        "bzzr://9fd78b77716ce520e78aca45af8709101d0a9eb07ed8ddc07a166f6964a9df60",
+        "dweb:/ipfs/QmVKPzEU56b2ercuGibmt1PNX6T38oiv1UTMZNmBUsexkc"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.6.12+commit.27d51765",
+      "version": "0.6.12",
+      "build": "commit.27d51765",
+      "longVersion": "0.6.12+commit.27d51765",
+      "keccak256": "0xd3ad11d172cf5b8ca7c7c0fb6b751611a85323becd788180af5b30fc8b4b4987",
+      "sha256": "0x05ad8afa83df3b51d36fe9a84ea4467b3ed17585c903946985d6e2cd5e95685a",
+      "urls": [
+        "bzzr://45e7aadac409633022704d4d4a63317c8d106edaeb67972bf160bcaac9746dcb",
+        "dweb:/ipfs/QmWK8t2TGf4UEKFGkk8aa9TYtFcWU9NYqjwsYyso4VJNLC"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.7.0+commit.9e61f92b",
+      "version": "0.7.0",
+      "build": "commit.9e61f92b",
+      "longVersion": "0.7.0+commit.9e61f92b",
+      "keccak256": "0x0f29a363cfc30a28d2f82e241b3c6feafd04c6aa57cfd3969b6c70d6d64997ba",
+      "sha256": "0x40555d6e826104cacd0c0b637c5fb573d5b6e2a6ac70110dc0333466c0115e1d",
+      "urls": [
+        "bzzr://720bd9c72285bf715fae1ca378bd1bb24432d662ce6e8ea3605735d0585d8e61",
+        "dweb:/ipfs/QmcpsbvXVFacMFTgAoKz5VXKdT1WFNFFEmsxGq9K4Ef6Sa"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.7.1+commit.f4a555be",
+      "version": "0.7.1",
+      "build": "commit.f4a555be",
+      "longVersion": "0.7.1+commit.f4a555be",
+      "keccak256": "0x5a29ea217cdacf04d8611706771ee041571207db75e554c88e38c975308fbfbe",
+      "sha256": "0x55b8072cc6ac154bf27f22177afe58be05f28c11ef51fc4e660313d3045a4268",
+      "urls": [
+        "bzzr://3f6fdb64f1fd58f16285737aa4c46f5cf955aff0accc36a93a0012c84e1ac153",
+        "dweb:/ipfs/Qmbsseaeu3GmMe4y3oqqonaVUkSYLqKB18gdrNiA6BdT2g"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.7.2+commit.51b20bc0",
+      "version": "0.7.2",
+      "build": "commit.51b20bc0",
+      "longVersion": "0.7.2+commit.51b20bc0",
+      "keccak256": "0x1fcec1bb8e66af87b944f82ccf8ff7690931f7872093f4b14647dce62174a3eb",
+      "sha256": "0x5518641f6c4a286054f5c9f29146970ef72f2f34ee76ed23f5eb1f6d1dcfecdb",
+      "urls": [
+        "bzzr://1c226f35bf118d903ccc943516761564497d8b0cfc79eba1206c924254af0240",
+        "dweb:/ipfs/QmcpwuWTL3ZgcSX1WUs4L3WVZtctRSzm8eHhGXosn7cz3L"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.7.3+commit.9bfce1f6",
+      "version": "0.7.3",
+      "build": "commit.9bfce1f6",
+      "longVersion": "0.7.3+commit.9bfce1f6",
+      "keccak256": "0x2bbcfb7135c6ae1a23be3ff24d00f423a5772b8c96afdeb29366243d9b9b586a",
+      "sha256": "0xf185104ed5e2a90b3ce8dfc7283c5d0ffbb738d7c8da19e8635dd9fda34c337a",
+      "urls": [
+        "bzzr://576d33181f5dc0c42bf0c1cdcd5fae565d0278b035c907fd5410b212ad9ffa05",
+        "dweb:/ipfs/QmNUC4SV1jEWHv2VDck4WYToHgZrZZ4BDLvXJnj9DM6G9p"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.7.4+commit.3f05b770",
+      "version": "0.7.4",
+      "build": "commit.3f05b770",
+      "longVersion": "0.7.4+commit.3f05b770",
+      "keccak256": "0xd6a9d389b2d303f226f9e5ecffcd33f610687b556cc254cf30589f72a6fb8b77",
+      "sha256": "0xcce002688cf10fb0243a042503f3e9896aa991ab59b08b57971d42d68e99f83d",
+      "urls": [
+        "bzzr://acba761d4123cfc40249bc922a66e9d190802bccf269431a5aaa80bf9f99803b",
+        "dweb:/ipfs/QmSZzdgjm8M7gz44MKMQpFUhDG9HBdTNHf7BLmLrkagos6"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.7.5+commit.eb77ed08",
+      "version": "0.7.5",
+      "build": "commit.eb77ed08",
+      "longVersion": "0.7.5+commit.eb77ed08",
+      "keccak256": "0xff52724ea7d3e0913219c765b40f311f72fe1e5c95389020a165a1959e57e24f",
+      "sha256": "0x1c100ce86a3167fd4c194290aafec0d3d94fe86c7a1aa0837c1346cc93d8b6ce",
+      "urls": [
+        "bzzr://e40c2432e6e49c8ccf67ea1684d1fbdfb43fbbb7ad44264ecb17ce73ef3a7c7d",
+        "dweb:/ipfs/Qmayevqr3TEHNqL2eAumCnFjgcMRp5Y1ckkwnfo9ewsCdF"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.7.6+commit.7338295f",
+      "version": "0.7.6",
+      "build": "commit.7338295f",
+      "longVersion": "0.7.6+commit.7338295f",
+      "keccak256": "0xcbc087311397f47993e7332637a999ac98a5661754ce33e4b265edcaaffdcd85",
+      "sha256": "0xa6a8f9f9388c5fcd9222474e00270242c832e936b0f5257c20374d27ee5bd1ab",
+      "urls": [
+        "bzzr://f908a6c0e311461118264568c0cff1a428fa2b401ca9b815b9c74b4e5995b347",
+        "dweb:/ipfs/QmcpVjAEjNMrQYWqZ96pHJp2v7CrM63S2VQJDiLTgWx4eg"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.0+commit.c7dfd78e",
+      "version": "0.8.0",
+      "build": "commit.c7dfd78e",
+      "longVersion": "0.8.0+commit.c7dfd78e",
+      "keccak256": "0x945af5c3c9d75a6ca7d48a4ee9df3201b0a34c273ba6b50aed6afb2a41dab845",
+      "sha256": "0xc7c3ff484d2dd69350fc182d44ecf6057ff2885b96a1c3990ca362e9c8325335",
+      "urls": [
+        "bzzr://d65c16cb03339d288f0bf103fd22e610532989be6f64529db52f794da0c15427",
+        "dweb:/ipfs/Qma8sQw9vxvSvEUTNsz7DxPvuo9Lx8nLpdAFgzQxVaHbSV"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.1+commit.df193b15",
+      "version": "0.8.1",
+      "build": "commit.df193b15",
+      "longVersion": "0.8.1+commit.df193b15",
+      "keccak256": "0x1f546c34241257015e73eb90b7b7ed099399c5ed84964f266e651f3a9de0f493",
+      "sha256": "0x38504e357632c15afed612c20ef878992ca8411ce3fb6afee37dec6ebd22ce02",
+      "urls": [
+        "bzzr://a6ac5a8d50ade8d5df91dd9c6bf623a9246b721b17b991514ccdbeaee50ddd68",
+        "dweb:/ipfs/QmShTho5JF2vrmnGwBWStrwTz89GNgiCfJKVoKKz1Dk1D7"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.2+commit.661d1103",
+      "version": "0.8.2",
+      "build": "commit.661d1103",
+      "longVersion": "0.8.2+commit.661d1103",
+      "keccak256": "0x3abbb7ac75c90ba7dc9d4aafe0f5c183c8d572d9c07303e892963774f8e6c53f",
+      "sha256": "0x0898c23b0ac8cdabcee3b646b676da1205f4be7c0bec8a58de81b060c59b4c1c",
+      "urls": [
+        "bzzr://8acc5ef01c96279bb7665995352fbc3a2e1519f44de68b05abc2343cf2e377df",
+        "dweb:/ipfs/QmYU4oyuNdJmNrPbNj6p3zWzhWzbdWHhSidHvSC3AqS3Jp"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.3+commit.8d00100c",
+      "version": "0.8.3",
+      "build": "commit.8d00100c",
+      "longVersion": "0.8.3+commit.8d00100c",
+      "keccak256": "0xef385c85cb7e3ab6faa28c7223c7f55b0d6a28e113420eb4d07aae5db1edb834",
+      "sha256": "0x1188f5c24d33ec1ec2ce811a7a45bdc3c167f1ba71cbc2664016564d2fdd46ba",
+      "urls": [
+        "bzzr://9e6b437fef68587b3c8ce3d930de77075ee6008611273ccfa2140f5c868e2ffb",
+        "dweb:/ipfs/QmSUdtQRWmGe7kHX3FaJNiYp8TaPmDJFQQqwdYDBgUKq9T"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.4+commit.c7e474f2",
+      "version": "0.8.4",
+      "build": "commit.c7e474f2",
+      "longVersion": "0.8.4+commit.c7e474f2",
+      "keccak256": "0xb8027ceccd3892550e0389af02716a658123eb4530bc02fc437d167c38501101",
+      "sha256": "0x4f6f2e6942a09051bbbc850d4fa9b0d907749612cb5db58cac0c87745435070f",
+      "urls": [
+        "bzzr://317c789ec9854aa6037a49f5f9b1598a95e6046a17b55d37b776bd0d3af93c96",
+        "dweb:/ipfs/QmQ27VGKwchmwWN2TmfYALfgU17D8MJxPxHSCt2jSuAWDE"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.5+commit.a4f2e591",
+      "version": "0.8.5",
+      "build": "commit.a4f2e591",
+      "longVersion": "0.8.5+commit.a4f2e591",
+      "keccak256": "0x728b089ccc3f1225ba7e7170fb88a75ae6b89c9d168f79493702f8b6bb725b7a",
+      "sha256": "0x3421ee67a26ef4a720e79531ffd9b96deec89defbcd70bb4a33e968b12ddb938",
+      "urls": [
+        "bzzr://e0e118ce0fdad202969c5ad18cffc482837c522ecdc86578a4fb208117e36cbd",
+        "dweb:/ipfs/QmRGVXZ3rGb5zfnHCJEJTAgrDemFkKrxrcVKRFF9HAcF17"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.6+commit.11564f7e",
+      "version": "0.8.6",
+      "build": "commit.11564f7e",
+      "longVersion": "0.8.6+commit.11564f7e",
+      "keccak256": "0x89e95cde55521904929e8dae6f0acf450db091d28a45dc824780a35c4c9b910d",
+      "sha256": "0x86ee99f64fc7e36bfa046169b6a4d4c10eb35017ed11e0c970f01223b2f5db36",
+      "urls": [
+        "bzzr://057db05ffb78d1d29087c7ae6f7cb9c34890b97d105fe791643cbf0ecf1626a6",
+        "dweb:/ipfs/QmQZsG2rzoXmkhHMGgXJxzbdi9TCvt4yuV1akuAcEE4QMT"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.7+commit.e28d00a7",
+      "version": "0.8.7",
+      "build": "commit.e28d00a7",
+      "longVersion": "0.8.7+commit.e28d00a7",
+      "keccak256": "0xbcc6fd8ff1d27e4b1a1d277e2d36b3e135981472038401a0e0eee275d0b28846",
+      "sha256": "0xcc5c663d1fe17d4eb4aca09253787ac86b8785235fca71d9200569e662677990",
+      "urls": [
+        "bzzr://2ec2ee1c310b0f62231a74f0b18de7d669ae204288c895343153ca95a7913800",
+        "dweb:/ipfs/QmWCTWH2NP3pSjcEPoYQ2ss6YPW98R2WmqX2mfQbLepvr4"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.8+commit.dddeac2f",
+      "version": "0.8.8",
+      "build": "commit.dddeac2f",
+      "longVersion": "0.8.8+commit.dddeac2f",
+      "keccak256": "0xa7dfe9ed26a2d2e9f1e7b1581838bd35d49ccbec36228ce232dabd3a2ddedd3f",
+      "sha256": "0x1422e10454251d56fef62940fb2e209a6f467ae35f73bdce580bc0bad35851dd",
+      "urls": [
+        "bzzr://9464141458eab56775a5be4186cc6a73440f609b26c3fa14c7b0a424ce128926",
+        "dweb:/ipfs/Qmd32FsxALkBcWgRCD6zvFmZ3PvZN2jLtYVWBVpnVj5PFd"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.9+commit.e5eed63a",
+      "version": "0.8.9",
+      "build": "commit.e5eed63a",
+      "longVersion": "0.8.9+commit.e5eed63a",
+      "keccak256": "0x0dec1d0015c882a98259d9ed1c7a157c77cb4fb05dfe0e2b74484957501dce7c",
+      "sha256": "0xd619d4f5d8fd988bc63262407e749e905ccc8d8ab1ccf0280da1d12b918894ce",
+      "urls": [
+        "bzzr://b7ed2e4abec3c6e075fdd6369e3705accea9a7677be58a6ff05e94765e00d57a",
+        "dweb:/ipfs/Qmax1ZEAvgqfyNmXBSTrmerSYWgsbCfiUMGqnQYQGUNEUA"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.10+commit.fc410830",
+      "version": "0.8.10",
+      "build": "commit.fc410830",
+      "longVersion": "0.8.10+commit.fc410830",
+      "keccak256": "0x6fab4e609b69b16f2ab6d3c9fc9262e52cb76ab93619325eaec590a5efe3178b",
+      "sha256": "0xa79fff23aeb35be856e446827c44a9cfa4c382f29babd2f6a405ef73d1e2a4cc",
+      "urls": [
+        "bzzr://4473d82fb0d080fafc4b1e4305dfaa042d081a1b9993024ba337cacdfdc29d3a",
+        "dweb:/ipfs/QmZPQAFTJSBAg3GjSW7JS8h2yk9nBcAjCjYYEygz5GxNMt"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.11+commit.d7f03943",
+      "version": "0.8.11",
+      "build": "commit.d7f03943",
+      "longVersion": "0.8.11+commit.d7f03943",
+      "keccak256": "0x7f7e17b585fcd8b3c5025210e478a330281a4bdbb6054569d81dc21d32394b61",
+      "sha256": "0x10cdcc8d8ea4dde9fd8b953b95885dc737f24b8a31fea65f4715ffd007b80281",
+      "urls": [
+        "bzzr://c21c33c4d4907b1712003b3428b6af25fc1089493bc2aec06d04a41210f698ec",
+        "dweb:/ipfs/QmRkNwKe9t8KNVMViMGEVJotaZCiY8i1qJ4v5EV4UBRnaG"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.12+commit.f00d7308",
+      "version": "0.8.12",
+      "build": "commit.f00d7308",
+      "longVersion": "0.8.12+commit.f00d7308",
+      "keccak256": "0x3285e72f53b0ce49958234d29e3c58aa2ac12e38c21ef59cb9940edd245ce76d",
+      "sha256": "0x95738a27909a13502385e9fe8f8f3d8a873d2faf5d06ff617bc2fe3edb8c4bf9",
+      "urls": [
+        "bzzr://1b149c02263e66a260c11be38c7b19ed946f1e6a59c77f15c4d8148d1d69887e",
+        "dweb:/ipfs/QmSi3sQoQhUmQCxD6xaMtq3nYnWE8ydqYjqhe7kvRAfCUC"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.13+commit.abaa5c0e",
+      "version": "0.8.13",
+      "build": "commit.abaa5c0e",
+      "longVersion": "0.8.13+commit.abaa5c0e",
+      "keccak256": "0x9f05bd40e25ff5ab7c6e657558ba71d472b30bff3359de15122271c4065b9c24",
+      "sha256": "0x14d4ef013ea82ad95e91fd949b7fa7b78271a483ff1a79c43d6cc58b826f5bea",
+      "urls": [
+        "bzzr://dfa7ef356ac5736c1f5cb2defc500390898881afa1b67913a832be445f026945",
+        "dweb:/ipfs/QmXaKT1hqJCNuJX5uryXJzbHHUsH48GoGBhoYPoLCVrZUg"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.14+commit.80d49f37",
+      "version": "0.8.14",
+      "build": "commit.80d49f37",
+      "longVersion": "0.8.14+commit.80d49f37",
+      "keccak256": "0x93d71d0692befba81239f7a0b7443ca117ff7fe9ae190ed32550db678d086aae",
+      "sha256": "0xb3d19ab47657af37be4c551f83494248e99d7ba103b6072e8c08dbb62708e2b0",
+      "urls": [
+        "bzzr://f46b7d64c5327360d840752b6acf354040ea61d43eac1d14e0f373f96e2b5d8c",
+        "dweb:/ipfs/QmcK4egnnjdrkLsM8R5QeSBoYs59M1CxvRi331zaxoSEq4"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.15+commit.e14f2714",
+      "version": "0.8.15",
+      "build": "commit.e14f2714",
+      "longVersion": "0.8.15+commit.e14f2714",
+      "keccak256": "0xcd862fb2d2e2f83738c2d08632cea128bee9278a4840053262b0e2495f9216ce",
+      "sha256": "0x00656dc73224e4c0702940df10310bdc024b60f4a7598e774d305bc3b94f7d79",
+      "urls": [
+        "bzzr://8a277ebe4f557a46c93f6e1a4ecffac34f7e0a60afe8a20508e42ae646571c20",
+        "dweb:/ipfs/QmSJmnXuyPy4TtxnUSwD6f2vF5MSzcvN4cohtZfeJc8H6p"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.16+commit.07a7930e",
+      "version": "0.8.16",
+      "build": "commit.07a7930e",
+      "longVersion": "0.8.16+commit.07a7930e",
+      "keccak256": "0xf3dd3636e7bca007430e091bcacc2dd9b9af72edb838a0e0d77de9610169f7c3",
+      "sha256": "0x7d471cb9bae9a7f29c7ebf402f7e16fa8226b17ba9ab68a88ce107114479dc4d",
+      "urls": [
+        "bzzr://53af1a8c08f9025b93c23759efa15c9eadaa3b20a8a590424c12d4a89a0b7503",
+        "dweb:/ipfs/QmZCFxnqy312mEc99qxXLRs6UE57pgFM5XPMVmw6G1WXfS"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.17+commit.8df45f5f",
+      "version": "0.8.17",
+      "build": "commit.8df45f5f",
+      "longVersion": "0.8.17+commit.8df45f5f",
+      "keccak256": "0xf1d882dae250037523afce650a3e6d2069810d7f7e18a5f861094587fd946b6c",
+      "sha256": "0xe40eef83c24d4c42b47f461b01748a6ca89f1e09e778995b71debfa0de99e12a",
+      "urls": [
+        "bzzr://1ff61f15fbeef7eb86e4a5df8046880cb31a07e354bc3d6339aa072e0eeb8e1d",
+        "dweb:/ipfs/QmPLRuidw4wXZhaWbd24VYWthZrUftJwaXQKWHPPj9Gktz"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.18+commit.87f61d96",
+      "version": "0.8.18",
+      "build": "commit.87f61d96",
+      "longVersion": "0.8.18+commit.87f61d96",
+      "keccak256": "0x30e1130aa13ced52eb874d224dba7683ed4caf32291c4081f6b83230b341190d",
+      "sha256": "0x8f15287c799ad2b33f241d1252226abda5d4bc3ef6be40b946923178fc57d397",
+      "urls": [
+        "bzzr://892792c1a2975f25ec0f96083559933412c25e0c1100eb85c33b61d1b9a385e8",
+        "dweb:/ipfs/QmTepA9fra5vjbooDmxjcmM8pYXj5Xz1KFt5d73N8S84NA"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.19+commit.7dd6d404",
+      "version": "0.8.19",
+      "build": "commit.7dd6d404",
+      "longVersion": "0.8.19+commit.7dd6d404",
+      "keccak256": "0x6247a3e93a840acdfda0b111b27bd48e22ed2515bf67d0310864979fd4440155",
+      "sha256": "0x38c8523ab67e0b3e21c48189d6bfb99ad6879b9ce02e0d802ec8be598bb2622d",
+      "urls": [
+        "bzzr://f0fb303e649106358f518d1cb3c49b8c3f488a86f7e345a0d9f2029c2e3d7154",
+        "dweb:/ipfs/QmdXcpr6U4kr7KmuYfduz7DRbvbyWViLoyoAEh5USqUKVu"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.20+commit.a1b79de6",
+      "version": "0.8.20",
+      "build": "commit.a1b79de6",
+      "longVersion": "0.8.20+commit.a1b79de6",
+      "keccak256": "0x6968bdf9827c7aa35eccae41063e812250828bee530d23b59f0034f6c62eeb02",
+      "sha256": "0xfc329945e0068e4e955d0a7b583776dc8d25e72ab657a044618a7ce7dd0519aa",
+      "urls": [
+        "bzzr://c44d37faf405274cae14f988e4b0b5ebe66abbc2ea0828ff433d168e8e339bf5",
+        "dweb:/ipfs/QmVgJUFru26w9nsKzEZ8WSrcc4JbtcTkbhuNq7Vb1juDqc"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.21+commit.d9974bed",
+      "version": "0.8.21",
+      "build": "commit.d9974bed",
+      "longVersion": "0.8.21+commit.d9974bed",
+      "keccak256": "0xdd0ddc6d53bbecac4ed0f0b78c4d9990841d250e0e4eda116e84c9d0e1c2f4a2",
+      "sha256": "0x19d065749fb08cbff4f7b45284ac55853063865f6ae8621e4defa5d938b9a502",
+      "urls": [
+        "bzzr://c701d26aee88e21ba5803b02561a031ca6f61abb6fe08fbb2b78c784789fe712",
+        "dweb:/ipfs/QmX6LQNJ23wCfv3TCkbLS4nmazPAYgWTKred7CDTGLi8tX"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.22+commit.4fc1097e",
+      "version": "0.8.22",
+      "build": "commit.4fc1097e",
+      "longVersion": "0.8.22+commit.4fc1097e",
+      "keccak256": "0x791bb778cf604f6dfd073e6b11673384aba23beab55accd3f29bb310b5c4d128",
+      "sha256": "0xc8d3b7803c0eb2c3bdd34b2c3b9706e9d8c81b8829250e49245dacb984a62e05",
+      "urls": [
+        "bzzr://a07c2d2704a44b2300cd130fcd2c834bed6edb203ee63f0529f78130c437b872",
+        "dweb:/ipfs/Qme1Cmme2nGyy3V4KBcY2amBdZdykqiryYp5KjXcos4xZy"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.23+commit.f704f362",
+      "version": "0.8.23",
+      "build": "commit.f704f362",
+      "longVersion": "0.8.23+commit.f704f362",
+      "keccak256": "0x8380e8a6f66e4b2547250b9cbee170a62e1e899df12f7c0c3effbc5df3c06137",
+      "sha256": "0xe09a42980e44644be33a8455c87d095a4f0028e41a7dde1137f5d9a7605a2d62",
+      "urls": [
+        "bzzr://00319ed318e2cd094791d858f56cd7031f60023b00cdd2f9bd2f0d96e5ad918d",
+        "dweb:/ipfs/QmXuBDhncvou72S86KxNxeTcVH1pGhU6DCZYzbcVrbfY1p"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.24+commit.e11b9ed9",
+      "version": "0.8.24",
+      "build": "commit.e11b9ed9",
+      "longVersion": "0.8.24+commit.e11b9ed9",
+      "keccak256": "0xf8c5313dfe054e7f3c208905ee6bb4097a1c7a1dd360050f90fab4b182ac1c24",
+      "sha256": "0xcc2d44c706905ccc382f484625dff61d741e0c24232d226f139a6835fc644f3f",
+      "urls": [
+        "bzzr://fab9be6f2b588ade1d1805e2bc52896f9a51d283fa513daf8a70b3e6050524cc",
+        "dweb:/ipfs/QmfNsBiCB9QDHh9fX8QRAJfFKubX2ahutAXnoWx4BfXosT"
+      ]
+    }
+  ],
+  "releases": {
+    "0.8.24": "solc-macosx-amd64-v0.8.24+commit.e11b9ed9",
+    "0.8.23": "solc-macosx-amd64-v0.8.23+commit.f704f362",
+    "0.8.22": "solc-macosx-amd64-v0.8.22+commit.4fc1097e",
+    "0.8.21": "solc-macosx-amd64-v0.8.21+commit.d9974bed",
+    "0.8.20": "solc-macosx-amd64-v0.8.20+commit.a1b79de6",
+    "0.8.19": "solc-macosx-amd64-v0.8.19+commit.7dd6d404",
+    "0.8.18": "solc-macosx-amd64-v0.8.18+commit.87f61d96",
+    "0.8.17": "solc-macosx-amd64-v0.8.17+commit.8df45f5f",
+    "0.8.16": "solc-macosx-amd64-v0.8.16+commit.07a7930e",
+    "0.8.15": "solc-macosx-amd64-v0.8.15+commit.e14f2714",
+    "0.8.14": "solc-macosx-amd64-v0.8.14+commit.80d49f37",
+    "0.8.13": "solc-macosx-amd64-v0.8.13+commit.abaa5c0e",
+    "0.8.12": "solc-macosx-amd64-v0.8.12+commit.f00d7308",
+    "0.8.11": "solc-macosx-amd64-v0.8.11+commit.d7f03943",
+    "0.8.10": "solc-macosx-amd64-v0.8.10+commit.fc410830",
+    "0.8.9": "solc-macosx-amd64-v0.8.9+commit.e5eed63a",
+    "0.8.8": "solc-macosx-amd64-v0.8.8+commit.dddeac2f",
+    "0.8.7": "solc-macosx-amd64-v0.8.7+commit.e28d00a7",
+    "0.8.6": "solc-macosx-amd64-v0.8.6+commit.11564f7e",
+    "0.8.5": "solc-macosx-amd64-v0.8.5+commit.a4f2e591",
+    "0.8.4": "solc-macosx-amd64-v0.8.4+commit.c7e474f2",
+    "0.8.3": "solc-macosx-amd64-v0.8.3+commit.8d00100c",
+    "0.8.2": "solc-macosx-amd64-v0.8.2+commit.661d1103",
+    "0.8.1": "solc-macosx-amd64-v0.8.1+commit.df193b15",
+    "0.8.0": "solc-macosx-amd64-v0.8.0+commit.c7dfd78e",
+    "0.7.6": "solc-macosx-amd64-v0.7.6+commit.7338295f",
+    "0.7.5": "solc-macosx-amd64-v0.7.5+commit.eb77ed08",
+    "0.7.4": "solc-macosx-amd64-v0.7.4+commit.3f05b770",
+    "0.7.3": "solc-macosx-amd64-v0.7.3+commit.9bfce1f6",
+    "0.7.2": "solc-macosx-amd64-v0.7.2+commit.51b20bc0",
+    "0.7.1": "solc-macosx-amd64-v0.7.1+commit.f4a555be",
+    "0.7.0": "solc-macosx-amd64-v0.7.0+commit.9e61f92b",
+    "0.6.12": "solc-macosx-amd64-v0.6.12+commit.27d51765",
+    "0.6.11": "solc-macosx-amd64-v0.6.11+commit.5ef660b1",
+    "0.6.10": "solc-macosx-amd64-v0.6.10+commit.00c0fcaf",
+    "0.6.9": "solc-macosx-amd64-v0.6.9+commit.3e3065ac",
+    "0.6.8": "solc-macosx-amd64-v0.6.8+commit.0bbfe453",
+    "0.6.7": "solc-macosx-amd64-v0.6.7+commit.b8d736ae",
+    "0.6.6": "solc-macosx-amd64-v0.6.6+commit.6c089d02",
+    "0.6.5": "solc-macosx-amd64-v0.6.5+commit.f956cc89",
+    "0.6.4": "solc-macosx-amd64-v0.6.4+commit.1dca32f3",
+    "0.6.3": "solc-macosx-amd64-v0.6.3+commit.8dda9521",
+    "0.6.2": "solc-macosx-amd64-v0.6.2+commit.bacdbe57",
+    "0.6.1": "solc-macosx-amd64-v0.6.1+commit.e6f7d5a4",
+    "0.6.0": "solc-macosx-amd64-v0.6.0+commit.26b70077",
+    "0.5.17": "solc-macosx-amd64-v0.5.17+commit.d19bba13",
+    "0.5.16": "solc-macosx-amd64-v0.5.16+commit.9c3226ce",
+    "0.5.15": "solc-macosx-amd64-v0.5.15+commit.6a57276f",
+    "0.5.14": "solc-macosx-amd64-v0.5.14+commit.01f1aaa4",
+    "0.5.13": "solc-macosx-amd64-v0.5.13+commit.5b0b510c",
+    "0.5.12": "solc-macosx-amd64-v0.5.12+commit.7709ece9",
+    "0.5.11": "solc-macosx-amd64-v0.5.11+commit.22be8592",
+    "0.5.10": "solc-macosx-amd64-v0.5.10+commit.5a6ea5b1",
+    "0.5.9": "solc-macosx-amd64-v0.5.9+commit.c68bc34e",
+    "0.5.8": "solc-macosx-amd64-v0.5.8+commit.23d335f2",
+    "0.5.7": "solc-macosx-amd64-v0.5.7+commit.6da8b019",
+    "0.5.6": "solc-macosx-amd64-v0.5.6+commit.b259423e",
+    "0.5.5": "solc-macosx-amd64-v0.5.5+commit.47a71e8f",
+    "0.5.4": "solc-macosx-amd64-v0.5.4+commit.9549d8ff",
+    "0.5.3": "solc-macosx-amd64-v0.5.3+commit.10d17f24",
+    "0.5.2": "solc-macosx-amd64-v0.5.2+commit.1df8f40c",
+    "0.5.1": "solc-macosx-amd64-v0.5.1+commit.c8a2cb62",
+    "0.5.0": "solc-macosx-amd64-v0.5.0+commit.1d4f565a",
+    "0.4.26": "solc-macosx-amd64-v0.4.26+commit.4563c3fc",
+    "0.4.25": "solc-macosx-amd64-v0.4.25+commit.59dbf8f1",
+    "0.4.24": "solc-macosx-amd64-v0.4.24+commit.e67f0147",
+    "0.4.23": "solc-macosx-amd64-v0.4.23+commit.124ca40d",
+    "0.4.22": "solc-macosx-amd64-v0.4.22+commit.4cb486ee",
+    "0.4.21": "solc-macosx-amd64-v0.4.21+commit.dfe3193c",
+    "0.4.20": "solc-macosx-amd64-v0.4.20+commit.3155dd80",
+    "0.4.19": "solc-macosx-amd64-v0.4.19+commit.c4cbbb05",
+    "0.4.18": "solc-macosx-amd64-v0.4.18+commit.9cf6e910",
+    "0.4.17": "solc-macosx-amd64-v0.4.17+commit.bdeb9e52",
+    "0.4.16": "solc-macosx-amd64-v0.4.16+commit.d7661dd9",
+    "0.4.15": "solc-macosx-amd64-v0.4.15+commit.8b45bddb",
+    "0.4.14": "solc-macosx-amd64-v0.4.14+commit.c2215d46",
+    "0.4.13": "solc-macosx-amd64-v0.4.13+commit.0fb4cb1a",
+    "0.4.12": "solc-macosx-amd64-v0.4.12+commit.194ff033",
+    "0.4.11": "solc-macosx-amd64-v0.4.11+commit.68ef5810",
+    "0.4.10": "solc-macosx-amd64-v0.4.10+commit.f0d539ae",
+    "0.4.9": "solc-macosx-amd64-v0.4.9+commit.364da425",
+    "0.4.8": "solc-macosx-amd64-v0.4.8+commit.60cc1668",
+    "0.4.7": "solc-macosx-amd64-v0.4.7+commit.822622cf",
+    "0.4.6": "solc-macosx-amd64-v0.4.6+commit.2dabbdf0",
+    "0.4.5": "solc-macosx-amd64-v0.4.5+commit.b318366e",
+    "0.4.4": "solc-macosx-amd64-v0.4.4+commit.4633f3de",
+    "0.4.3": "solc-macosx-amd64-v0.4.3+commit.2353da71",
+    "0.4.2": "solc-macosx-amd64-v0.4.2+commit.af6afb04",
+    "0.4.1": "solc-macosx-amd64-v0.4.1+commit.4fc6fc2c",
+    "0.4.0": "solc-macosx-amd64-v0.4.0+commit.acd334c9",
+    "0.3.6": "solc-macosx-amd64-v0.3.6+commit.988fe5e5"
+  },
+  "latestRelease": "0.8.24"
+}

--- a/packages/dev/foundry/update-svm-lists.sh
+++ b/packages/dev/foundry/update-svm-lists.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Get the directory of the current script
+script_dir=$(dirname "$(realpath "$0")")
+
+# Directory where the files will be downloaded
+dir="${script_dir}/svm-lists"
+
+# URLs of the files
+urls=(
+    "https://binaries.soliditylang.org/macosx-amd64/list.json"
+    "https://binaries.soliditylang.org/linux-amd64/list.json"
+)
+
+# Create the directory (no error if it already exists)
+mkdir -p "$dir"
+
+# Function to extract filename from URL
+extract_filename() {
+    url=$1
+    # Extract the parent directory name and append .json
+    echo "$(basename "$(dirname "$url")").json"
+}
+
+# Function to fix line endings and remove trailing newline
+ensure_unix_format() {
+    file=$1
+    # Convert to Unix LF line endings and ensure there's no trailing newline
+    tr -d '\r' < "$file" | sed -e '$a\' > "${file}.tmp" && mv "${file}.tmp" "$file"
+}
+
+# Iterate over the URLs
+for url in "${urls[@]}"; do
+    # Extract filename from URL
+    filename=$(extract_filename "$url")
+
+    # Download the file and fix line endings
+    echo "Fetching $url to $dir/$filename"
+    curl -sL "$url" -o "${dir}/${filename}"
+    ensure_unix_format "${dir}/${filename}"
+done


### PR DESCRIPTION
This introduces a new built-from-source `foundry` package and renames the old binary package from the `foundry.nix` repo to `foundry-bin` following the `nixpkgs` convention.

### svm-rs

One quirk of `foundry` builds is the `svm-rs` crate dependency, which by default fetches a list of all available `solc` binaries for each platform`build.rs`. As there is no hash or versioning of the file itself, the file can change between fetches (e.g. when new solc versions are added).

Fortunately svm-rs exposes a `SVM_RELEASES_LIST_JSON` env var which allows for pointing to a local file path instead making support for Nix feasible without having the package break each time a new `solc` version is released. A script called `update-svm-lists.sh` is included that allows for downloading the latest lists for linux and darwin.

also cc @shazow you might be interested!