### PR TITLE
ssvnode: 1.3.8 -> 2.0.0

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -73,7 +73,7 @@
         bls = callPackage2311 ./bls {};
         mcl = callPackage2311 ./mcl {};
       };
-      ssvnode = callPackage2311 ./ssvnode {
+      ssvnode = callPackage ./ssvnode {
         bls = callPackage2311 ./bls {};
         mcl = callPackage2311 ./mcl {};
       };

--- a/pkgs/ssvnode/default.nix
+++ b/pkgs/ssvnode/default.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule rec {
   pname = "ssv";
-  version = "2.0.0-unstable.0";
+  version = "2.0.0-unstable.2";
 
   src = fetchFromGitHub {
     owner = "ssvlabs";
     repo = "${pname}";
-    rev = "aafa85e73bf0d3579fcc8997ec631a4ad1bf4ffe";
-    hash = "sha256-uI7Am4zSMZCX1t4JcdtD0T5cd24dy1oed0xm1pG4jGQ=";
+    rev = "cdce10d1f95866a9e13003934fc3771d22a8aba4";
+    hash = "sha256-1VyGA9nIDIJvL4zqHIAuxlY8FWywZ8ycYm06zCCUP3M=";
   };
 
   vendorHash = "sha256-cVSbOxyul87/y0lp0x9INw76XzHFTBOv9BjQTs2bvPU=";

--- a/pkgs/ssvnode/default.nix
+++ b/pkgs/ssvnode/default.nix
@@ -7,16 +7,16 @@
 }:
 buildGoModule rec {
   pname = "ssv";
-  version = "2.0.0-unstable.2";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "ssvlabs";
     repo = "${pname}";
-    rev = "cdce10d1f95866a9e13003934fc3771d22a8aba4";
-    hash = "sha256-1VyGA9nIDIJvL4zqHIAuxlY8FWywZ8ycYm06zCCUP3M=";
+    rev = "e39f1d0ec67c47f6ba437d83367aba0d2b4d34dd";
+    hash = "sha256-2/o+FyfJcX/Av82O3DV3gSkLHDtJCoUw2+zpozyr628=";
   };
 
-  vendorHash = "sha256-cVSbOxyul87/y0lp0x9INw76XzHFTBOv9BjQTs2bvPU=";
+  vendorHash = "sha256-lr62X/Fo97CzxKgwdNCv3OELa6yMSEQBOs2cG53rYJY=";
 
   buildInputs = [bls mcl];
 

--- a/pkgs/ssvnode/default.nix
+++ b/pkgs/ssvnode/default.nix
@@ -1,29 +1,43 @@
 {
   bls,
-  mcl,
-  buildGo120Module,
+  buildGoModule,
   fetchFromGitHub,
+  mcl,
+  openssl,
 }:
-buildGo120Module rec {
+buildGoModule rec {
   pname = "ssv";
-  version = "1.3.8";
+  version = "2.0.0-unstable.0";
 
   src = fetchFromGitHub {
-    owner = "bloxapp";
+    owner = "ssvlabs";
     repo = "${pname}";
-    rev = "v${version}";
-    hash = "sha256-5JUaJwo8snUrw/Uhk23uiGr+YV4UogiyvLGXXPiYICY=";
+    rev = "aafa85e73bf0d3579fcc8997ec631a4ad1bf4ffe";
+    hash = "sha256-uI7Am4zSMZCX1t4JcdtD0T5cd24dy1oed0xm1pG4jGQ=";
   };
 
-  vendorHash = "sha256-paFwSCVQEEkZzd/QHGBfaPvDwSAXYxvS5Cq+N18QTIU=";
+  vendorHash = "sha256-cVSbOxyul87/y0lp0x9INw76XzHFTBOv9BjQTs2bvPU=";
 
   buildInputs = [bls mcl];
+
+  ldflags = [
+    "-X main.Commit=${src.rev}"
+    "-X main.Version=v${version}"
+  ];
+
+  # Dynamic loading of openssl
+  # See: https://github.com/ssvlabs/ssv/blob/v2.0.0-unstable.0/operator/keys/rsa_linux.go#L30
+  postFixup = ''
+    patchelf \
+      --add-rpath ${openssl.out}/lib \
+      $out/bin/ssvnode
+  '';
 
   subPackages = ["cmd/ssvnode"];
 
   meta = {
     description = "Secret-Shared-Validator(SSV) for ethereum staking";
-    homepage = "https://github.com/bloxapp/ssv";
+    homepage = "https://github.com/ssvlabs/ssv";
     platforms = ["x86_64-linux"];
     mainProgram = "ssvnode";
   };


### PR DESCRIPTION
Draft until the real v2 is released. This updates upgrades the Go version. The current branch uses weird openssl loading feature, for which a postFixup had to be added (alternatively, a runtime environment could set `LD_LIBRARY_PATH`). If anyone has a better idea how to work around this, please do comment.