### PR TITLE
Implement Reth service module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -18,6 +18,7 @@
       ./prysm-beacon
       ./prysm-validator
       ./restore
+      ./reth
     ];
   };
 }

--- a/modules/reth/args.nix
+++ b/modules/reth/args.nix
@@ -1,0 +1,166 @@
+lib:
+with lib; {
+  datadir = mkOption {
+    type = types.nullOr types.str;
+    default = null;
+    description = mdDoc "Data directory for Reth. Defaults to '%S/reth-\<name\>', which generally resolves to /var/lib/reth-\<name\>.";
+  };
+
+  port = mkOption {
+    type = types.port;
+    default = 30303;
+    description = mdDoc "Network listening port.";
+  };
+
+  chain = mkOption {
+    type = types.enum [
+      "mainnet"
+      "sepolia"
+      "holesky"
+      "dev"
+    ];
+    default = "mainnet";
+    description = mdDoc "Name of the network to join. If null the network is mainnet.";
+  };
+
+  full = mkOption {
+    type = types.bool;
+    default = false;
+    description = mdDoc "Run full node. Only the most recent [`MINIMUM_PRUNING_DISTANCE`] block states are stored. This flag takes priority over pruning configuration in reth.toml";
+  };
+
+  http = {
+    enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = mdDoc "Enable HTTP-RPC server";
+    };
+
+    addr = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = mdDoc "HTTP-RPC server listening interface.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8545;
+      description = mdDoc "HTTP-RPC server listening port.";
+    };
+
+    corsdomain = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      description = mdDoc "List of domains from which to accept cross origin requests.";
+      example = ["*"];
+    };
+
+    api = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      description = mdDoc "API's offered over the HTTP-RPC interface.";
+      example = ["net" "eth"];
+    };
+  };
+
+  ws = {
+    enable = mkEnableOption (mdDoc "Reth WebSocket API");
+    addr = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = mdDoc "WS server listening interface.";
+      example = "127.0.0.1";
+    };
+
+    port = mkOption {
+      type = types.nullOr types.port;
+      default = null;
+      description = mdDoc "WS server listening port.";
+      example = 8545;
+    };
+
+    origins = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      description = mdDoc "List of origins from which to accept `WebSocket` requests";
+    };
+
+    api = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      description = mdDoc "API's offered over the WS interface.";
+      example = ["net" "eth"];
+    };
+  };
+
+  authrpc = {
+    addr = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = mdDoc "HTTP-RPC server listening interface for the Engine API.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8551;
+      description = mdDoc "HTTP-RPC server listening port for the Engine API";
+    };
+
+    jwtsecret = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = mdDoc "Path to the token that ensures safe connection between CL and EL.";
+      example = "/var/run/reth/jwtsecret";
+    };
+  };
+
+  metrics = {
+    enable = mkEnableOption (mdDoc "Enable Prometheus metrics collection and reporting.");
+
+    addr = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = mdDoc "Enable stand-alone metrics HTTP server listening interface.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 6060;
+      description = mdDoc "Metrics HTTP server listening port";
+    };
+  };
+
+  log = let
+    mkFormatOpt = channel:
+      mkOption {
+        type = types.nullOr (types.enum ["terminal" "log-fmt" "json"]);
+        default = null;
+        description = mdDoc "The format to use for logs written to ${channel}.";
+        example = "log-fmt";
+      };
+    mkFilterOpt = channel:
+      mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = mdDoc "The filter to use for logs written to ${channel}.";
+        example = "info";
+      };
+  in {
+    stdout = {
+      format = mkFormatOpt "stdout";
+      filter = mkFilterOpt "stdout";
+    };
+    file = {
+      format = mkFormatOpt "the log file";
+      filter = mkFilterOpt "the log file";
+      directory = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = mdDoc "The path to put log files in";
+        example = "/var/log/reth";
+      };
+    };
+    journald = {
+      filter = mkFilterOpt "journald";
+    };
+  };
+}

