### PR TITLE
chore: add foundry, lighthouse, wake and reth to blacklist for updating

### DIFF
--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           # TODO: remove nethermind after we fix build for them
           # TODO: remove mev-boost after they make a new release tag
-          blacklist: "staking-deposit-cli,dreamboat,bls,blst,evmc,mcl,besu,teku,docs,foundry-bin,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,mev-boost,nethermind"
+          blacklist: "staking-deposit-cli,dreamboat,bls,blst,evmc,mcl,besu,teku,lighthouse,reth,wake,docs,foundry-bin,foundry,web3signer,mev-boost-prysm,vscode-plugin-consensys-vscode-solidity-visual-editor,vscode-plugin-ackee-blockchain-solidity-tools,mev-boost,nethermind"
           sign-commits: true
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
add foundry, lighthouse, wake and reth to blacklist for updating. After this change update script is working: https://github.com/nix-community/ethereum.nix/pull/466

P.S.: I'm thinking about rewriting the update script to work like in nixpkgs, where the update script runs `passthru.updateScript` instead of a hardcoded updater. I tried to use nixpkgs `update.nix` (got the idea from [here](https://discourse.nixos.org/t/how-can-i-run-the-updatescript-of-personal-packages/25274/3)) but I'm still struggling to make it work