### PR TITLE
blutgang: 0.3.0-canary2 -> 0.3.1

### DIFF
--- a/pkgs/blutgang/default.nix
+++ b/pkgs/blutgang/default.nix
@@ -6,13 +6,13 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "blutgang";
-  version = "0.3.0-canary2";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "rainshowerLabs";
     repo = pname;
-    rev = version;
-    hash = "sha256-xjDieJgN7BzyCzeKMd3X7dwl/hOnqFPGCtZzlAbVGdI=";
+    rev = "Blutgang-${version}";
+    hash = "sha256-prJq1enn2bJdJieVjvq1vd7dCNBlg5ppymIwjU4pgzg=";
   };
 
   nativeBuildInputs = [
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  cargoHash = "sha256-pSdNGmwBCejQbjtfi7YhQmfpoMs9Gxf+6qusD8YSiFc=";
+  cargoHash = "sha256-bAHUcfRtefGsRgFMBY5JJ4QSstB8wApcdqz/pqSVpuk=";
 
   meta = {
     description = "the wd40 of ethereum load balancers";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -26,7 +26,7 @@
       besu = callPackage ./besu {};
       bls = callPackage ./bls {};
       blst = callPackage ./blst {};
-      blutgang = callPackage ./blutgang {};
+      blutgang = callPackage ./blutgang {inherit (pkgsUnstable) rustPlatform;};
       charon = callPackage ./charon {inherit bls mcl;};
       dirk = callPackage ./dirk {inherit bls mcl;};
       dreamboat = callPackage ./dreamboat {inherit blst;};


### PR DESCRIPTION
Includes fixes up to this comment on this tracking ticket: https://github.com/rainshowerLabs/blutgang/issues/57#issuecomment-1961721149

A more recent Rust version is also needed for the project to now compile.