### PR TITLE
reth: 0.2.0-beta.6 -> 1.0.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1720546058,
+        "narHash": "sha256-iU2yVaPIZm5vMGdlT0+57vdB/aPq/V5oZFBRwYw+HBM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2d83156f23c43598cf44e152c33a59d3892f8b29",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "devour-flake": {
       "flake": false,
       "locked": {
@@ -198,11 +218,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1719317636,
-        "narHash": "sha256-bu0xbu2Z6DDzA9LGV81yJunIti6r7tjUImeR8orAL/I=",
+        "lastModified": 1720498663,
+        "narHash": "sha256-juqJkkdAt44mOfA43q1qUHn7iWoK++81lR8Mh7N/EF8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9c513fc6fb75142f6aec6b7545cb8af2236b80f5",
+        "rev": "d211b80d2944a41899a6ab24009d9729cca05e49",
         "type": "github"
       },
       "original": {
@@ -214,6 +234,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "devour-flake": "devour-flake",
         "devshell": "devshell",
         "flake-compat": "flake-compat",
@@ -224,8 +245,29 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "rust-overlay": "rust-overlay",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1720491570,
+        "narHash": "sha256-PHS2BcQ9kxBpu9GKlDg3uAlrX/ahQOoAiVmwGl6BjD4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b970af40fdc4bd80fd764796c5f97c15e2b564eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,14 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.treefmt-nix.follows = "treefmt-nix";
     };
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs @ {
@@ -95,6 +103,7 @@
           pkgsUnstable = lib.extras.nix.mkNixpkgs {
             inherit system;
             nixpkgs = inputs.nixpkgs-unstable;
+            overlays = [(import inputs.rust-overlay)];
           };
           pkgs2311 = lib.extras.nix.mkNixpkgs {
             inherit system;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -59,7 +59,7 @@
       nethermind = callPackageUnstable ./nethermind {};
       nimbus = callPackageUnstable ./nimbus {};
       prysm = callPackage ./prysm {inherit bls blst;};
-      reth = callPackageUnstable ./reth {};
+      reth = callPackageUnstable ./reth {inherit (inputs) crane;};
       rocketpool = callPackage ./rocketpool {};
       rocketpoold = callPackage ./rocketpoold {inherit bls blst;};
       rotki-bin = callPackage2311 ./rotki-bin {};


### PR DESCRIPTION
Reth recently had their 1.0, production-read release. This PR updates reth to the latest 1.0.1 release.

### Considerations

I had to make several potentially controversial changes in order to get reth to build. Specifically two new flake inputs where added, [rust-overlay] and [crane]

#### rust-overlay
Reth requires Rust 1.79.0, this required pulling in the [rust-overlay] flake as even nixpkgs-unstable only has 1.78.0.

#### crane
The nixpkgs native `rustPlatform.buildRustPackage` is fairly rudimentary and doesn't play nicely with Rusts incremental compilation (it will re-download and rebuild your ENTIRE dependency closure every time the nix derivation is built). This is partially Rust's fault (since a package can change how it's dependencies are compiled), however the [crane] flake was designed to help improve this situation and reduce re-compile times. Crane also turned out to be required for testing as described below.

### Testing
Reth has an extensive testing suite. These tests don't *require* nextest, however we only want to run the unit tests which is difficult to do with `cargo test` (would require a significant number of `--skip` args), but can easily be accomplished by providing `-E '!kind(test)'` to the `nextest` invocation. Additionally some "unit" tests require I/O access that is not compatible with the nix sandbox requiring us to skip several specific tests. In `nextest` this looks like `-E '!kind(test) - test(tests::test_exex)'`.

Unfortunately, when passing arguments via `rustPlatform.buildRustPackage`, nix tries to be "help" and will shell escape all arguments passed in. This completely breaks the `-E` args because it contains special characters that need to be included as-is to the actual call to `cargo nextest run`. There would be a workaround for this, simply have `preCheck` script that directly modifies `cargoTestFlags`, however unfortunately there is a bug in nixpkgs [here](https://github.com/NixOS/nixpkgs/blob/3f35c2c40fbadf5cba8b45bbeec19879e144262c/pkgs/build-support/rust/hooks/cargo-nextest-hook.sh#L32) where despite `cargoTestFlags` being an array, only the first element of that array is included in the final call (`${cargoTestFlags}` instead of the correct `${cargoTestFlags[@}}`.

I have opted to use `nextest` since that is the officially supported testing platform with Reth and also executes >x3 faster than `cargo test`. This forced me to use [crane] due to the inability to properly pass in args to the `cargo nextest run` call with `rustPlatform.buildRustPackage`

[rust-overlay]:https://github.com/oxalica/rust-overlay
[crane]:https://github.com/ipetkov/crane