### PR TITLE
geth: 1.14.7 -> 1.14.8

### DIFF
--- a/pkgs/geth/default.nix
+++ b/pkgs/geth/default.nix
@@ -16,23 +16,22 @@
     "ethkey"
     "evm"
     "geth"
-    "p2psim"
     "rlpdump"
   ];
 in
   buildGoModule rec {
     pname = "geth";
-    version = "1.14.7";
+    version = "1.14.8";
 
     src = fetchFromGitHub {
       owner = "ethereum";
       repo = "go-ethereum";
       rev = "v${version}";
-      hash = "sha256-axllyeumgR6DJ5NXGBVanLcjfeDEHhBTRI9eiJUpFw4=";
+      hash = "sha256-y831v6ar1RdDvGQMZf2lZKgq2IQzAAQrNwDCL0xbj24=";
     };
 
     proxyVendor = true;
-    vendorHash = "sha256-OnVHsJUDezTH1NFvDRO7lAtouSaBDRvhTbFdhloQLAs=";
+    vendorHash = "sha256-CLGf64Fftu4u8Vaj66Q4xuRKBEMNZmpltUyaUMVyVJk=";
 
     ldflags = ["-s" "-w"];
 
@@ -56,7 +55,6 @@ in
       "cmd/ethkey"
       "cmd/evm"
       "cmd/geth"
-      "cmd/p2psim"
       "cmd/rlpdump"
       "cmd/utils"
     ];


### PR DESCRIPTION
The biggest change is that the p2psim package got dropped: https://github.com/ethereum/go-ethereum/pull/30250