### PR TITLE
eth-validator-watcher: init at 0.7.1

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -34,6 +34,7 @@
       erigon = callPackage ./erigon {};
       eth2-testnet-genesis = callPackage ./eth2-testnet-genesis {inherit bls;};
       eth2-val-tools = callPackage ./eth2-val-tools {inherit bls mcl;};
+      eth-validator-watcher = callPackage ./eth-validator-watcher {};
       ethdo = callPackage ./ethdo {inherit bls mcl;};
       ethereal = callPackage ./ethereal {inherit bls mcl;};
       evmc = callPackage ./evmc {};

--- a/pkgs/eth-validator-watcher/default.nix
+++ b/pkgs/eth-validator-watcher/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+python3.pkgs.buildPythonPackage rec {
+  pname = "eth-validator-watcher";
+  version = "0.7.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kilnfi";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-OhrThxzyuBSSdN/MM4wOj0yebVa219uQDW+o0xtsgTg=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    typer
+    prometheus-client
+    pydantic
+    requests
+    slack-sdk
+    tenacity
+    more-itertools
+  ];
+
+  meta = with lib; {
+    description = "Ethereum validator monitor";
+    longDescription = ''      Ethereum Validator Watcher monitors the Ethereum beacon
+      chain in real-time and notifies you when your validators perform certain actions. '';
+    homepage = "https://github.com/kilnfi/eth-validator-watcher";
+    license = licenses.mit;
+    platforms = ["x86_64-linux"];
+  };
+}


### PR DESCRIPTION
Kilnfi's validator watcher.  May be interesting to anyone who wants to roll their own notifier, for upcoming block proposals etc. rather than relying on an external service such as beaconcha.in
I have tried this with lighthouse and it works (using the generic beacon API)