### PR TITLE
fix mev-boost module option generation and network options

### DIFF
--- a/modules/mev-boost/args.nix
+++ b/modules/mev-boost/args.nix
@@ -1,7 +1,7 @@
 lib:
 with lib; {
   network = mkOption {
-    type = types.nullOr (types.enum ["mainnet" "goerli" "sepolia" "zhejiang"]);
+    type = types.nullOr (types.enum ["mainnet" "holesky" "sepolia" "zhejiang"]);
     default = null;
     description = "The network to connect to. Mainnet (null) is the default ethereum network.";
   };

--- a/modules/mev-boost/default.nix
+++ b/modules/mev-boost/default.nix
@@ -40,28 +40,27 @@ in {
               # filter out certain args which need to be treated differently
               specialArgs = [
                 "--network"
-                "-goerli"
-                "-holesky"
-                "-mainnet"
-                "-relay-monitor"
-                "-relay-monitors"
-                "-relay"
-                "-relays"
-                "-sepolia"
-                "-zhejiang"
+                "--holesky"
+                "--mainnet"
+                "--relay-monitor"
+                "--relay-monitors"
+                "--relay"
+                "--relays"
+                "--sepolia"
+                "--zhejiang"
               ];
               isNormalArg = name: (findFirst (arg: hasPrefix arg name) null specialArgs) == null;
               filteredArgs = builtins.filter isNormalArg args;
 
               network =
                 if cfg.args.network != null
-                then "-${cfg.args.network}"
+                then "--${cfg.args.network}"
                 else "";
 
-              relays = "-relays " + (concatStringsSep "," cfg.args.relays);
+              relays = "--relays " + (concatStringsSep "," cfg.args.relays);
               relayMonitors =
                 if cfg.args.relay-monitors != null
-                then "-relay-monitors" + (concatStringsSep "," cfg.args.relay-monitors)
+                then "--relay-monitors" + (concatStringsSep "," cfg.args.relay-monitors)
                 else "";
             in ''
               ${network} \

--- a/modules/mev-boost/default.test.nix
+++ b/modules/mev-boost/default.test.nix
@@ -13,8 +13,10 @@
           enable = true;
           args = {
             addr = "localhost:18550";
-            network = "goerli";
-            relays = ["https://0x8f7b17a74569b7a57e9bdafd2e159380759f5dc3ccbd4bf600414147e8c4e1dc6ebada83c0139ac15850eb6c975e82d0@builder-relay-goerli.blocknative.com"];
+            network = "holesky";
+            relays = [
+              "https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-holesky.flashbots.net"
+            ];
           };
         };
       };


### PR DESCRIPTION
Contains the following changes:

- Remove goerli as it is retired and no longer a valid network option.
- Fix the cli option generation so that it works with the change in mev-boost v1.8 to use the urfave cli library.

Resolves issue #558 
The mev-boost test passes for me now.