### PR TITLE
erigon: 2.60.0 -> 2.60.8

### DIFF
--- a/pkgs/erigon/default.nix
+++ b/pkgs/erigon/default.nix
@@ -5,17 +5,17 @@
 }:
 buildGoModule rec {
   pname = "erigon";
-  version = "2.60.0";
+  version = "2.60.8";
 
   src = fetchFromGitHub {
     owner = "ledgerwatch";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-c0CArubKvdh9xcvBM15O4vGwAsSHzaINtoKd0XczJHU=";
+    rev = "${version}";
+    hash = "sha256-cHEJbRP/v1GOmpfjrYjso2d+SVcXG+TEiIZoX+sSdYQ=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-38NmSSK3a70WvhZAZ529wdAMlEuk8/4YqtadoLOn1IY=";
+  vendorHash = "sha256-J535F9xXtxuCHvshJOJ63fOGpa5ZhReaOu9+jAKXDfo=";
   proxyVendor = true;
 
   # Silkworm's .so fails to find libgmp when linking


### PR DESCRIPTION
Note that erigon's version tags are no longer prefixed with a `v` (starting from [2.60.7](https://github.com/erigontech/erigon/releases/tag/2.60.7))