### PR TITLE
rotki-bin: init at 1.32.1

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -58,6 +58,7 @@
       prysm = callPackage ./prysm {inherit bls blst;};
       reth = callPackageUnstable ./reth {};
       rocketpool = callPackage ./rocketpool {};
+      rotki-bin = callPackage ./rotki-bin {};
       sedge = callPackage ./sedge {inherit bls mcl;};
       slither = callPackage ./slither {};
       ssvnode = callPackage ./ssvnode {inherit bls mcl;};
@@ -124,6 +125,7 @@
       };
       reth.bin = "reth";
       rocketpool.bin = "rocketpool";
+      rotki-bin.bin = "rotki";
       sedge.bin = "sedge";
       slither.bin = "slither";
       ssvnode.bin = "ssvnode";

--- a/pkgs/rotki-bin/default.nix
+++ b/pkgs/rotki-bin/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+appimageTools.wrapType2 rec {
+  pname = "rotki-bin";
+  version = "1.32.1";
+
+  src = fetchurl {
+    url = "https://github.com/rotki/rotki/releases/download/v${version}/rotki-linux_x86_64-v${version}.AppImage";
+    sha256 = "sha256-0TRaUQmVoGfJvT6VWkwnVIZpAFJnoUe4jV7Wkf9YkLA=";
+  };
+
+  # Rename installed bin to `rotki` to make it easier to specify in `apps.rotki-bin.bin` declaration.
+  extraInstallCommands = ''
+    mv "$out/bin/${pname}-${version}" "$out/bin/rotki"
+  '';
+
+  meta = with lib; {
+    description = "An open source portfolio tracking tool that respects your privacy";
+    homepage = "https://rotki.com/";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [mitchmindtree];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
I had a quick go at building it from source following [the guide][1], then decided on just wrapping the appimage after running into some python build issues related to the `ruff` linter that was being invoked in a build phase for some reason. I'm sure it's doable with some patching if someone's keen enough, but this at least makes the package available for now.

[1]: https://rotki.readthedocs.io/en/latest/installation_guide.html#build-from-source