### PR TITLE
add vouch-unstable

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -64,6 +64,7 @@
       teku = callPackage ./teku {};
       tx-fuzz = callPackage ./tx-fuzz {};
       vouch = callPackage ./vouch {inherit bls mcl;};
+      vouch-unstable = callPackage ./vouch/unstable.nix {inherit bls mcl;};
       vscode-plugin-ackee-blockchain-solidity-tools = callPackage ./ackee-blockchain.solidity-tools {};
       vscode-plugin-consensys-vscode-solidity-visual-editor = callPackage ./consensys.vscode-solidity-auditor {};
       wake = callPackage ./wake {inherit poetry2nix;};

--- a/pkgs/vouch/unstable.nix
+++ b/pkgs/vouch/unstable.nix
@@ -1,0 +1,31 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  mcl,
+  bls,
+}:
+buildGoModule rec {
+  pname = "vouch";
+  version = "1.8.0-beta.3";
+
+  src = fetchFromGitHub {
+    owner = "attestantio";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-CK6cLXJYMQL+ZRv8bYabgQ0GeDWK8Jcek6d/Wow2LI0=";
+  };
+
+  runVend = true;
+  vendorHash = "sha256-Mp+RA2L4mOe089ceyKh3m5Q8zLsdwyx6geMFrqbn5Dk=";
+
+  buildInputs = [mcl bls];
+
+  doCheck = false;
+
+  meta = {
+    description = "An Ethereum 2 multi-node validator client";
+    homepage = "https://github.com/attestantio/vouch";
+    mainProgram = "vouch";
+    platforms = ["x86_64-linux"];
+  };
+}


### PR DESCRIPTION
This is needed mostly during hard forks where unstable software is
needed to test things on test networks like Holesky.
