### PR TITLE
geth: 1.13.12 -> 1.13.14

### DIFF
--- a/pkgs/geth/default.nix
+++ b/pkgs/geth/default.nix
@@ -20,16 +20,16 @@
 in
   buildGoModule rec {
     pname = "geth";
-    version = "1.13.12";
+    version = "1.13.14";
 
     src = fetchFromGitHub {
       owner = "ethereum";
       repo = "go-ethereum";
       rev = "v${version}";
-      hash = "sha256-2olJV7Z01kuXlUGyI0v4YNW07/RfYiDUhBncCIS4s0A=";
+      hash = "sha256-+o/yOsS8tm8zvTJ17jd+dNPJpJB0vsjf4WRWNv6HgG0=";
     };
 
-    vendorHash = "sha256-gcLVQTBpOE0DHz7/p7PENhwghftJKUDm88/4jaQ1VYw=";
+    vendorHash = "sha256-LWNFuF66KudxrpWBBXjMbrWP5CwEuPE2h3kGfILIII0=";
 
     ldflags = ["-s" "-w"];
 


### PR DESCRIPTION
Diff: https://github.com/ethereum/go-ethereum/compare/v1.13.12...v1.13.14