--- a/modules/reth/args.nix
+++ b/modules/reth/args.nix
@@ -3,13 +3,13 @@ with lib; {
   datadir = mkOption {
     type = types.nullOr types.str;
     default = null;
-    description = mdDoc "Data directory for Reth. Defaults to '%S/reth-\<name\>', which generally resolves to /var/lib/reth-\<name\>.";
+    description = "Data directory for Reth. Defaults to '%S/reth-\<name\>', which generally resolves to /var/lib/reth-\<name\>.";
   };
 
   port = mkOption {
     type = types.port;
     default = 30303;
-    description = mdDoc "Network listening port.";
+    description = "Network listening port.";
   };
 
   chain = mkOption {
@@ -20,74 +20,74 @@ with lib; {
       "dev"
     ];
     default = "mainnet";
-    description = mdDoc "Name of the network to join. If null the network is mainnet.";
+    description = "Name of the network to join. If null the network is mainnet.";
   };
 
   full = mkOption {
     type = types.bool;
     default = false;
-    description = mdDoc "Run full node. Only the most recent [`MINIMUM_PRUNING_DISTANCE`] block states are stored. This flag takes priority over pruning configuration in reth.toml";
+    description = "Run full node. Only the most recent [`MINIMUM_PRUNING_DISTANCE`] block states are stored. This flag takes priority over pruning configuration in reth.toml";
   };
 
   http = {
     enable = mkOption {
       type = types.bool;
       default = true;
-      description = mdDoc "Enable HTTP-RPC server";
+      description = "Enable HTTP-RPC server";
     };
 
     addr = mkOption {
       type = types.str;
       default = "127.0.0.1";
-      description = mdDoc "HTTP-RPC server listening interface.";
+      description = "HTTP-RPC server listening interface.";
     };
 
     port = mkOption {
       type = types.port;
       default = 8545;
-      description = mdDoc "HTTP-RPC server listening port.";
+      description = "HTTP-RPC server listening port.";
     };
 
     corsdomain = mkOption {
       type = types.nullOr (types.listOf types.str);
       default = null;
-      description = mdDoc "List of domains from which to accept cross origin requests.";
+      description = "List of domains from which to accept cross origin requests.";
       example = ["*"];
     };
 
     api = mkOption {
       type = types.nullOr (types.listOf types.str);
-      description = mdDoc "API's offered over the HTTP-RPC interface.";
+      description = "API's offered over the HTTP-RPC interface.";
       example = ["net" "eth"];
     };
   };
 
   ws = {
-    enable = mkEnableOption (mdDoc "Reth WebSocket API");
+    enable = mkEnableOption ("Reth WebSocket API");
     addr = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc "WS server listening interface.";
+      description = "WS server listening interface.";
       example = "127.0.0.1";
     };
 
     port = mkOption {
       type = types.nullOr types.port;
       default = null;
-      description = mdDoc "WS server listening port.";
+      description = "WS server listening port.";
       example = 8545;
     };
 
     origins = mkOption {
       type = types.nullOr (types.listOf types.str);
       default = null;
-      description = mdDoc "List of origins from which to accept `WebSocket` requests";
+      description = "List of origins from which to accept `WebSocket` requests";
     };
 
     api = mkOption {
       type = types.nullOr (types.listOf types.str);
       default = null;
-      description = mdDoc "API's offered over the WS interface.";
+      description = "API's offered over the WS interface.";
       example = ["net" "eth"];
     };
   };
@@ -96,36 +96,36 @@ with lib; {
     addr = mkOption {
       type = types.str;
       default = "127.0.0.1";
-      description = mdDoc "HTTP-RPC server listening interface for the Engine API.";
+      description = "HTTP-RPC server listening interface for the Engine API.";
     };
 
     port = mkOption {
       type = types.port;
       default = 8551;
-      description = mdDoc "HTTP-RPC server listening port for the Engine API";
+      description = "HTTP-RPC server listening port for the Engine API";
     };
 
     jwtsecret = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = mdDoc "Path to the token that ensures safe connection between CL and EL.";
+      description = "Path to the token that ensures safe connection between CL and EL.";
       example = "/var/run/reth/jwtsecret";
     };
   };
 
   metrics = {
-    enable = mkEnableOption (mdDoc "Enable Prometheus metrics collection and reporting.");
+    enable = mkEnableOption ("Enable Prometheus metrics collection and reporting.");
 
     addr = mkOption {
       type = types.str;
       default = "127.0.0.1";
-      description = mdDoc "Enable stand-alone metrics HTTP server listening interface.";
+      description = "Enable stand-alone metrics HTTP server listening interface.";
     };
 
     port = mkOption {
       type = types.port;
       default = 6060;
-      description = mdDoc "Metrics HTTP server listening port";
+      description = "Metrics HTTP server listening port";
     };
   };
 
