### PR TITLE
vouch: 1.9.0 -> 1.9.2

### DIFF
--- a/pkgs/vouch/default.nix
+++ b/pkgs/vouch/default.nix
@@ -6,16 +6,16 @@
 }:
 buildGoModule rec {
   pname = "vouch";
-  version = "1.9.0";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "attestantio";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-EPBMFff9NoGy8L+aNilVZ2oHo2QcgwLyPxhRZDY6QrY=";
+    hash = "sha256-1FH4H4iH5uc7nUYVlQdqwYylB9puNJ557LLgy3ovcRI=";
   };
 
-  vendorHash = "sha256-sRoLkvULqYtA76TqgoEQK7CS59oalGH5V0SXlvlHWGw=";
+  vendorHash = "sha256-h5MQ3v3YLKxyOK16wb/p8ND68P5LaugWiIXXG8mtXqE=";
 
   runVend = true;
 


### PR DESCRIPTION
There was a small issue with the 1.9.0 release:
https://github.com/attestantio/vouch/releases/tag/v1.9.2
