### PR TITLE
Fix nethermind module

### DIFF
--- a/modules/nethermind/default.nix
+++ b/modules/nethermind/default.nix
@@ -114,7 +114,7 @@ in {
 
               filteredArgs = builtins.filter isNormalArg args;
             in ''
-              ${datadir}
+              ${datadir} \
               ${jwtSecret} \
               ${concatStringsSep " \\\n" filteredArgs} \
               ${lib.escapeShellArgs cfg.extraArgs}

--- a/modules/nethermind/default.nix
+++ b/modules/nethermind/default.nix
@@ -132,12 +132,13 @@ in {
 
               # create service config by merging with the base config
               serviceConfig = mkMerge [
-                baseServiceConfig
                 {
                   User = serviceName;
                   StateDirectory = serviceName;
+                  MemoryDenyWriteExecute = false; # setting this option is incompatible with JIT
                   ExecStart = "${cfg.package}/bin/nethermind ${scriptArgs}";
                 }
+                baseServiceConfig
                 (mkIf (cfg.args.modules.JsonRpc.JwtSecretFile != null) {
                   LoadCredential = ["jwtsecret:${cfg.args.modules.JsonRpc.JwtSecretFile}"];
                 })


### PR DESCRIPTION
Module was missing a backslash and included a systemd option that causes a core dump, presumably because it isn't compatible with JIT elements in the dotnet runtime