### PR TITLE
blutgang: init at 0.3.0-canary2

### DIFF
--- a/pkgs/blutgang/default.nix
+++ b/pkgs/blutgang/default.nix
@@ -1,16 +1,16 @@
 {
-  buildRustPackage,
   fetchFromGitHub,
   openssl,
   pkg-config,
+  rustPlatform,
 }:
-buildRustPackage rec {
-  name = "blutgang";
+rustPlatform.buildRustPackage rec {
+  pname = "blutgang";
   version = "0.3.0-canary2";
 
   src = fetchFromGitHub {
     owner = "rainshowerLabs";
-    repo = name;
+    repo = pname;
     rev = version;
     hash = "sha256-xjDieJgN7BzyCzeKMd3X7dwl/hOnqFPGCtZzlAbVGdI=";
   };
@@ -23,7 +23,7 @@ buildRustPackage rec {
     openssl
   ];
 
-  cargoHash = "sha256-/MnydP0inqGHmYOiSrq90pp1nHkXtzPbzJmzbprP864=";
+  cargoHash = "sha256-pSdNGmwBCejQbjtfi7YhQmfpoMs9Gxf+6qusD8YSiFc=";
 
   meta = {
     description = "the wd40 of ethereum load balancers";

--- a/pkgs/blutgang/default.nix
+++ b/pkgs/blutgang/default.nix
@@ -1,0 +1,34 @@
+{
+  buildRustPackage,
+  fetchFromGitHub,
+  openssl,
+  pkg-config,
+}:
+buildRustPackage rec {
+  name = "blutgang";
+  version = "0.3.0-canary2";
+
+  src = fetchFromGitHub {
+    owner = "rainshowerLabs";
+    repo = name;
+    rev = version;
+    hash = "sha256-xjDieJgN7BzyCzeKMd3X7dwl/hOnqFPGCtZzlAbVGdI=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  cargoHash = "sha256-/MnydP0inqGHmYOiSrq90pp1nHkXtzPbzJmzbprP864=";
+
+  meta = {
+    description = "the wd40 of ethereum load balancers";
+    homepage = "https://github.com/rainshowerLabs/blutgang";
+    mainProgram = "blutgang";
+    platforms = ["x86_64-linux"];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -26,6 +26,7 @@
       besu = callPackage ./besu {};
       bls = callPackage ./bls {};
       blst = callPackage ./blst {};
+      blutgang = callPackage ./blutgang {};
       charon = callPackage ./charon {inherit bls mcl;};
       dirk = callPackage ./dirk {inherit bls mcl;};
       dreamboat = callPackage ./dreamboat {inherit blst;};
@@ -73,6 +74,7 @@
 
     apps = platformApps self'.packages {
       besu.bin = "besu";
+      blutgang.bin = "blutgang";
       charon.bin = "charon";
       dirk.bin = "dirk";
       dreamboat.bin = "dreamboat";


### PR DESCRIPTION
Consider adding blutgang, a load balancer for Ethereum RPC calls into the repository.

The canary pre-release supports WS RPC in addition to HTTP RPC, for which the initial proposition is to add this pre-release package.