### PR TITLE
Update reth and support `x86_64-darwin`

### DIFF
--- a/pkgs/reth/default.nix
+++ b/pkgs/reth/default.nix
@@ -7,20 +7,21 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "reth";
-  version = "0.2.0-beta.1";
+  version = "0.2.0-beta.6";
 
   src = fetchFromGitHub {
     owner = "paradigmxyz";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-9PTGYOEsOv8L9INafIKHHjQ1jfMxqW8BR3TEY93tWWs=";
+    hash = "sha256-ZcQ29AwlTU6rDiknlJbOo8JubXQOJg1UVMSlRb1l8Yk=";
   };
 
   cargoLock = {
     lockFile = "${src}/Cargo.lock";
     outputHashes = {
-      "alloy-eips-0.1.0" = "sha256-OtcmYr/pBJ+4osmC+jomU2PjoFC4UAeoEVVXDhF7bAQ=";
-      "revm-inspectors-0.1.0" = "sha256-TVd78Inbpu1OfFPwYctHsopC6kd9yLLZkLJxa+CQ0ec=";
+      "alloy-consensus-0.1.0" = "sha256-2TZeQo0d+Yp0M46VNx3OZoyDT4F31cLdOpl1tk3syfg=";
+      "discv5-0.4.1" = "sha256-agrluN1C9/pS/IMFTVlPOuYl3ZuklnTYb46duVvTPio=";
+      "revm-inspectors-0.1.0" = "sha256-ZRlYNEHD+wewlttUcMuEoTYg9Hn89JVAr7+hIeMBXog=";
     };
   };
 

--- a/pkgs/reth/default.nix
+++ b/pkgs/reth/default.nix
@@ -29,6 +29,10 @@ rustPlatform.buildRustPackage rec {
     rustPlatform.bindgenHook
   ];
 
+  # `x86_64-darwin` seems to have issues with jemalloc
+  buildNoDefaultFeatures = true;
+  buildFeatures = lib.optional (stdenv.system != "x86_64-darwin") "jemalloc";
+
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
@@ -47,7 +51,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/paradigmxyz/reth";
     license = with licenses; [mit asl20];
     mainProgram = "reth";
-    # `x86_64-darwin` seems to have issues with jemalloc, but these are fine.
-    platforms = ["aarch64-darwin" "aarch64-linux" "x86_64-linux"];
+    platforms = ["aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux"];
   };
 }


### PR DESCRIPTION
I don't have `x86_64-darwin` machine, so didn't test it. I can remove it from platforms, though.

Also, reth-0.2.0-beta.1 seems to be changed, as I can't reproduce cached build.