### PR TITLE
Separate nethermind JSON RPC Host and EngineHost options

### DIFF
--- a/modules/nethermind/args.nix
+++ b/modules/nethermind/args.nix
@@ -68,6 +68,12 @@ with lib; {
         description = "Defines whether the JSON RPC service is enabled on node startup.";
       };
 
+      Host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "Host for JSON RPC calls.";
+      };
+
       Port = mkOption {
         type = types.port;
         default = 8545;
@@ -83,7 +89,7 @@ with lib; {
       EngineHost = mkOption {
         type = types.str;
         default = "127.0.0.1";
-        description = "Host for JSON RPC calls.";
+        description = "Host for Execution Engine RPC calls.";
       };
 
       EnginePort = mkOption {

--- a/modules/nethermind/default.nix
+++ b/modules/nethermind/default.nix
@@ -126,7 +126,7 @@ in {
               description = "Nethermind Node (${nethermindName})";
 
               environment = {
-                WEB3_HTTP_HOST = cfg.args.modules.JsonRpc.EngineHost;
+                WEB3_HTTP_HOST = cfg.args.modules.JsonRpc.Host;
                 WEB3_HTTP_PORT = builtins.toString cfg.args.modules.JsonRpc.Port;
               };
 


### PR DESCRIPTION
Separate the RPC host and engine host options so that they can, for example, bind to different interfaces