### PR TITLE
mev-boost: 1.6.0 -> 1.7

### DIFF
--- a/pkgs/mev-boost/default.nix
+++ b/pkgs/mev-boost/default.nix
@@ -5,16 +5,16 @@
 }:
 buildGoModule rec {
   pname = "mev-boost";
-  version = "1.6.0";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "flashbots";
     repo = "${pname}";
     rev = "v${version}";
-    hash = "sha256-vzgX9irpI5i85bohppyL5KWQuf71SryRu1gkhWSCVKk=";
+    hash = "sha256-4Vxs1Jo7rkw9l0pXfi+J7YmzQawt7tc19I1MdHQgjBA=";
   };
 
-  vendorHash = "sha256-xw3xVbgKUIDXu4UQD5CGftON8E4o1u2FcrPo3n6APBE=";
+  vendorHash = "sha256-yfWDGVfgCfsmzI5oxEmhHXKCUAHe6wWTkaMkBN5kQMw=";
 
   buildInputs = [blst];
 

--- a/pkgs/mev-boost/default.nix
+++ b/pkgs/mev-boost/default.nix
@@ -5,13 +5,13 @@
 }:
 buildGoModule rec {
   pname = "mev-boost";
-  version = "1.7.1";
+  version = "1.7";
 
   src = fetchFromGitHub {
     owner = "flashbots";
     repo = "${pname}";
     rev = "v${version}";
-    hash = "sha256-4Vxs1Jo7rkw9l0pXfi+J7YmzQawt7tc19I1MdHQgjBA=";
+    hash = "sha256-Z5B+PRYb6eWssgyaXpXoHOVRoMZoSAwun7s6Fh1DrfM=";
   };
 
   vendorHash = "sha256-yfWDGVfgCfsmzI5oxEmhHXKCUAHe6wWTkaMkBN5kQMw=";


### PR DESCRIPTION
Dencun update, tested that binary starts.

On the [release page](https://github.com/flashbots/mev-boost/releases/tag/v1.7), the authors recommend Go `1.22`. However, that is not package on Nix yet. Despite the recommendation, the program seems to compile and start fine.