### PR TITLE
nimbus: 24.2.1 -> 24.2.2

### DIFF
--- a/pkgs/nimbus/default.nix
+++ b/pkgs/nimbus/default.nix
@@ -19,13 +19,13 @@
 in
   stdenv.mkDerivation rec {
     pname = "nimbus-eth2";
-    version = "24.2.1";
+    version = "24.2.2";
 
     src = fetchFromGitHub {
       owner = "status-im";
       repo = pname;
       rev = "v${version}";
-      hash = "sha256-0dfiIB9EVrc8JDL+o/NE5C0zKEKQ9bCYX9WAe+vkfAk=";
+      hash = "sha256-6BLek0y6ke0/bh1s24x6JUyUFMEsFJk75x/rGW8CeHY=";
       fetchSubmodules = true;
     };
 


### PR DESCRIPTION
Builds with `nix build '.#nimbus'`. From the release announcement: "This is a hotfix release addressing a consensus violation issue affecting Deneb-transitioned network such as Holešky. Please upgrade as soon as possible if your node is affected."
