### PR TITLE
erigon: 2.58.1 -> 2.60.0

### DIFF
--- a/pkgs/erigon/default.nix
+++ b/pkgs/erigon/default.nix
@@ -5,17 +5,17 @@
 }:
 buildGoModule rec {
   pname = "erigon";
-  version = "2.58.1";
+  version = "2.60.0";
 
   src = fetchFromGitHub {
     owner = "ledgerwatch";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-jeOV86QVRQ6RiXUPesa+RbYgSe/t43xYZ8X9t/d9fMs=";
+    hash = "sha256-c0CArubKvdh9xcvBM15O4vGwAsSHzaINtoKd0XczJHU=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-DOsM0G0idAHUsil4KNkmghq3VZwVE1ub6fAvRnELHn0=";
+  vendorHash = "sha256-38NmSSK3a70WvhZAZ529wdAMlEuk8/4YqtadoLOn1IY=";
   proxyVendor = true;
 
   # Silkworm's .so fails to find libgmp when linking


### PR DESCRIPTION
`nix build .#erigon` works and an old node of mine is making progress on the sync.