@@ -134,14 +134,14 @@ with lib; {
       mkOption {
         type = types.nullOr (types.enum ["terminal" "log-fmt" "json"]);
         default = null;
-        description = mdDoc "The format to use for logs written to ${channel}.";
+        description = "The format to use for logs written to ${channel}.";
         example = "log-fmt";
       };
     mkFilterOpt = channel:
       mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = mdDoc "The filter to use for logs written to ${channel}.";
+        description = "The filter to use for logs written to ${channel}.";
         example = "info";
       };
   in {
@@ -155,7 +155,7 @@ with lib; {
       directory = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = mdDoc "The path to put log files in";
+        description = "The path to put log files in";
         example = "/var/log/reth";
       };
     };

--- a/modules/reth/args.nix
+++ b/modules/reth/args.nix
@@ -63,7 +63,7 @@ with lib; {
   };
 
   ws = {
-    enable = mkEnableOption ("Reth WebSocket API");
+    enable = mkEnableOption "Reth WebSocket API";
     addr = mkOption {
       type = types.nullOr types.str;
       default = null;
@@ -114,7 +114,7 @@ with lib; {
   };
 
   metrics = {
-    enable = mkEnableOption ("Enable Prometheus metrics collection and reporting.");
+    enable = mkEnableOption "Enable Prometheus metrics collection and reporting.";
 
     addr = mkOption {
       type = types.str;

--- a/modules/reth/default.nix
+++ b/modules/reth/default.nix
@@ -1,0 +1,140 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.lists) optionals findFirst;
+  inherit (lib.strings) hasPrefix;
+  inherit
+    (lib)
+    concatStringsSep
+    filterAttrs
+    flatten
+    mapAttrs'
+    mapAttrsToList
+    mkIf
+    mkMerge
+    nameValuePair
+    zipAttrsWith
+    ;
+
+  modulesLib = import ../lib.nix lib;
+  inherit (modulesLib) baseServiceConfig mkArgs dotPathReducer;
+
+  eachNode = config.services.ethereum.reth;
+in {
+  # Disable the service definition currently in nixpkgs
+  disabledModules = ["services/blockchain/ethereum/reth.nix"];
+
+  ###### interface
+  inherit (import ./options.nix {inherit lib pkgs;}) options;
+
+  ###### implementation
+
+  config = mkIf (eachNode != {}) {
+    # configure the firewall for each service
+    networking.firewall = let
+      openFirewall = filterAttrs (_: cfg: cfg.openFirewall) eachNode;
+      perService =
+        mapAttrsToList
+        (
+          _: cfg:
+            with cfg.args; {
+              allowedTCPPorts =
+                [port authrpc.port]
+                ++ (optionals http.enable [http.port])
+                ++ (optionals ws.enable [ws.port])
+                ++ (optionals metrics.enable [metrics.port]);
+            }
+        )
+        openFirewall;
+    in
+      zipAttrsWith (_name: flatten) perService;
+
+    # configure systemd to create the state directory with a subvolume
+    systemd.tmpfiles.rules =
+      map
+      (name: "v /var/lib/private/reth-${name}")
+      (builtins.attrNames (filterAttrs (_: v: v.subVolume) eachNode));
+
+    # create a service for each instance
+    systemd.services =
+      mapAttrs'
+      (
+        rethName: let
+          serviceName = "reth-${rethName}";
+        in
+          cfg: let
+            scriptArgs = let
+              args = mkArgs {
+                opts = import ./args.nix lib;
+                pathReducer = dotPathReducer;
+                args = builtins.removeAttrs cfg.args ["ws"];
+              };
+
+              wsArgs = mkArgs {
+                opts = import ./args.nix lib;
+                args = {
+                  ws = builtins.removeAttrs cfg.args.ws ["enable"];
+                };
+              };
+
+              # filter out certain args which need to be treated differently
+              specialArgs = [
+                "--authrpc.jwtsecret"
+                "--http.enable"
+                "--metrics.enable"
+                "--metrics.addr"
+                "--metrics.port"
+              ];
+
+              isNormalArg = name: (findFirst (arg: hasPrefix arg name) null specialArgs) == null;
+              filteredArgs =
+                (builtins.filter isNormalArg args)
+                ++ (optionals cfg.args.http.enable ["--http"])
+                ++ (optionals cfg.args.ws.enable wsArgs)
+                ++ (optionals cfg.args.metrics.enable ["--metrics" "${cfg.args.metrics.addr}:${toString cfg.args.metrics.port}"]);
+
+              jwtSecret =
+                if cfg.args.authrpc.jwtsecret != null
+                then "--authrpc.jwtsecret %d/jwtsecret"
+                else "";
+
+              datadir =
+                if cfg.args.datadir != null
+                then "${cfg.args.datadir}"
+                else "%S/${serviceName}";
+            in ''
+              --log.file.directory ${datadir}/logs \
+              --datadir ${datadir} \
+              ${jwtSecret} \
+              ${concatStringsSep " \\\n" filteredArgs} \
+              ${lib.escapeShellArgs cfg.extraArgs}
+            '';
+          in
+            nameValuePair serviceName (mkIf cfg.enable {
+              description = "Reth Ethereum node (${rethName})";
+              wantedBy = ["multi-user.target"];
+              after = ["network.target"];
+
+              # create service config by merging with the base config
+              serviceConfig = mkMerge [
+                baseServiceConfig
+                {
+                  User = serviceName;
+                  StateDirectory = serviceName;
+                  ExecStart = "${cfg.package}/bin/reth node ${scriptArgs}";
+
+                  # Reth needs this system call for some reason
+                  SystemCallFilter = ["@system-service" "~@privileged" "mincore"];
+                }
+                (mkIf (cfg.args.authrpc.jwtsecret != null) {
+                  LoadCredential = ["jwtsecret:${cfg.args.authrpc.jwtsecret}"];
+                })
+              ];
+            })
+      )
+      eachNode;
+  };
+}

--- a/modules/reth/options.nix
+++ b/modules/reth/options.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  args = import ./args.nix lib;
+
+  rethOpts = with lib; {
+    options = {
+      enable = mkEnableOption (mdDoc "Reth Ethereum Node.");
+
+      subVolume = mkEnableOption (mdDoc "Use a subvolume for the state directory if the underlying filesystem supports it e.g. btrfs");
+
+      inherit args;
+
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        description = mdDoc "Additional arguments to pass to Reth.";
+        default = [];
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.reth;
+        defaultText = literalExpression "pkgs.reth";
+        description = mdDoc "Package to use as Reth node.";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc "Open ports in the firewall for any enabled networking services";
+      };
+    };
+  };
+in {
+  options.services.ethereum.reth = with lib;
+    mkOption {
+      type = types.attrsOf (types.submodule rethOpts);
+      default = {};
+      description = mdDoc "Specification of one or more Reth instances.";
+    };
+}

--- a/modules/reth/options.nix
+++ b/modules/reth/options.nix
@@ -7,15 +7,15 @@
 
   rethOpts = with lib; {
     options = {
-      enable = mkEnableOption (mdDoc "Reth Ethereum Node.");
+      enable = mkEnableOption ("Reth Ethereum Node.");
 
-      subVolume = mkEnableOption (mdDoc "Use a subvolume for the state directory if the underlying filesystem supports it e.g. btrfs");
+      subVolume = mkEnableOption ("Use a subvolume for the state directory if the underlying filesystem supports it e.g. btrfs");
 
       inherit args;
 
       extraArgs = mkOption {
         type = types.listOf types.str;
-        description = mdDoc "Additional arguments to pass to Reth.";
+        description = "Additional arguments to pass to Reth.";
         default = [];
       };
 
@@ -23,13 +23,13 @@
         type = types.package;
         default = pkgs.reth;
         defaultText = literalExpression "pkgs.reth";
-        description = mdDoc "Package to use as Reth node.";
+        description = "Package to use as Reth node.";
       };
 
       openFirewall = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc "Open ports in the firewall for any enabled networking services";
+        description = lib."Open ports in the firewall for any enabled networking services";
       };
     };
   };
@@ -38,6 +38,6 @@ in {
     mkOption {
       type = types.attrsOf (types.submodule rethOpts);
       default = {};
-      description = mdDoc "Specification of one or more Reth instances.";
+      description = "Specification of one or more Reth instances.";
     };
 }

--- a/modules/reth/options.nix
+++ b/modules/reth/options.nix
@@ -7,9 +7,9 @@
 
   rethOpts = with lib; {
     options = {
-      enable = mkEnableOption ("Reth Ethereum Node.");
+      enable = mkEnableOption "Reth Ethereum Node.";
 
-      subVolume = mkEnableOption ("Use a subvolume for the state directory if the underlying filesystem supports it e.g. btrfs");
+      subVolume = mkEnableOption "Use a subvolume for the state directory if the underlying filesystem supports it e.g. btrfs";
 
       inherit args;
 


### PR DESCRIPTION
I tested this against Reth 1.0 (from #530), however I don't think the command line has changed since the current imported version (0.2.0-beta.6) so I opted to implement it against `main` instead of on top of my other PR.

I chose not to implement and integration test with a nixos vm because I felt it is mostly likely unecessary due to the extensive test coverage within Reth itself.