### PR TITLE
besu: use jemalloc if possible

### DIFF
--- a/pkgs/besu/default.nix
+++ b/pkgs/besu/default.nix
@@ -1,11 +1,14 @@
 {
   fetchurl,
+  jemalloc,
   jre,
   lib,
   makeWrapper,
+  runCommand,
   stdenv,
+  testers,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "besu";
   version = "24.1.2";
 
@@ -14,6 +17,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-CC24z0+2dSeqDddX5dJUs7SX9QJ8Iyh/nAp0pqdDvwg=";
   };
 
+  buildInputs = lib.optionals stdenv.isLinux [jemalloc];
   nativeBuildInputs = [makeWrapper];
 
   installPhase = ''
@@ -21,8 +25,29 @@ stdenv.mkDerivation rec {
     cp -r bin $out/
     mkdir -p $out/lib
     cp -r lib $out/
-    wrapProgram $out/bin/${pname} --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/${pname} --set JAVA_HOME "${jre}" --suffix ${
+      if stdenv.isDarwin
+      then "DYLD_LIBRARY_PATH"
+      else "LD_LIBRARY_PATH"
+    } : ${lib.makeLibraryPath buildInputs}
   '';
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      version = "v${version}";
+    };
+    jemalloc =
+      runCommand "${pname}-test-jemalloc"
+      {
+        nativeBuildInputs = [finalAttrs.finalPackage];
+        meta.platforms = with lib.platforms; linux;
+      } ''
+        # Expect to find this string in the output, ignore other failures.
+        (besu 2>&1 || true) | grep -q "# jemalloc: ${jemalloc.version}"
+        mkdir $out
+      '';
+  };
 
   meta = with lib; {
     description = "Besu is an Apache 2.0 licensed, MainNet compatible, Ethereum client written in Java";
@@ -32,4 +57,4 @@ stdenv.mkDerivation rec {
     platforms = ["x86_64-linux"];
     sourceProvenance = with sourceTypes; [binaryBytecode];
   };
-}
+})


### PR DESCRIPTION
This PR recycles my (maybe-merged-one-day) [PR from nixpkgs](https://github.com/NixOS/nixpkgs/pull/282523). A little bit of information can be found there.

However, this PR introduces tests in the package definition itself. I expect change requests here since I haven't seen any other packages that defines `.passthru.tests` so I don't think this is a fit currently. From a cursory look into the code/issues/PRs, I guess you would want to have dedicated module tests. I'm happy to adapt the code in any direction (keeping tests, though), just let me know what you expect.