### PR TITLE
besu: 24.3.3 -> 24.5.2

### DIFF
--- a/pkgs/besu/default.nix
+++ b/pkgs/besu/default.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "besu";
-  version = "24.3.3";
+  version = "24.5.2";
 
   src = fetchurl {
-    url = "https://hyperledger.jfrog.io/hyperledger/${pname}-binaries/${pname}/${version}/${pname}-${version}.tar.gz";
-    hash = "sha256-ua7lGVIYf/VQ3kgfLAQFE3uF8dCqOCYWDfbX5QXzWa4=";
+    url = "https://github.com/hyperledger/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-QEm/SAIq4HMGW0bicIg5nfsiA16RNO1Kwsht2MW1++k=";    
   };
 
   buildInputs = lib.optionals stdenv.isLinux [jemalloc];


### PR DESCRIPTION
Updated besu to 24.5.2
Built and running a mainnet validator.
Note that the binaries are now only available on github. Also recommend reading the release notes for this one as there are known issues to be aware of.

