### PR TITLE
Update flake dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "devour-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1709858306,
-        "narHash": "sha256-Vey9n9hIlWiSAZ6CCTpkrL6jt4r2JvT2ik9wa2bjeC0=",
+        "lastModified": 1733242247,
+        "narHash": "sha256-RrSH+9vlDDDh+yZao012bvV8Hoej/5poQQYfYlEr6Zw=",
         "owner": "srid",
         "repo": "devour-flake",
-        "rev": "17b711b9deadbbc5629cb7d2b64cf86ae72af3fa",
+        "rev": "017e3a0eb62e2a3d63fb20c5028af71f39a81181",
         "type": "github"
       },
       "original": {
@@ -18,19 +18,16 @@
     },
     "devshell": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1717408969,
-        "narHash": "sha256-Q0OEFqe35fZbbRPPRdrjTUUChKVhhWXz3T9ZSKmaoVY=",
+        "lastModified": 1735644329,
+        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "1ebbe68d57457c8cae98145410b164b5477761f4",
+        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
         "type": "github"
       },
       "original": {
@@ -61,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -96,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -119,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717405880,
-        "narHash": "sha256-qcXXOnRSl0sGKm7JknntBU4su8/342YKZvjklHsIl+Q=",
+        "lastModified": 1735981876,
+        "narHash": "sha256-PAyEy36HBOOwzChB7D6xKzzkHwiK9ynsRX4/0ZFspgI=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "708c0df1e36b5185a727a3c517a5100e46392792",
+        "rev": "14f071541283aa90e15efc980121a8296f70a2d3",
         "type": "github"
       },
       "original": {
@@ -198,11 +195,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1719317636,
-        "narHash": "sha256-bu0xbu2Z6DDzA9LGV81yJunIti6r7tjUImeR8orAL/I=",
+        "lastModified": 1736241350,
+        "narHash": "sha256-CHd7yhaDigUuJyDeX0SADbTM9FXfiWaeNyY34FL1wQU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9c513fc6fb75142f6aec6b7545cb8af2236b80f5",
+        "rev": "8c9fd3e564728e90829ee7dbac6edc972971cd0f",
         "type": "github"
       },
       "original": {
@@ -250,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719243788,
-        "narHash": "sha256-9T9mSY35EZSM1KAwb7K9zwQ78qTlLjosZgtUGnw4rn4=",
+        "lastModified": 1736154270,
+        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "065a23edceff48f948816b795ea8cc6c0dee7cdf",
+        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -141,7 +141,7 @@
               "*.md"
               "*.html"
             ];
-            mdformat.command = lib.mkDefault (pkgsUnstable.mdformat.withPlugins (p: [
+            mdformat.package = lib.mkDefault (pkgsUnstable.mdformat.withPlugins (p: [
               p.mdformat-admon
               p.mdformat-beautysh
               p.mdformat-footnote

--- a/pkgs/blutgang/default.nix
+++ b/pkgs/blutgang/default.nix
@@ -6,13 +6,13 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "blutgang";
-  version = "0.3.1";
+  version = "0.3.6";
 
   src = fetchFromGitHub {
     owner = "rainshowerLabs";
     repo = pname;
     rev = "Blutgang-${version}";
-    hash = "sha256-prJq1enn2bJdJieVjvq1vd7dCNBlg5ppymIwjU4pgzg=";
+    hash = "sha256-EAmmCvESMneYuoTEa8Qm5eYqJkkRDY8CqlfsER1Pq8s=";
   };
 
   nativeBuildInputs = [
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  cargoHash = "sha256-bAHUcfRtefGsRgFMBY5JJ4QSstB8wApcdqz/pqSVpuk=";
+  cargoHash = "sha256-1G80j/lZrAlrgOLgpKyGYP9x6g/9kxXf3wmY2OcynFc=";
 
   meta = {
     description = "the wd40 of ethereum load balancers";

--- a/pkgs/foundry/default.nix
+++ b/pkgs/foundry/default.nix
@@ -15,18 +15,12 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "foundry-rs";
     repo = "foundry";
-    rev = "0688b5ad19a637303c038d1a66aec62a73713e20";
-    hash = "sha256-OIsUzJVNcb2nVCYU/BdGGGICEg9Cr9LXc8zzN2JSb8g=";
+    rev = "8a08a3a92b0c842db2f254983cc3bd179300ad46";
+    hash = "sha256-djEWWltp+5DErOsADmcF/NlCNslAfDMMhLmFSm0HbBM=";
   };
 
   cargoLock = {
     lockFile = "${src}/Cargo.lock";
-    outputHashes = {
-      "alloy-consensus-0.1.0" = "sha256-rHDLt0N6VIAlg2EKEdF0S2S8XqJebRlIB7owyGQ04aA=";
-      "ethers-2.0.11" = "sha256-ySrCZOiqOcDVH5T7gbimK6Bu7A2OCcU64ZL1RfFPrBc=";
-      "revm-3.5.0" = "sha256-gdDJq2ZyIkMhTgMNz45YJXnopF/xxt3CaSd/eYSDGcY=";
-      "revm-inspectors-0.1.0" = "sha256-mH6On3cjKLT14S+5dxB1G5lcf5PBtz0KcusMxOtRRWA=";
-    };
   };
 
   env = {

--- a/pkgs/foundry/svm-lists/linux-amd64.json
+++ b/pkgs/foundry/svm-lists/linux-amd64.json
@@ -8,7 +8,6 @@
       "keccak256": "0x66bd5478b31c7ad1ec9b148618945dc8b7d0dc9ca4a2469992b9728daf672f9f",
       "sha256": "0xf3638225df24f444a72123956033f5743079118f0e1195ce6969aa16a7ef2283",
       "urls": [
-        "bzzr://9d3ea309ce8ece74f89babfd3e55035f6164e5a0f9ab7d839c0493fe10e915de",
         "dweb:/ipfs/QmUGR45KnfMmJUSGvZyNiB9c9Cpf7FLTHdK8X3bZQb1GaS"
       ]
     },
@@ -20,7 +19,6 @@
       "keccak256": "0xf27dfded17794053f0e9144a35a9a9e2fcc1c7b34f46f593b87000d00aa39eb5",
       "sha256": "0x0a8d138ee245039e6f8312edc024ba3c4739cc3c013b47dc7fc9196a2e327fea",
       "urls": [
-        "bzzr://f88f5572e75465633a2a1fad99e4ab329f854b73aa8c9d2f1a7a14011e32df6d",
         "dweb:/ipfs/QmenL4RpDaBXFcY8HHH5rzieMGE9KFWcbHZzG1ypC4pGLr"
       ]
     },
@@ -32,7 +30,6 @@
       "keccak256": "0x6cffb262a3498b98e59baa4f579ba92c9496c960ca37f675fbd17d179a31dbd1",
       "sha256": "0x221ae33e12bda5c8b796c9abae2b2eb73e46d9b12128bfee451b12856f8b47ee",
       "urls": [
-        "bzzr://246480c5502c5daea350af895c79213971672c5fdb85b7de93d27b20406c89a8",
         "dweb:/ipfs/QmTTW8RScz5F9W9fyYMafyQKYP2y1XN5ZeJE89N55LU122"
       ]
     },
@@ -44,7 +41,6 @@
       "keccak256": "0x7d2ee23b3ecbc3a178e7fbdb50eb52e5d2637289b92c0c370dbf69be20e58031",
       "sha256": "0x791ee3a20adf6c5ab76cc889f13cca102f76eb0b7cf0da4a0b5b11dc46edf349",
       "urls": [
-        "bzzr://d6182ecde7e8d10659176cb59b60d3fffdae0f87ae8f3ff79d758fa22c03ebc0",
         "dweb:/ipfs/QmPBGiJHDCyqFaqbtfPbSozFBtiF8cpL1mMDvumpSNYDEt"
       ]
     },
@@ -56,7 +52,6 @@
       "keccak256": "0xd952abd8839609ebc5a42350419cdac388d39fa0def02cd2b0c2c559dc2598e8",
       "sha256": "0x28ce35a0941d9ecd59a2b1a377c019110e79a6b38bdbf5a3bffea811f9c2a13b",
       "urls": [
-        "bzzr://948ebc4b72e2e5705512ec441b3a3055e522a8cf46bd82cfad42aefb1c1c25d4",
         "dweb:/ipfs/QmeDMVjzcKysgVrEj2W7ewtNtDwut4xHknP79jqbdZMpBL"
       ]
     },
@@ -68,7 +63,6 @@
       "keccak256": "0xba3b29e25b9e9b5082832bb27b0d1bafe2ce3a78aaad85a7ebbeba5edc825447",
       "sha256": "0xc71ac6c28bf3b1a425e77e97f5df67a80da3e4c047261875206561c0a110c0cb",
       "urls": [
-        "bzzr://f5f436b729b8c3a4e31d607f3ad0256de8b970b207fd83ae7552a34570e5071e",
         "dweb:/ipfs/QmcEoM1BbxFoUs1PrxkK42JiWbW8YS3ZsFNUgsthFaypZc"
       ]
     },
@@ -80,7 +74,6 @@
       "keccak256": "0xc0c1df80393ca97d89bdfb435cd66027ccdbe4f88ca70b0c94afa1d243c99268",
       "sha256": "0x78e0da6cad24ab145a8d17420c4f094c8314418ca23cff4b050bb2bfd36f3af2",
       "urls": [
-        "bzzr://24f7c4bccb3711985253911fd2df23be1bc92cf3629b238d4ba7aaa433cb5251",
         "dweb:/ipfs/QmVSF192Nbgqh9zA1JQYyCVbzyxqYhYPFXBunzyHtxJRZ5"
       ]
     },
@@ -92,7 +85,6 @@
       "keccak256": "0x91c51381736ad2bc23e2a29423f786c8da5f9a7e13d6cfade90e9bced0636026",
       "sha256": "0x13414bf86f80319e6f5863b4ca4af786956d188f5f9b99dda6439362c6d91115",
       "urls": [
-        "bzzr://e4b2755454fdc9ab73ba013f0d646fb2735f7d7f1c696b0d38be593ad68752ce",
         "dweb:/ipfs/QmYezLj4Qky7HXv5iZLzBc7itTV1xhnh3kPuFGMhohCkZj"
       ]
     },
@@ -104,7 +96,6 @@
       "keccak256": "0x5f35f3ababcda47bcfbb7aefea8dc3ccda06bb12690e047a8330e895f2682e61",
       "sha256": "0x898a5e05d3ac08d726b019d2415c1c087a9ae87866cdfa551c08b36b6b45321d",
       "urls": [
-        "bzzr://63bee56c93171ea27e96e35f54411b79d12bc6c398f8451229919707e93a33a3",
         "dweb:/ipfs/QmcZajAm1bVSyGRmAxq3yNbF31M6yMuNX9tVkFzmarHn4p"
       ]
     },
@@ -116,7 +107,6 @@
       "keccak256": "0x7310233685fca42969a942384662203fe3150098c20a3285ed702f769873661b",
       "sha256": "0x07f89753cdda28054bb6f159a21911716caeb43b3c7659a25f1f2d9dd17bc827",
       "urls": [
-        "bzzr://0fea8889d30bb35a31805e59382bf15fc6321c39358a16d0a7eb5a28b79b24db",
         "dweb:/ipfs/QmQBKWnNXJyVjBVsTLmbNosfScV3eoGDfz81L9inC4SJEZ"
       ]
     },
@@ -128,7 +118,6 @@
       "keccak256": "0x6ac0e06558f9c1e28497da8e7b1aec808a85ad59862a13a42d537dc9e5608165",
       "sha256": "0xd966b8215a4f83377ce9d622c9198fe91e5b93300652bf081aaf2f6aa3ac6a16",
       "urls": [
-        "bzzr://bfe04eb5a64c0be572bb03df2a53d8bdef52db767cfecc963ddca4b584138105",
         "dweb:/ipfs/QmXfGHL16gtaDFTkk4GT5RXmxp8ciyMz4Yt5YARE8PoRUx"
       ]
     },
@@ -140,7 +129,6 @@
       "keccak256": "0x18830ee60c27e630558ed4dc26543800ecd1189aab3d42f3ef0bcba9ced97a26",
       "sha256": "0x905228505420cd31e6393e09ea685b87585b62c4339d3addc0a3049bebbc4332",
       "urls": [
-        "bzzr://28cbeae79e05b0b72b7a22247124071a3881b09886ee716acf2024038a5c52aa",
         "dweb:/ipfs/Qma2XrmazW6bsiEma64uUmpjfJMDXCsirP72nw8nuEPpKX"
       ]
     },
@@ -152,7 +140,6 @@
       "keccak256": "0x7fb2ce6341df972568b9987542f17c72f0f8481b6d6544df9464541dcd48ce07",
       "sha256": "0xfade9ba6dd489ffc3f73e53a13d5f1031325779708e448224970979b8cc86ba7",
       "urls": [
-        "bzzr://1ad67b6130be54ad37b3ed7d4024d8277e5abe01fd2ba3b4a1db8d7d95c743d2",
         "dweb:/ipfs/QmWzkuv48UJnPwNdDFKN2A5yejZYizckwX4FdD2A6sXcGs"
       ]
     },
@@ -164,7 +151,6 @@
       "keccak256": "0xbab9657147aef06499bf9b016671754be7233ca08bbfc056c260fa888789d044",
       "sha256": "0xc648d299bd21f4c74ce17954706cfc5a7a9fbbd1e8739546ed8754cacd8ca7c2",
       "urls": [
-        "bzzr://17f4e7bea5718a310c7a59b6bdce8e33e32e6569f186116e44b49c83e394ab71",
         "dweb:/ipfs/QmeYUkb7mzaKxgHsTszv7FnSC4wSrMk73BxJrwsuwisYgo"
       ]
     },
@@ -176,7 +162,6 @@
       "keccak256": "0x9dc72f961d7dbe7c3d3cc380955b994dd5fffdf4020d217cbe45d349d25aadb5",
       "sha256": "0x665675b9e0431c2572d59d6a7112afbdc752732ea0ce9aecf1a1855f28e02a09",
       "urls": [
-        "bzzr://8472dab7460f19869b64c3462bd17f689a77bb9ebb178cf7ace5c887e5c0985d",
         "dweb:/ipfs/QmQRjyb894sQXHy7izsj9D7g6UNn6WapQUnemRiqiNRucC"
       ]
     },
@@ -188,7 +173,6 @@
       "keccak256": "0x3daf486a85a9ed33b63c7e9f89e40f46c528340b3d096f3ccd84bce60a9d1d59",
       "sha256": "0xc9b268750506b88fe71371100050e9dd1e7edcf8f69da34d1cd09557ecb24580",
       "urls": [
-        "bzzr://9d44af75f7b3d0a8b1079814c9e78e07efe9ffc7b42c7ef379e3453ae7b49f3b",
         "dweb:/ipfs/QmcBqre2ncDfq1SRX3SzXtP54FJXbD4smmWVhhwvWGrs8E"
       ]
     },
@@ -200,7 +184,6 @@
       "keccak256": "0x5ee9bf00d10e712f1d43b94df82a17c4a2382a622f41ef67757f83fcbb0a604c",
       "sha256": "0x5d577b3f7918dd735ab157e2f37a21d06c90469f13868359874f15184f2fa4d0",
       "urls": [
-        "bzzr://ec7ce34dca7075d994468cfc407b0cddd2fd5d6426d5ba3bc7b9f0471304e11d",
         "dweb:/ipfs/QmbVDnn2V5uvBZk6vBXSELYvQLZQfegQUNygn3nXMyfrTU"
       ]
     },
@@ -212,7 +195,6 @@
       "keccak256": "0x7189e393d88774aa4b82ea081f871fa50812c85eaa46f5555169dbcb6d0aff66",
       "sha256": "0xc1bb15b520f5076aebd7aa9ef4ce5fa245b6f210a91cbd2064b9e383e6510e08",
       "urls": [
-        "bzzr://b041cea8f6345b61b95e46edb2fe259fddde1f54314c8ccc4ddb6f50fbbd2f84",
         "dweb:/ipfs/QmYWyPLHYcgptU2PTffmycrSYdpvnx2xssjKoKvEuugH5C"
       ]
     },
@@ -224,7 +206,6 @@
       "keccak256": "0x622e30657718674c5c9a1175c432eb3e2873ad15307bc7083c2539de6184565d",
       "sha256": "0x6275d481f23180e00b38996848534db78b4f73caaca15435ad861df545bb71d0",
       "urls": [
-        "bzzr://702c4fd0cfaa35c3f55578208ad49256a94e16949bde4e0abd3a908fd5042dfe",
         "dweb:/ipfs/QmTigsgEim4YBrRd4XWo4zR2nyFewLBEu7H9mgq1PmVxH4"
       ]
     },
@@ -236,7 +217,6 @@
       "keccak256": "0x636748ef7a5915f5ceacf3d4ae173b66deb129db22b1b6b6e2e502efe7a0e302",
       "sha256": "0x87146a7b284b1c9067a915930c0c6af7c99ff9dd1807e3680367fc03a59e83bf",
       "urls": [
-        "bzzr://c9a3d6a2b2324f8c47a00ac071c4c79181c28892342124342d66b350056a7bc8",
         "dweb:/ipfs/QmPTVaEGr5RWyNa6ULXbuYQtGW1qyEWbiy6AGqrk4qSQMH"
       ]
     },
@@ -248,7 +228,6 @@
       "keccak256": "0x6013590701af06ff53c10861ade4d52eec3005e6d730155f28fd04e3115d2d9e",
       "sha256": "0xbe08eb95cb3a1da52e918cf51a0c0397fbe7f0693145eb31835bf2924209f1e0",
       "urls": [
-        "bzzr://aec5fb36baf59e8f06e7dc721a1e27c3c59ff29a83d601cd971962fe3b6babba",
         "dweb:/ipfs/QmbDNEV2Nvrro3S5LZ5CwhcErd1vY7md715Rrsn6JBNTYr"
       ]
     },
@@ -260,7 +239,6 @@
       "keccak256": "0xccd306bccc95abb2eacb561fe3580de72c08a3be138c82b6962850f6fe4db564",
       "sha256": "0x0fde347db5e632fc3aef3ca8da74896d8df7a35287646e7fbdee829fe236054a",
       "urls": [
-        "bzzr://c93b2d5ff975e9213a9d2d2bfd3060bf36f4e4b6a9a569b09a2eb3f51345197f",
         "dweb:/ipfs/QmZU87uh8XYDvADWmkayr4kQ2sPmRD6E7kyrpanQzRgJfM"
       ]
     },
@@ -272,7 +250,6 @@
       "keccak256": "0x3657b60cb1f6a25ed8698b3b4de1720e71e35c3e5ee48fdedc6aca23e2eaff7d",
       "sha256": "0x718c7cc5818a9179d360ca5422c9f13a312a2baf8884f3dd8bbe3287ecaef0c6",
       "urls": [
-        "bzzr://ba603014c72546dbdf82c93ee3919418d5e36f34c8e46cdcb0ae5ef8b1688820",
         "dweb:/ipfs/QmWvL7waFJgJv2Mb74mzeHvM6px1QDs1P6TFyFxxacKm5v"
       ]
     },
@@ -284,7 +261,6 @@
       "keccak256": "0x5653c7311b09a6b04060e5b68bf28bb8d45d3179894f6ff3526c02c70c050ee7",
       "sha256": "0xf3c70a4d716b7b4e811ef5204b3ae6a16497ae701a2b86260d1bdee7e4484b53",
       "urls": [
-        "bzzr://ac1025b53049d2ecd2cce1e12ff2f4c1dcbb0855c1c90e470b5d40bdb0a21438",
         "dweb:/ipfs/QmTVw4eKdJZgc6m6RZutt6jkz1N6VkeMGg2XjoMqmudvrs"
       ]
     },
@@ -296,7 +272,6 @@
       "keccak256": "0x7b32dc1532f3813dfa8500f956c80d66c03f82ac220aff0156b8fc62b4d796d9",
       "sha256": "0x810c52cff29511f95c44f9a1ae2b11c04598d413d6ffa37bdb19415926fb5b37",
       "urls": [
-        "bzzr://85af46ad75bebc7a45987d0460c0de075b3e0161abd1b78d91733d5ff10a8852",
         "dweb:/ipfs/QmQxKe3R7iia439pkZEVA11TJLummjLQkZRvXkEHmj13gn"
       ]
     },
@@ -308,7 +283,6 @@
       "keccak256": "0xb389dda6ab00851f358e3cbc63225446ad25e040d41aa5f6d0e9652c091eb8f2",
       "sha256": "0x58fbe9bbb709277957fd12b922530f03cf558cf803b72333a2d76d54757885d1",
       "urls": [
-        "bzzr://f7d73e9b221345383d49629aee97feb49a454339b8c31a3ff135fd57685eaa3a",
         "dweb:/ipfs/QmaDkx6JGoXGe6u5Qc5k3JJfgUULnMUuppPNqCcEzxwLYu"
       ]
     },
@@ -320,7 +294,6 @@
       "keccak256": "0x26b8447660363201da6eeb1bc385c787665e021b10d030880652451310342fff",
       "sha256": "0x390d14ac47b4a01e4f804a57159ffa526c2329a0eb08b9e20dee00649efb3461",
       "urls": [
-        "bzzr://b439b715fae73a8c2471d8315575e4c79b541b0185e4f0da9a78ee08a903794d",
         "dweb:/ipfs/QmU8DmfWBdwWgTb5AZtkJeHBrxHkBV5dGprXvSVdh1kH2h"
       ]
     },
@@ -332,7 +305,6 @@
       "keccak256": "0x2b6c452b238ccc907e9522591e4716bb5413ee8cfa7c4e086a82c16487959011",
       "sha256": "0x3c9b2e8eb98d4294fc45326dafcbccb46a70993c346c7d3b55aa0292b3ca0334",
       "urls": [
-        "bzzr://eb8e321524b2f48894c1668da98f2aecbfd79204544ddc07353dbff57792c18f",
         "dweb:/ipfs/QmeWo82KNFgwHCyVe6Cqj6G8XJcMbEM7UXMdSNviaaMRmh"
       ]
     },
@@ -344,7 +316,6 @@
       "keccak256": "0xbf509bbb99e6ef89500b4f7ae7d7a7c4b85228ae71da485fe7d1c57d5533f78f",
       "sha256": "0x350d5abc5862dca43292426b6d4e592f81f40b02cda833f38406ba0047b6b9d0",
       "urls": [
-        "bzzr://318190b038a3eeaaa27cb5436fdcd27d27aa0bdd35c8462baf4e5cb2d6add544",
         "dweb:/ipfs/QmPAZqF436X578buawLseywFbvBQo54A76jaau9h9GEbZE"
       ]
     },
@@ -356,7 +327,6 @@
       "keccak256": "0x3087e10734e9af721d84795d384f4485927dadfa5e65aa0e648b2eb51dfec881",
       "sha256": "0x70b6f0a355385c5aea26c761b2e58b3216aa564f41e4e156813be3c47a66ae9c",
       "urls": [
-        "bzzr://caa56d91c1184ca7983dd9c6aa143de3f57f03290c5c8377de06cea4b61f68d1",
         "dweb:/ipfs/QmSFtnXbPxR5mJbZwrydD6ABPLJ3hNuBBux2hBtVen4yi6"
       ]
     },
@@ -368,7 +338,6 @@
       "keccak256": "0x98b18283a9a1da352430e948499d5d548acc760b84f8a56d1830c4ec8e4304c3",
       "sha256": "0x5b62105e89c229f5951d05f2b19af81163599c7f0decc04af81e253996366aaf",
       "urls": [
-        "bzzr://3370e2d53cbccc0e70ddf342bd7fdddfbd6c583fa4b2c335597a0ab73c06e81d",
         "dweb:/ipfs/QmNboEZDcAnbuHki5Apz9G1nYnaeMRrmpazGT3p72jb8Z1"
       ]
     },
@@ -380,7 +349,6 @@
       "keccak256": "0xb440f4b7c3255a977c55e8cb920777a97ce92ad565cb016eab6ebedd43a54d46",
       "sha256": "0x48454e290effd1b9b2aa860013deff09a79b4d7472875a07f3e7d547df297ecc",
       "urls": [
-        "bzzr://d392a01d93bd53fca27da9126452b7240577e1541144521d76616232665ce4ed",
         "dweb:/ipfs/QmX7eboJmijaznyXcBERoc64rWVwXQseoBuemAz7TieUta"
       ]
     },
@@ -392,7 +360,6 @@
       "keccak256": "0x43f5c0bd6454961553e545545b01f63cd211bdf4c1bff904236c308b1caa0456",
       "sha256": "0xbc816f2104d0e316179bce69afcf24a48b5c6c7203cb72becad7d9e7b66990b4",
       "urls": [
-        "bzzr://6eb5b621d876347c431700fbed4853eb598d3506c5911df918283ec4452afef9",
         "dweb:/ipfs/QmYMz5h8r9mu29uYtdLSqB2E8mw9CxHs43f9KNmUwQVAGF"
       ]
     },
@@ -404,7 +371,6 @@
       "keccak256": "0x6b11bfff1870b2b6410a4a9d97c9142325770c80e3620b05b7f78a7fa1fcdecc",
       "sha256": "0xa15f01700ec7e02f91bbdfd4b6ff4450b3c2decae173e4f41910a3cfbaf5d3d3",
       "urls": [
-        "bzzr://259dcd9c09bb9fbb50fbb3fb4b97a03cfcd47c3fb99fd7b75be10bf4c59835d0",
         "dweb:/ipfs/QmdyLZQ1LWwx4joeUYMN7rxPkDp4wDdMCgmUoDNQU2J6KC"
       ]
     },
@@ -416,7 +382,6 @@
       "keccak256": "0x7e3f9626d004adbe0b835b08ebec2c0373f46dbccc0b2b36119c545ec27ff701",
       "sha256": "0xc35ce7a4d3ffa5747c178b1e24c8541b2e5d8a82c1db3719eb4433a1f19e16f3",
       "urls": [
-        "bzzr://f9f1f3d03d7caca5683f5206ea2439d85183d086668bba688fd095ac9d67384d",
         "dweb:/ipfs/QmT3q4iWxzcF8X5ArX6vQpQue6f6rBP86cvti4udk6gMbC"
       ]
     },
@@ -428,7 +393,6 @@
       "keccak256": "0xb93ada00cffdf9bedc152f8a095c7694cbf16f9f0d0be5d27ec44814fb4b67b8",
       "sha256": "0x5c4b30da18b0fa5f1ae3183127a4dcd64a279fcc15e16a477b0841d576770283",
       "urls": [
-        "bzzr://ebe627323633c0fd23bbfb17ced455db9786dff2d30d9be30232d0076660a8a5",
         "dweb:/ipfs/QmYZEbZxXVZbapmzXdea86J4e6RAADa3kyFTNrqCWoiiJk"
       ]
     },
@@ -440,7 +404,6 @@
       "keccak256": "0xe2087f40f53b10f8c28d84c5062da1659d99ad299a4d1549ba676163d7d682ff",
       "sha256": "0x499c2aad132ffdf7a59ce87d88e4fece2ccd63f5ab7e283b1be4c722b06206cb",
       "urls": [
-        "bzzr://c04235c5dedee430f9013641993ac5ebc7d76c94b656ec4d94333217e3aab066",
         "dweb:/ipfs/QmVgKp1VC2vpGcdGtEgopvSiefLKzqHzKEnUf2gqcUzQj1"
       ]
     },
@@ -452,7 +415,6 @@
       "keccak256": "0x876d2cf22bbd0e036ad1d5ec15b7d611907319014d27832356001944dfcd19e9",
       "sha256": "0x109ca8c6b92f4548e78c72a64c47c614617d7b2b5e4b6f8b9e7d654fc5186365",
       "urls": [
-        "bzzr://4cd19e2db58f63d3bf597a478aa7152e44c9c25284d7d0f8ab140ddd5920d931",
         "dweb:/ipfs/QmbUMYf94qPgf4yypkmCgDdkUwViDpQJ6Wk5GAdmcoAwse"
       ]
     },
@@ -464,7 +426,6 @@
       "keccak256": "0x69fba2b6f43131c1a1ad71bd79938a83c320bfe58066f1b8c3de5c53b17d2c21",
       "sha256": "0x601f874e2a52c759ddcc1074cb75c12848e2ce899a8746a43e2affbd28a655e1",
       "urls": [
-        "bzzr://0c4192b681918edb569a86c907f1e7efcb11b0cc1243c743fd58540cf4952bb7",
         "dweb:/ipfs/QmczLgpsCYbhNEVkcm3A8XsussFXBa3rBd4cP5N8n7thoZ"
       ]
     },
@@ -476,7 +437,6 @@
       "keccak256": "0x6caf7161a0fc98f00aa278f8adc243e2945282a5f9a64cb7ad215dcbf862116c",
       "sha256": "0x96ddd81ea7d94d6e7f1135f7b11ab1d0635ad5585ed94147f1fe39b1ab7266fb",
       "urls": [
-        "bzzr://bbfeeb7c451be78c94f5c8bd0d5238bdd59fb48363bd7d7f07f7ed8c3000de8d",
         "dweb:/ipfs/QmQsiknhp8sSbDa1Yz3Pxs2jJTAMBFnXTJke2YqsgJmFdL"
       ]
     },
@@ -488,7 +448,6 @@
       "keccak256": "0xdf597805353d77648745b8fcd9280cf03bc9ccbadce9832df6a94dd63f2164cf",
       "sha256": "0x33276adff8f0e620adf71c4ab66d748d0690c34360ce4f55e0d18c77fa13476d",
       "urls": [
-        "bzzr://cd7ee6bcef98c2825cf62e5f1d9224c357c2977862d9aa504d30fd94fb1d0666",
         "dweb:/ipfs/Qme5AoEsw1knaoGJk2GhwBbHpxFcaxJoRnvUip2qqqZMgh"
       ]
     },
@@ -500,7 +459,6 @@
       "keccak256": "0x802424b83dc8a24e867dfb26b5e63ab553f01ab0529690c420b54d3517c5f953",
       "sha256": "0x5d8cd4e0cc02e9946497db68c06d56326a78ff95a21c9265cfedb819a10a539d",
       "urls": [
-        "bzzr://8ef79a241e86c95822e096d2fa48b990673cbb53102265d9ad6732238a8d3604",
         "dweb:/ipfs/QmfUrBizg8wPJcY5VX166LEidWNyT2GWjqunEVJHY63o9E"
       ]
     },
@@ -512,7 +470,6 @@
       "keccak256": "0xb287de7e2847e25b8b07ce260ac6a69ff679b35e1657f29840abe29b07b1e1b6",
       "sha256": "0x20263aa17c2e7ca8c10ecd3d4242df61db9d549bc1ddb72b9a387c0c1136c1cf",
       "urls": [
-        "bzzr://e916a33d8b35fd712dcef219aeb08bdf17ff0f9e939c0765a5d83fa07e36c6e0",
         "dweb:/ipfs/QmcR4mBvu2unSmwCD5AXGt1r8cPv3iSMM8cdHc8RKy919R"
       ]
     },
@@ -524,7 +481,6 @@
       "keccak256": "0x79a7f7af2d8730ccb11d9b21f20cd033c1c0dac58490976e202f0dec24587c58",
       "sha256": "0x9f76167c78635cd048ca30e75d9dade57ea6f0d03b83384d640d5da38e8c580d",
       "urls": [
-        "bzzr://77d79270a51ce044c8525d1de127a6f2c303751d558bec1bef59839f4a10aaf6",
         "dweb:/ipfs/QmR5GGfqrm1cK6wg6h2D3RjqmV2Gn45emGXGVp6nxWSdyN"
       ]
     },
@@ -536,7 +492,6 @@
       "keccak256": "0x8a2ed47fa7e1df9ee005ef76ae177619c5f4e7ef2fca378d910787834edf66a4",
       "sha256": "0xeb42bef5784a0dec0f1b54c260b376deb0495940bfd474c44b5be31c0b634603",
       "urls": [
-        "bzzr://21ae78060cf6faa09fcf7823bab119e10d6fc8f89f2ea3f54bfc3092a394e28a",
         "dweb:/ipfs/QmZuLUuX3FgzFLCiEtzHMeaaRqiyvhJRnezxGg6Tk2zNkQ"
       ]
     },
@@ -548,7 +503,6 @@
       "keccak256": "0x21fcb7912ee577def32c50261fe40b7b5f47e31889a66eb24f5c0173b76430aa",
       "sha256": "0x68c414ba78325570a34817a829b1f3c62a18985708a2509729b50f79829a374b",
       "urls": [
-        "bzzr://07ca755f5c200e94effb587ddb9870618e5b8eff3cb2d4b6320db118e1ec70e8",
         "dweb:/ipfs/QmeB2irmzLRG4ijqZepyVKzRptu8LXHisBUYsHD4xJxfqD"
       ]
     },
@@ -560,7 +514,6 @@
       "keccak256": "0xb86c9264dcf7f5c95fdae2152e585e0ae27cca7473eb3846a8529bd7f201b031",
       "sha256": "0x2e091d5f13bea0bc445c7f674d5cf8c9e42a3d4e35e1e50f00f4dd44898505aa",
       "urls": [
-        "bzzr://77cd25017a79f47a4a7d89ede8e6dbd444568da0434d6b23a562ada1d709526c",
         "dweb:/ipfs/QmTeKeZRbb695CuVMFtxChsM2B7zLEb9Yc69bDLCerPtCU"
       ]
     },
@@ -572,7 +525,6 @@
       "keccak256": "0x29aa693df3ed607f8dad19d47eac620c3db0e3f80eca94500b22c0f9975e6cb7",
       "sha256": "0xf6cb519b01dabc61cab4c184a3db11aa591d18151e362fcae850e42cffdfb09a",
       "urls": [
-        "bzzr://9c92be120b892904eb7fb993724e9afcefe1acb49c8b53a71e6e154bf0df8fd8",
         "dweb:/ipfs/QmW2QNCj3nqoBsNjJCQX5sg6pNKUoU6SjpVgvJ6j5P9Qsr"
       ]
     },
@@ -584,7 +536,6 @@
       "keccak256": "0x2835bcea8a4bd76205a1734604747c3418039a78395034be4e25323689c34921",
       "sha256": "0x117454791903d34587b7b07626c03253c6d4472b6f09f72ee007cf1f220b49e9",
       "urls": [
-        "bzzr://4c426ab9c8545eee06aeb8288430e6653c1325b858b0e9cba99e26753b1b80bf",
         "dweb:/ipfs/QmUKUg8pGVUiSdcoZCKbk1dctFxvuGpMN9QjHb21RhUqYL"
       ]
     },
@@ -596,7 +547,6 @@
       "keccak256": "0x2e51df133f8a2a242ba061662ab3eaeb4443b4d903ebfa2e73dd264bab06294a",
       "sha256": "0xc0c49402eaf18353e6bfb8fdc72627eca5d2d63fb36a5ea787114dee949799aa",
       "urls": [
-        "bzzr://f27ee269598fa41541b53d7346b679d2851c2425c000eced8c4734e5c50b3f41",
         "dweb:/ipfs/QmTjxYdpykbUKJVMp8sCsdU6pLsYJuvthaGupRdu19TGVg"
       ]
     },
@@ -608,7 +558,6 @@
       "keccak256": "0x0f1fb44ffea640ecd278fbe68859391fafa076183e9e5d3a2684c7eada34a7d5",
       "sha256": "0x759930b396cda0d17621dd6eca8aa16a3570145960254431e6c42e81626e5a10",
       "urls": [
-        "bzzr://887fae3c92d4ddd0fb35f17a10060c20fdc953b95a602c1cec62bc84bf756f70",
         "dweb:/ipfs/QmVBDrv9CPZBnucUNASqeV2gWdJzTcqDJZr1mutw4TKB2u"
       ]
     },
@@ -620,7 +569,6 @@
       "keccak256": "0xbd9427ebf103bc57b76c2d58b56643251bf4070aa573cc53bf10b0e1046307eb",
       "sha256": "0x2a17dea3b1785eac45e6af0ce328af68eb943a6463b36e03d31d99d7651a28b1",
       "urls": [
-        "bzzr://14a344535f797bb68fcac5061834d2510c24a0ccf1be3029d8d9dd8d7a389a71",
         "dweb:/ipfs/QmcrNXLFH9Q7t6L94ZHSpUC4oTgL9sp5qYM6Ws8zMP3TKi"
       ]
     },
@@ -632,7 +580,6 @@
       "keccak256": "0xc0276f1a865e4403c24172c53a540b5c6177d1aa52e0631b2d4689c5347f51b5",
       "sha256": "0xe0fa6a8347a52bc6ec351e22537e645be06eb5041894460b1a9114f3732e9d07",
       "urls": [
-        "bzzr://825d909b0212b5c62a22315a29afd7ffc49e33efaafde190ad2cf5015b1387a5",
         "dweb:/ipfs/QmbwNDaZBPRpcTKrw4ersHpidTuprKwc2A4Dub5hw2QsWr"
       ]
     },
@@ -644,7 +591,6 @@
       "keccak256": "0x843edb5865c0668a6c7047af388ab8d3a6286006fe8ea8b3c3b2da1a873fd633",
       "sha256": "0x96fb22134c10939334c62c8c0a668b712696f8f81426e6fcf042f0e709e7aa1e",
       "urls": [
-        "bzzr://37a486de05ca46f2214e89fc2fbf80bbd985e9a9f7af191350de517566444840",
         "dweb:/ipfs/QmWuiwFpMVA6Fwnfmt75BHbJ2294P7ZTcSBH9iUxz1inux"
       ]
     },
@@ -656,7 +602,6 @@
       "keccak256": "0x995f7d67d87a936dca9922389e6bdbfd2febb3aabe52beed5a43f73fb45a5146",
       "sha256": "0xbd69ea85427bf2f4da74cb426ad951dd78db9dfdd01d791208eccc2d4958a6bb",
       "urls": [
-        "bzzr://dc89697408277a96a802a0f84f113a65cd0923206403d6c6cda9a99f9071c5f7",
         "dweb:/ipfs/QmUr3dNEKNCvsALhMb9NAhiX6otFBGfNpSXniLUn87hSoC"
       ]
     },
@@ -668,7 +613,6 @@
       "keccak256": "0xcbc4fc0c2aa7976afd378608aa5702e2d53d5df325c0c29c894386e5cfe7d327",
       "sha256": "0x64016310a57caf1af76a3610f1f94c8848c04c9673e7fa268492e608918a4bdc",
       "urls": [
-        "bzzr://a541fb3df5f6b7ebe0716a958e83dd540ef820ea7b40d9835962d219d4670cd8",
         "dweb:/ipfs/Qmas3dcZXXHwBtPp9aKCxZfVoJL17ndUHSUdBc2cLzJkZh"
       ]
     },
@@ -680,7 +624,6 @@
       "keccak256": "0x0fbc7448fd94f69159e28505bd9afe1a6fd3659a4651884409f04f55cfbad754",
       "sha256": "0xdaa7f6d6cc0a316beb2607533183b64904798677b0cb99bda0549ea70e8de61a",
       "urls": [
-        "bzzr://b3f593c602c78873a90c3b558f1d5ee7587e1833b294630f4c9d03ba8850fcc7",
         "dweb:/ipfs/QmdsHDR2fbRsfEo2oorumuRsdAGXwhgFyssHSqcWV2eqaR"
       ]
     },
@@ -692,7 +635,6 @@
       "keccak256": "0x1cd8e6d1f694fd6287882c57043a0ac6212788eae7c9ea10125b5ae85a3a0e27",
       "sha256": "0xb6b9429d71d4395901795936a0aaee0b23082fcaee10d563d87b42e69c0e68c2",
       "urls": [
-        "bzzr://bf4d50233cc84b7d827494fdcecdfa0b273811e02b6b920daee0440eed77f0a7",
         "dweb:/ipfs/QmXb4CcPVvKfnst6xP7W8oeEY6XLCd9LAMzpKnk6PEu3gJ"
       ]
     },
@@ -704,7 +646,6 @@
       "keccak256": "0x8544a5953ba29ded6dd78cba0343c15bb99f0994f8252527c1d8ab82d49f75fb",
       "sha256": "0xfb33afd761d0d704671dad582d3b4a790d4d85a6370fe71b3f8935649681e292",
       "urls": [
-        "bzzr://95d6a343a95590a185e7a34419ee0a55b1870979206f6d30bb1e780b33114d09",
         "dweb:/ipfs/Qmb1AFeoZzpy32zDG1A4dqRXwk6idm5z6pnxkv3rU1toLV"
       ]
     },
@@ -716,7 +657,6 @@
       "keccak256": "0xd13637ffb69029cae89a865066e78772d3264c0d05674c973a637c768f588f61",
       "sha256": "0xf7115ccaf11899dcf3aaa888949f8614421f2d10af65a74870bcfd67010da7f8",
       "urls": [
-        "bzzr://2f553b9aa9558949b90795e49298cb74ccd99b71bf44f1b038bd4f9722f64328",
         "dweb:/ipfs/QmaH93CFvM25yNszPFokJqsGhoEs38fT6ib6M2WQwhwxqg"
       ]
     },
@@ -728,7 +668,6 @@
       "keccak256": "0x81b1b9610c05be13dd2294f1419c095131763187914358501d85789c3c051ad6",
       "sha256": "0xbd782007a7d50500d22703145ace6d44c916c853cd0d0fcb2caeab9fa5fa33e7",
       "urls": [
-        "bzzr://9b2f9cf220a2e42f3f33e7fa473aeddfb31f30d0a2acd933c75a73a507fb974d",
         "dweb:/ipfs/QmaVmPWbjGrVaS9H3XEKqR8J9cYfqAPobAMjzRGNVwK2Cb"
       ]
     },
@@ -740,7 +679,6 @@
       "keccak256": "0xd82f930c3db5da803c7b634bfca624279967da3a53bee1e2cef5b74057438a2d",
       "sha256": "0xabd5c4f3f262bc3ed7951b968c63f98e83f66d9a5c3568ab306eac49250aec3e",
       "urls": [
-        "bzzr://4815ed102dbe75cde56e0c2d89a340c601c6b86e78485937bb2ee2b3a1951f2f",
         "dweb:/ipfs/QmTVGXJndEL6a8XHyxqsdZBh36BV3GQzZtV327P5TD8pfp"
       ]
     },
@@ -752,7 +690,6 @@
       "keccak256": "0x0163c110432e288bef6ef2c7e7c043e887459f5aee018cfa8f5a95f1a5d32746",
       "sha256": "0x003d75383e45212f9812d0b6add90329fd3b239e6c378d2882f61f9345896d99",
       "urls": [
-        "bzzr://4f16ed229bfb441868ca5cacf6005671a0fc6715c098c9732b6cf306bae1ee5c",
         "dweb:/ipfs/QmW3LxYgQHDcUQp1SYMmHNRoLDrKyY5hh4czR5ZoJ1ByQv"
       ]
     },
@@ -764,7 +701,6 @@
       "keccak256": "0xd2f57fd0233d9ba2bccfb29498da59ee02c0433e07b9a99bcbd789b0cadfe99b",
       "sha256": "0xe677b1216b136c61e38934a3de3a8e67de3f733d7ab28f0f046bd4a078b0cbb0",
       "urls": [
-        "bzzr://6354038df1fc237e1f501ad38f8270b70e05481de75ece157b316abd58656886",
         "dweb:/ipfs/QmUfzeuKDqyhGtFK3SB7mNFth4jXnnaSA93tsiFWVQVro8"
       ]
     },
@@ -776,7 +712,6 @@
       "keccak256": "0xc3a70946c825ecd5d7ce2db1ff2e9a608f1319e8912cc10bd1be9d171617066e",
       "sha256": "0xf851f11fad37496baabaf8d6cb5c057ca0d9754fddb7a351ab580d7fd728cb94",
       "urls": [
-        "bzzr://50b453a11c6b9a1f944cec38d4fd803abb75a4eb4a592592a769c38d773b5415",
         "dweb:/ipfs/QmXV9woKT7inPFZEMhp2QiSnR7uMavef9CnBJoMUMdWVcb"
       ]
     },
@@ -788,7 +723,6 @@
       "keccak256": "0x915372f0d78e22a4fd337d3b0f13a7fe5aac57ec120639e7ebd066571a8e4420",
       "sha256": "0xc7effacf28b9d64495f81b75228fbf4266ac0ec87e8f1adc489ddd8a4dd06d89",
       "urls": [
-        "bzzr://6303ebb014b5fefc0a72f8a0c034994f8ad65c0c7394e8ccca37ea780e6f2866",
         "dweb:/ipfs/QmSq2hGDMwASXwvEgZVkaUcpfBMwzQEWDnPEFdPTyHabmm"
       ]
     },
@@ -800,7 +734,6 @@
       "keccak256": "0x222e13f9ebf5119083e555823669a7e537475450986bd1d095124e240d98e21c",
       "sha256": "0x717c239f3a1dc3a4834c16046a0b4b9f46964665c8ffa82051a6d09fe741cd4f",
       "urls": [
-        "bzzr://4d8a2aeed9af85852274b64edb3b8512e5680e9ab219d712383e5bd1957efbdf",
         "dweb:/ipfs/QmTz8D5wkVmW4jfMHMsi638XBXQc3fWZqk2QJPz2Hk5Jos"
       ]
     },
@@ -812,7 +745,6 @@
       "keccak256": "0xe18e051fd3770fc0f2678ea2975b33212feba0f5bdbece0aef0ac96265a218a7",
       "sha256": "0x556c3ec44faf8ff6b67933fa8a8a403abe82c978d6e581dbfec4bd07360bfbf3",
       "urls": [
-        "bzzr://ccaf2bc010c8d3ae9dc3d2c83092a1ee67dd2fbb34fbed42a08c5b315e84cdf1",
         "dweb:/ipfs/QmamYEMfG154iMNydETqvGnpQDWGXEmu7cg6YHmKWDbNqQ"
       ]
     },
@@ -824,7 +756,6 @@
       "keccak256": "0x789ce72e01f83cf052b543d6f0508c2ed2adae7ed40ea37913d9bd90166040ce",
       "sha256": "0xa805dffa86ccd8ed5c9cd18ffcfcca6ff46f635216aa7fc0246546f7be413d62",
       "urls": [
-        "bzzr://73cb255e06cd0f1eb3abf03dcb915f4843728f2783e3535c76f547b87eeb829e",
         "dweb:/ipfs/QmSrfbnJcgUXUjT1oEAMQ77LC1MeEDxVfMGYuCJVRnogTr"
       ]
     },
@@ -836,7 +767,6 @@
       "keccak256": "0x73c9a363ad79aa396a706175521b9ccb41dce2a2eee9f04b58dbac87b1fc8614",
       "sha256": "0xd5b027c86c0f8fecc024d5d4f95d8ea48d8a942d79970310e342370532b502f0",
       "urls": [
-        "bzzr://a46ac2b6fa96c949a6f70c05b07f378d565ae51f0de1b6bfb5ee4dbd13820019",
         "dweb:/ipfs/QmPpPcCq91ufSe3ZCNjWs26nuGEuuUNLcgX5Sa3y3wPiPk"
       ]
     },
@@ -848,7 +778,6 @@
       "keccak256": "0x3811602585e07c5404735f5bd329b11619a855f40ff2e1428bf95cb10c1a57ff",
       "sha256": "0x5189155ce322d57fb75e8518d9b39139627edea4fb25b5f0ebed0391c52e74cc",
       "urls": [
-        "bzzr://151d8aa0efc4c02e7d5656b9d2b926dedd3207ca010f787bf2ecc0564eb3c3e4",
         "dweb:/ipfs/QmWdaqCBgtJyXJS5R5CbUYzxqbBuPxkKnKNxVmUtFGf2Zd"
       ]
     },
@@ -860,7 +789,6 @@
       "keccak256": "0x88dde999590940b17b34e657c40067918e0078b3d903548d4ea44fa259ff2b71",
       "sha256": "0x1632786c6c1f856a4a899232ec975a12f305118f43cce90e724ed0b2eebfeee1",
       "urls": [
-        "bzzr://3061e1e12ffcb7dbe9f7b198bffa3a3fbd0d484e27ca96888b9b944a384e8b2a",
         "dweb:/ipfs/QmSzG1PQR93uiUs3ov12vetPkfvJzxQZyfpeVh5WMGW4Uk"
       ]
     },
@@ -872,7 +800,6 @@
       "keccak256": "0xca03e8f6474b5becc8c28ad61830a23761e28b0dd53a6c89d48be89ab82e3a34",
       "sha256": "0x99f2070b776e9714f1f76c43c229cf99b8978a92938ee8d2364c6de11c1a03d4",
       "urls": [
-        "bzzr://f564ec3270c16b1bc458d9162cf10f26dc5d0a5884912423167f973a6dd63f96",
         "dweb:/ipfs/QmePhTsZLZJfEsMSWpB36NRx7vZQuwUoysGgKaEdZLtnHb"
       ]
     },
@@ -884,7 +811,6 @@
       "keccak256": "0x932901581a2ef0795851363522811fa160db5561e34cbb306e7105b6bbc3834d",
       "sha256": "0x95e6ed4949a63ad89afb443ecba1fb8302dd2860ee5e9baace3e674a0f48aa77",
       "urls": [
-        "bzzr://61828ca55d703ddcd2ceff0e20a48ae6bca28a58b09725836893dc5f6b8e8018",
         "dweb:/ipfs/Qmf68UBPAspGAh6TJ1F9zKLFy3WjvH6W43HvzWWGAUQXTv"
       ]
     },
@@ -896,7 +822,6 @@
       "keccak256": "0x8da560f93223e19fbd973f12a29f765869559274aaeed3f795738ac433130ab9",
       "sha256": "0x7a5c1d3dc9a8eba62bb2ec37192c9178ae5fe8a54a56e5573fd3c9c17cd9eb48",
       "urls": [
-        "bzzr://49229e5b39418fb70d9aac067baba0a745ad1ce4c01ce1a97fe6a73bc416140c",
         "dweb:/ipfs/Qmdpou1M3LCvJNUihLD2cmopbpbeKdhro1YvkT7KfpaTvt"
       ]
     },
@@ -908,7 +833,6 @@
       "keccak256": "0xd68fa7092d5af50c1dca4d6318f8a2470b11a766794814e505e3cc6a587deebb",
       "sha256": "0x0479d44fdf9c501c25337fdc540419f1593b884a87b47f023da4f1c700fda782",
       "urls": [
-        "bzzr://ea20fb34f982032a6bc6dcaa895429b859d7cbba5f80ba2b3343df65c77f2d2e",
         "dweb:/ipfs/QmVhca2opoR2DEY7v9ntXHETfytq1jRMnatid4UuLNCMyp"
       ]
     },
@@ -920,7 +844,6 @@
       "keccak256": "0x00bebaa90cfcc8c807b6b48cd8e9423bdbe5b7054ca0e47cbe5d8dd1aa1dced3",
       "sha256": "0xf2857a898be15c69e8de5598dcd3f3e169e94964a0ce9a0bbb1b111f145a81df",
       "urls": [
-        "bzzr://b22588ecb5c35fe0754c755b50bd1a1a7533171138e04970fc9c4dd2fcc269cd",
         "dweb:/ipfs/QmagT6RpAi56zzW3GiFED6q9ztbgrp5WXomBzisbbRTYPg"
       ]
     },
@@ -932,7 +855,6 @@
       "keccak256": "0x0e8190e07b0928bb7c9523cc5f992430fffec6bccc0dd4bec7937039ceac20b8",
       "sha256": "0x8be0aeb74fc1b8213292a09a84cb524a403602526df87ecad5f5cd2a7ea7d089",
       "urls": [
-        "bzzr://e51e0fc25e86d76b070a9e1f97fcbd16902f18cf77688782388a6731f1635d1c",
         "dweb:/ipfs/QmNaGrJcjMiTU66QndCZMSHeTv2WbCvWyP1R5KankxeZHt"
       ]
     },
@@ -944,7 +866,6 @@
       "keccak256": "0xf105026f42acb32bdad8d3dac86bfb37db9d9efdb0c730ee509a9cf3fdb1ec1b",
       "sha256": "0x28726a452290c70e1984f15c53ad3088e7d98783ee3070b11b3664da77415732",
       "urls": [
-        "bzzr://57ffacd9e36ddad5f6716914cb652c6ceffe72c5539b39a7ee88941d6fe939ee",
         "dweb:/ipfs/QmeC2pQS54j76BP85Akhsv1XEejqv2zxyK4mJvio7Pu9h4"
       ]
     },
@@ -956,12 +877,59 @@
       "keccak256": "0x5a127e73ef8c90f2df60ff2fe9dd79709da9e90d2d075cf05784c9a3efee2528",
       "sha256": "0xfb03a29a517452b9f12bcf459ef37d0a543765bb3bbc911e70a87d6a37c30d5f",
       "urls": [
-        "bzzr://696eac6b03201fe1e090f793ff3abcf862d738195e3db0da14c1cae1dc9315f6",
         "dweb:/ipfs/QmZ5YMZQfiLhjiXoPQBxJyY1KPVPzhUXDbD1B7bYQCVKjQ"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.25+commit.b61c2a91",
+      "version": "0.8.25",
+      "build": "commit.b61c2a91",
+      "longVersion": "0.8.25+commit.b61c2a91",
+      "keccak256": "0xce0797c0c76867d0bf6a1557961af6b9252faeee4f4802ce91d0b51c9b44e7c4",
+      "sha256": "0xc42aada7a52057ddbed93ec011235e256c564c440b68dbaac5ae482babbb3d6d",
+      "urls": [
+        "dweb:/ipfs/QmV7iyWgYrW9B3NzKe3SHZU9hN9MkHFVrGCHxA13MhmMqX"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.26+commit.8a97fa7a",
+      "version": "0.8.26",
+      "build": "commit.8a97fa7a",
+      "longVersion": "0.8.26+commit.8a97fa7a",
+      "keccak256": "0x9d138fc8bb5c20b4aaaa3a868d16eb897584ce8536a5c3a466d718e47ccbafb7",
+      "sha256": "0xd5f23436f443edb85d8e76906d12f0a86ce0490e7663a9e608efeb7a93f149ef",
+      "urls": [
+        "dweb:/ipfs/Qmctr14Exi4R3nbhcg3fYsMDesZ8PBzfgPpLfprvFy7ANZ"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.27+commit.40a35a09",
+      "version": "0.8.27",
+      "build": "commit.40a35a09",
+      "longVersion": "0.8.27+commit.40a35a09",
+      "keccak256": "0xdd9a58bbf98ace9b223b2a9431c6d37dd2cc2c5c4ac9813d93f0a3c62e83882a",
+      "sha256": "0xb9977d500c17cba6f0032ca939ef98c4decf6363f19f386d05fb02f708115264",
+      "urls": [
+        "dweb:/ipfs/QmaWSdMdzChrC1sThBpdTorsxaJFZ1yCRJXkK47WycFxeb"
+      ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.28+commit.7893614a",
+      "version": "0.8.28",
+      "build": "commit.7893614a",
+      "longVersion": "0.8.28+commit.7893614a",
+      "keccak256": "0x0d387f5ca7d0f298e79243cec5af7ab42eeb0a414e42f15c66f855d701479c43",
+      "sha256": "0x9a0fb7e0db2c0641dbae1c5cc645dc686820c83af516226abb1c0a2f76636f25",
+      "urls": [
+        "dweb:/ipfs/QmUQHJwVw1f8RCRTBReXEkXdpt4c3A3LEpHZWv4pRixrNW"
       ]
     }
   ],
   "releases": {
+    "0.8.28": "solc-linux-amd64-v0.8.28+commit.7893614a",
+    "0.8.27": "solc-linux-amd64-v0.8.27+commit.40a35a09",
+    "0.8.26": "solc-linux-amd64-v0.8.26+commit.8a97fa7a",
+    "0.8.25": "solc-linux-amd64-v0.8.25+commit.b61c2a91",
     "0.8.24": "solc-linux-amd64-v0.8.24+commit.e11b9ed9",
     "0.8.23": "solc-linux-amd64-v0.8.23+commit.f704f362",
     "0.8.22": "solc-linux-amd64-v0.8.22+commit.4fc1097e",
@@ -1043,5 +1011,5 @@
     "0.4.11": "solc-linux-amd64-v0.4.11+commit.68ef5810",
     "0.4.10": "solc-linux-amd64-v0.4.10+commit.9e8cc01b"
   },
-  "latestRelease": "0.8.24"
+  "latestRelease": "0.8.28"
 }

--- a/pkgs/foundry/svm-lists/macosx-amd64.json
+++ b/pkgs/foundry/svm-lists/macosx-amd64.json
@@ -8,7 +8,6 @@
       "keccak256": "0x662f94643bbc549d00fe7cfdbcdff504c78c697b10dcfca645d6082d464c1402",
       "sha256": "0x02d581b5b373d8160b9e75d690dd2ee898c3e0f6a39bbda54cd0698224c09df4",
       "urls": [
-        "bzzr://f8f4ef96514fda43ca31517a4f493aef6224d72ead70ac0b4cc36a5d341901a6",
         "dweb:/ipfs/QmR59SfyA5TETyhBvxgZBvhedSZyA9Ka2NPBGVbV9CknYf"
       ]
     },
@@ -20,7 +19,6 @@
       "keccak256": "0xe15cdf6bfd7a87c22aca862df0ed268c56d0a3aed404c56c92aaa1c02b4738c2",
       "sha256": "0xbba6e2c33935259c478060501a7fb0ee1db4b0c56567356c9d01b6ec0491a558",
       "urls": [
-        "bzzr://e130cfd6a4369d932e02220b164417ff025a6967ac2a4f4241140eb08793c8f9",
         "dweb:/ipfs/QmWtKJmhaLmaLsqQW5Bptq6FADF7WCaZkmMQdKdzi8bdUw"
       ]
     },
@@ -32,7 +30,6 @@
       "keccak256": "0xd0142f44be7a230ff448237472451521abbabcb5d75d388346d1b7cd1e9e6962",
       "sha256": "0x2de730163c80670b2f4c1ef78dc77ab13f757aad1ead044761821293275c382b",
       "urls": [
-        "bzzr://441e085a6f97965273b9dc0cae1870fdf769473db11aab99a9fc1dbbe073e7b3",
         "dweb:/ipfs/QmQhL9fPTox8eJsiSxzFyUjZ5G26sy2BVUSYXLya4KpcWT"
       ]
     },
@@ -44,7 +41,6 @@
       "keccak256": "0x1b25df7ffcbd8bd77346482483164905ec57837bca8a6035aa4d32beb11434ca",
       "sha256": "0x9882bb966b82c0f4847735dba20b517118cf5408ed2a872485750f6ff26cf98b",
       "urls": [
-        "bzzr://5d6baebbb6372afa3c0d6185de44709dc9fa0a69b239bcc06612eccd44f80216",
         "dweb:/ipfs/QmcjAyKwEdj93CTgL4DNYwgSzigb6ZhBtEzWpXBjs4xJvr"
       ]
     },
@@ -56,7 +52,6 @@
       "keccak256": "0x41d167822f3ab9cf03e4e3dcb800aff49a93cbd2b5ea37941777df80a5bef69e",
       "sha256": "0x3ac02a93f4c7c20b9f17b6038af25b41acb8cfe178040be0f2246adc8bb8fe0a",
       "urls": [
-        "bzzr://03a77f58631ae16e81aa85c6dacbc6bc2ca7c34c1073171e2562ef0738979570",
         "dweb:/ipfs/QmaZZSYJV7pYHTDJTX44UsVrSS8UkCX2xBx3FhYyjzP8bn"
       ]
     },
@@ -68,7 +63,6 @@
       "keccak256": "0x66721111ee0d4c3d718832ac2150fed55b3d61baa4fcf0f3bfcfd6d034f7515f",
       "sha256": "0x38ceeea801b5952d74bdb79ae5bc6bbb4c187ee5941e2701de388fdf95322f58",
       "urls": [
-        "bzzr://fe16871dbb1f5ae55e7fd4a2feb2e57f10fbe9ae240c408d74e4821544a71cfe",
         "dweb:/ipfs/QmWcNcnW2NiHiY4Lm1DaEWGgiBnHcDh8NjAJzmxtEewHC1"
       ]
     },
@@ -80,7 +74,6 @@
       "keccak256": "0x5171e0d6ee047330e44c5b041a579aabe348482145405449cdcdf70c089db66c",
       "sha256": "0x003b09c2f255d2a40c2b2a1798192f92e6a3f1b35bda1a35ba66675919be1555",
       "urls": [
-        "bzzr://77fac88430da037b2559f5023168624a071f4ecadf5ea6c65d9689a2e1f829cb",
         "dweb:/ipfs/QmTVDBJBqUyoJVXYYAYGsL3udgx8QrTcTMAADottWRCYpi"
       ]
     },
@@ -92,7 +85,6 @@
       "keccak256": "0x6ad5195014b546f57e6dee05a5170dadbedde6f657893da05d9da1416e45e2f0",
       "sha256": "0xaef1ebf2d2783a31742a612461f13e0ffc656c4a5ce25a0eeb747186ce03b276",
       "urls": [
-        "bzzr://2aac1f5d260866e1707f750fcad9eb253afd35073a6a97aa1a62121fb78d6a0f",
         "dweb:/ipfs/QmbrbFFvcCstpF8sVoSP8sPt3WYqHfvGmZ8zKHF1syx8uS"
       ]
     },
@@ -104,7 +96,6 @@
       "keccak256": "0xeeb96fbbe5b942c2c6ecf8a0ca4c0a88d290731a56782df8e52284aa3d48e754",
       "sha256": "0xfc386d2547b6f764a0c1139487ed1d4a19e334c510a727614ff8ebeb1bd01a93",
       "urls": [
-        "bzzr://518ea2503a211c4dbf511dee27dac4a367820273268103c14d0366400fe639da",
         "dweb:/ipfs/QmWoWxZpANYVnTwSf9ef1BG597NVDkxVyJzdxMcp1qTKgs"
       ]
     },
@@ -116,7 +107,6 @@
       "keccak256": "0x690ab93a9d9d5174e699cb58f4898391ea112850d95f5ecac25e259f36505dad",
       "sha256": "0xebb64b8b8dd465bd53a52fa7063569115df176c7561ac4feb47004513e1df74b",
       "urls": [
-        "bzzr://1a6089dc3d33e3bbec9f0a9ccd04872282b90da2563466200bea21eb72b8c7c3",
         "dweb:/ipfs/QmRiR9xu9wV3sGmfQbiWjDHnbpa1HfqwSeudL831LqFBYt"
       ]
     },
@@ -128,7 +118,6 @@
       "keccak256": "0x31fa8fa8b04ddb729490ca59fe1e212e8b1d25f9fb19de190864a1093d7c1609",
       "sha256": "0xa5b4227ed259c474426d8a2ef380606766aa8ba7f65487ab177139b3a51f0dee",
       "urls": [
-        "bzzr://06fdc632eda9b6916774ba35432bc0f02bbd2f48ca8c8675db24ec5a902b82b6",
         "dweb:/ipfs/QmQTVdW8cyRGPXEWbpRvinZBDGBYhUAsSZSf7Khp5VQKNQ"
       ]
     },
@@ -140,7 +129,6 @@
       "keccak256": "0x7b642dedbe89b221e7ab15c1b67d18aa04e4de91f987c5d2b8ff90c0bc761e60",
       "sha256": "0x40f179e4d27201ab726669dd26d594cfe10bf4dd6117495ee49d26f0dda9ef42",
       "urls": [
-        "bzzr://79a004dab9401b9e45c882ef19929ad3141af89b3d3f9fd8c21f8cf3310703e9",
         "dweb:/ipfs/Qmbsi7dJy45HyzkprNd3QuxARRedNH3akSLwcxibGghGaU"
       ]
     },
@@ -152,7 +140,6 @@
       "keccak256": "0x230569faf79408fec44b931151f7113006e4b34038b55eecb2a2d1dba6407c60",
       "sha256": "0x287eab0187dd4bdec50226f3173526bd8d247adeebdf64bc0b7448711abbea61",
       "urls": [
-        "bzzr://9cd6f534ed307b73097d1efa92f1fa12c4d44ae45026549e3d6c968d8c351e97",
         "dweb:/ipfs/QmZEGqT4RLTC6ngDzP22MAunduX537gdBD5FuHMRqWPzGi"
       ]
     },
@@ -164,7 +151,6 @@
       "keccak256": "0xd347f34d80512781730a88a35f54ea60cc8f22f41fa89a90fa23d6067e48e9c5",
       "sha256": "0x65cc92c918d6334f533a7596f62916825fc722b2a7a235729ed87cfbec622bcd",
       "urls": [
-        "bzzr://e6b9f049ff3fa866f1289081cd7696d0d60f5a6532d785c1453b8499244e24ee",
         "dweb:/ipfs/QmUGFo9on7dTJZEU5JUZpUpgat2B9dhyawSMxYnYVTmuvP"
       ]
     },
@@ -176,7 +162,6 @@
       "keccak256": "0x0715c4a2295fae7c057d810535d83cd34b280a2296cd7fc83efdfa2f38d5fece",
       "sha256": "0x701eebf0e37d172cb829dc1e65c74a46b3b96737f3866758f9894696a639b6b7",
       "urls": [
-        "bzzr://2b54f83e600406898dc18ba2e43307c79c49f29f1d2fdfdae0afc9b8f20a3d0b",
         "dweb:/ipfs/QmcTSjhWs8WCjqAoU8h5Wo5qCstmwxnNsDtGMzNu3F6MiV"
       ]
     },
@@ -188,7 +173,6 @@
       "keccak256": "0x1fbb0477543b5d27102f095807bf68ec8f2ff23b65212869fea942bcfe6f1e4d",
       "sha256": "0xa4ef22d9d36e75151bdd64720e69eddf57500883dd623c57805edb5ccb644a89",
       "urls": [
-        "bzzr://826435367348f6ecab540323f9dbe55540a0d0aeb7336cf7dfee5c18bd0eccbe",
         "dweb:/ipfs/QmdfbxCdhvrfL24y78KNzqUKGJzRHi5H8ckW9p6GLTZr72"
       ]
     },
@@ -200,7 +184,6 @@
       "keccak256": "0x64a70448467ddd8207ef0917b405ec5378a31b8b8e71b896f72c7b2721ea8366",
       "sha256": "0xe449a4980db4ff18e7ffe704b40083cded96cccf33986bf6a6bb6fe925eb86c0",
       "urls": [
-        "bzzr://d12223b8d998d355bb53aa8806ca68d64303521ec0bd33a263686b62ac47dcf2",
         "dweb:/ipfs/QmQrFUVDkwGfDeLvnX6tyTeEQf4ivcNYEHBGUmhZan1jTg"
       ]
     },
@@ -212,7 +195,6 @@
       "keccak256": "0x05d5bbd0dad953327dad1fcce80e5c44dfb04995d8ad87a3e7078eef6b4a83ec",
       "sha256": "0xa24512aee16652c4469979715bbdcaa6c4afabb94b717bb40980e4b2d25c4709",
       "urls": [
-        "bzzr://f69b11c78859b4d63777a18ce8320989a814a75751e9a1e7e8c958574d9b7089",
         "dweb:/ipfs/QmeHjMa2nfHsQkPHd2ameFYTEM7dRHtFvXRm1TzUakfRSA"
       ]
     },
@@ -224,7 +206,6 @@
       "keccak256": "0x52b105a3d36e2fd2b99e1fa69e4366035810c93c92baeb27ad9d37a29391a23d",
       "sha256": "0x458c3e2de2ffe609b79d9cdc4eb3080d6ed7662ef1bdd7c8a03fb18f1ca9a137",
       "urls": [
-        "bzzr://caf9f5842fe15e713653a69236cf51f8cb2bba9b29f03915b6588fcce8b9267d",
         "dweb:/ipfs/QmbNCaPHNdpaHBLYcAEHVFjms6TKfpo5maU9kS7fj2zF32"
       ]
     },
@@ -236,7 +217,6 @@
       "keccak256": "0x6ed8a169695fddb45e22975b416b6ac8bf5758f6765a5fc45a7708e266bd3eeb",
       "sha256": "0xdddc86683d12d0f016b5d5799ed84f6f2a79f667ebb932b9a8e6bfe9a48c3190",
       "urls": [
-        "bzzr://61696afc061612e49abd151286c3afef433f8d0a9e2eaf9527bc7fce7f3a5a2b",
         "dweb:/ipfs/QmQBofdea6hmCFSurTKyiqVW3dLC5raFiucVG7k8tFq26y"
       ]
     },
@@ -248,7 +228,6 @@
       "keccak256": "0xa291d2f1fb5d75e61c3f07e96093bce7fc0ac1607c609bf352b434bb9158170d",
       "sha256": "0xace5107a68fa75634e26848d6d208b808a76cc4f9262e53e8a3622bcefd4dcaf",
       "urls": [
-        "bzzr://9971fb2527a4627a4f74efec763417bfb80da2da2152a030d86112861378947e",
         "dweb:/ipfs/QmevE3c2Bezj8ommRqtY35SjrwRHUEMbJM8LntWHzqB99n"
       ]
     },
@@ -260,7 +239,6 @@
       "keccak256": "0x035cf886038fb4c4afe8014391c8432cf91997971f37d2cd509e8dd56a3f7f71",
       "sha256": "0x47425e338b9461d3e6498a0b0d5c2b9cc7cf998e4aa69126ea9f64c0a176e605",
       "urls": [
-        "bzzr://f07a63c06de8fbc236ae8e90d8e936656a1b1cb6d4009685e16382aa180ed6c0",
         "dweb:/ipfs/QmUUkRBTZ5KF5yZi8yzPVn7wrMr1rL2NPE7xfyyBCsbGxS"
       ]
     },
@@ -272,7 +250,6 @@
       "keccak256": "0xf5cb6ae6e7ad8d7d33e0dfb310691eff9fa18f27fbe8db2c3a848812ce38e1bf",
       "sha256": "0xe035cb9a81b5e3e11a7b99ead6f51a3ef7729794eebee470a964e2c08e30b857",
       "urls": [
-        "bzzr://6bb86ad1929e0eb0c499b0863324cae9f2c74686bba8961b23acb39c324b574e",
         "dweb:/ipfs/QmcgbaThT7VV5fJn3QrgMxXL5convCAccaopRX1yWii4CM"
       ]
     },
@@ -284,7 +261,6 @@
       "keccak256": "0x49ed59d22c36ff495a6167d4e34074dc0ad0c50806016fbb6e2dc111baf0ab09",
       "sha256": "0xa9341add7a4f01c52dbb36bb4028104676c684b0b6003a2cd9dd84a2a9802b59",
       "urls": [
-        "bzzr://e549af82db389897157316c7748c276d2b7706df4af04bd761e3f58b0b8efe85",
         "dweb:/ipfs/QmURjSdCxu4e6qpmFPArWjR5zZGaZt4gMxooWgUmZjE5ih"
       ]
     },
@@ -296,7 +272,6 @@
       "keccak256": "0x71f9c2c1eb71eaa97dc8cdeabb254f2bc460933bc59c2b3059aefab4942825a8",
       "sha256": "0x502eddb177f9268d79b1e05e6acfb2f229471823bf6711eff411d2a23e8cc0b1",
       "urls": [
-        "bzzr://8edd27d6b2a43ed0c8e4d3f4ab569d3bbaa58f18b7d69fe9c88913e2e074fd1c",
         "dweb:/ipfs/QmPHfgmtFZXrwb2jWnKSh3hXESNcHx6rRSoWPoDdvgyzKq"
       ]
     },
@@ -308,7 +283,6 @@
       "keccak256": "0x287dc3f7742980f494c95d7b70724133b7f49d51132eb47eaef1423c87a6edba",
       "sha256": "0x7034c4048bc713d5c14cdd6681953c736e2adbdb9174f8bfbfb6a097109ffaaa",
       "urls": [
-        "bzzr://d2778b5ba7cbcab0e9fbf9c8b0fdf689b3b680c145c6f949e47ec4f023bb2189",
         "dweb:/ipfs/QmbPhCgU88uhyWjYF7CBvFiCK6etGssxUTNkV3QkBHgtMk"
       ]
     },
@@ -320,7 +294,6 @@
       "keccak256": "0x857693802947544d326f294238bcffbade6a49acd2e1e7204d7b5c0577de21ca",
       "sha256": "0x9dd7686975200be71ce731f153823e7ea0d68106f3354ea16fecd5975f5c98b7",
       "urls": [
-        "bzzr://c1011a43e36ca050aa9a00b52e7ed0c42176439f781e4d59f45ee496f37d3e98",
         "dweb:/ipfs/QmcaC5MrrbYP9jEHo4Pn4FLMMhSwL6z8RhheGaVPFvGJjB"
       ]
     },
@@ -332,7 +305,6 @@
       "keccak256": "0x0f75819686eab4238b1f662667cd55bde1f923d022e83a547f5b9d4753ca7147",
       "sha256": "0xbc956645b792dcbb8f820b8010a8d4ec1e188f7b40c6af951a436da4c13ae677",
       "urls": [
-        "bzzr://1928511f27ffe8f44c5cff04e0f4f2787b67c816da9ea869d34628f6f499c7af",
         "dweb:/ipfs/QmaM4Fs6pzH8LvNFhFCbfgTfUo8nmZTKugfxmN7Ze6tT8U"
       ]
     },
@@ -344,7 +316,6 @@
       "keccak256": "0x0a89e22f8423a2ee551b4a7811c69321a06a70d8a00784deb712c6cf0757fca2",
       "sha256": "0x9fa663fc427e8e9613815ad6b83783b4e4cb10439f16ca0dcb12fc002c45ab5a",
       "urls": [
-        "bzzr://5f7b9658b980f95e54f2da92b39e02af3e1c81a8aca603955c3492b72651e51c",
         "dweb:/ipfs/QmdHxa1Z4fM3mFxueHba257rxyxD8Vjqg6a3n8GzvMQqFz"
       ]
     },
@@ -356,7 +327,6 @@
       "keccak256": "0x7135a9fd0c2e6cb403adbbd0534f22b8904bef330f5debaa4c240d7d5bdfd5ac",
       "sha256": "0xf2bad43386065684b4e15b86a175410f5d1e4d234b052cba44eb50f4c74b021f",
       "urls": [
-        "bzzr://060a48f64c36ec851b09dfa80af17a219db1945b1bd078e61e2e59287e5f5477",
         "dweb:/ipfs/QmejDUR2dLS5h6nrqt7x1pJ7seBoo82SJpRYBRW2qN2VDa"
       ]
     },
@@ -368,7 +338,6 @@
       "keccak256": "0x7a87045680f25893ebd0d14c36113303ee36864c715dae6b6bf60eff7c6c6073",
       "sha256": "0x9e7ee54f0bc2978fa8738b9603d636715a069d84771778d6195577bb91ecb9c8",
       "urls": [
-        "bzzr://6f84855b70c094210e3e0edb4549d746135a441ea5fcc5f3ac0e6bdb3d64225d",
         "dweb:/ipfs/QmPwnPkuf89E6H2U6mBjRUeMr6feD5YoAihnzd8a5HeQrF"
       ]
     },
@@ -380,7 +349,6 @@
       "keccak256": "0xa3e5beb407a5396463e4bb17a100cd8e19d00aa8bc76496af4dd7e96787c53b2",
       "sha256": "0x03a6cfa2d74e57ea38eee83ce9a3ea37a6e50928d7f109e74b37cae31319af2b",
       "urls": [
-        "bzzr://b0a16ff7c23c5da577edcacad06972d6cb7fafaa5c9215699ad99f0b4be9f8c7",
         "dweb:/ipfs/QmYvHkxeXXk8sPUsVtzmetE2osWfEYB85PNhtQ2d7uxFKe"
       ]
     },
@@ -392,7 +360,6 @@
       "keccak256": "0x6ac8af918e4121b072d51212a4648cbc3667f0aa7e50285cad1291577a08efb5",
       "sha256": "0x32a8affa996d05c55257317cc700b9e5b4377d94919b59055564eb0b5f941773",
       "urls": [
-        "bzzr://c7033e1e4fdf923304d28a5e188cb4f4a11bced6e3178c674cc843ed4c3583ed",
         "dweb:/ipfs/QmUJFZ4To2PfV5rbqpjNCfBopZQ7VXzkLd4DiRYf5EFWN4"
       ]
     },
@@ -404,7 +371,6 @@
       "keccak256": "0x182fc3bd33895c32dbb0613113aecd72f59f4330e7e7bfe5c47646abbdd26cc7",
       "sha256": "0x7fc0600cc150020402c9539ec0ad584eb9271b2d0e0bff9e3b4d4ca672be3452",
       "urls": [
-        "bzzr://9bad36f6326e8adc929b3c95abd6c6580092e0a3508056773203ae34ca17830c",
         "dweb:/ipfs/QmWp2yX7HF2sH61XsRkwqWmngXEdPnKtcz6Ah1pQopeMUj"
       ]
     },
@@ -416,7 +382,6 @@
       "keccak256": "0x29720ecdacb43bad240afea74e98c21ee106ddcf9fba81a2046bcff698e66346",
       "sha256": "0x428f9c0873d88740242f6fc16a3ae6f91b35f73ddf7676b5d5b39687d9d9b7dc",
       "urls": [
-        "bzzr://f704edde1884e85980ebb07b8fb9feb32adcd605c19cb78a1195aa4021354d2e",
         "dweb:/ipfs/QmSsdA3d2CzD2cMrhid4yDsTy1USkBWDYySLSsKJGvtPAc"
       ]
     },
@@ -428,7 +393,6 @@
       "keccak256": "0x02ffc634068a3930b72e9861207346ce033fc6710f11d288489f905b4c325815",
       "sha256": "0xa7d6b8e3cb22d90789a79b484b721fe02943f89e9b7e996863edd2d40ba7b524",
       "urls": [
-        "bzzr://dcf38cc06936a72f761c6b8eb77728d21d14e1130380a985893840c4f99fa140",
         "dweb:/ipfs/QmamAAci8zMaxZ3zCdQMm3Hke5ChCqLbRR5zJiCCH27QQB"
       ]
     },
@@ -440,7 +404,6 @@
       "keccak256": "0x0fc5f3026ac39048101bffae40a053f6da119e57c0154445cfabcea6dd716cb5",
       "sha256": "0x9f383896c8506cd96ac5ef9c97d7ab1c385fb5f4772a5f3d2cf8715cae793554",
       "urls": [
-        "bzzr://5256f697214601e713a377821707ab7aa81e00a86ba63cd0291683629d5c3db6",
         "dweb:/ipfs/QmdqvCaENZmRPg6WCjh2hVhWTpnaU7yf2qvY5a3T4BMXXh"
       ]
     },
@@ -452,7 +415,6 @@
       "keccak256": "0x0d4aa467fe96d5c934201f5265a5c940e556551e10bb630481f88ff59070b8d5",
       "sha256": "0x92e3688207c0c2b86bd9d10088340e4a585e29e3a88d1cf79c2043f4f9f121c4",
       "urls": [
-        "bzzr://8b6991bceb463e4d1617c9e5bbb2f5fe40c435a5fcc76b8286f3581e56ae3cbd",
         "dweb:/ipfs/QmYQEBMqCFzJAQgijj3AQUXx1b1UEEUmM6zHw3m8xQwrsA"
       ]
     },
@@ -464,7 +426,6 @@
       "keccak256": "0x001e08d9d1902a4f040e109b2b7e049371e687896409ad2de84dfe9b455bd547",
       "sha256": "0x5082bb5c492ca35b68b0c3e24d5934b56d3add83f1400ba95654e8f163c741ff",
       "urls": [
-        "bzzr://bae78448cfca3858a555580c0824271eabfd1bf808a15adc68fc00a861b98e53",
         "dweb:/ipfs/QmeXwGRydas256VMavRw4kPcT3fX1MY6LjZP28qmsnWPwx"
       ]
     },
@@ -476,7 +437,6 @@
       "keccak256": "0x6f0de51d7773d7670b5db78e143fd55809cd4490759311e018ad82b9f10d58a3",
       "sha256": "0x0e8ee89ddb1096b81c34e11bdb5985822e749d3a9dc4e7218ba2474afa6400cb",
       "urls": [
-        "bzzr://83204b31d6fa5fafc94244922a04ff84a63d5089e61359aee3fcb76935d92f54",
         "dweb:/ipfs/QmT4C8cecbPkS4vzkSYfA2KX1b4iqApEdQd4fswZr9K88u"
       ]
     },
@@ -488,7 +448,6 @@
       "keccak256": "0x815157d38845c5127c3dd3ab399ef90c6139019f6bf2a807a08e612e74439d35",
       "sha256": "0x3dfb97bc941492afaea7f404c3fb9c6fe215b3386aa6e0370791b571e4679548",
       "urls": [
-        "bzzr://cdcd3c916db81ad1f05405220069ee136a17d0f51db613e627fc8a36897b5b03",
         "dweb:/ipfs/QmQhhZKvjDQVwP6eaahfro5srD4jZ1JxQwgUUUowi6NkaL"
       ]
     },
@@ -500,7 +459,6 @@
       "keccak256": "0x472dab91d5bc4f7a4066a66869da74075dc587d48bd1cec55814b01f1126b9b9",
       "sha256": "0x68a344d9de40b0d7482089ee7748e43088c52e3b108480d801b34c64020beb48",
       "urls": [
-        "bzzr://9f15e79ade2f897c8a754887839c4aed352f37d3bbade568c269580c722563f6",
         "dweb:/ipfs/QmXxM4YfZcq5np84wcCn762sm4XDxyjoMaKXtUaeunp6th"
       ]
     },
@@ -512,7 +470,6 @@
       "keccak256": "0xcc9cddd6f0d0de2a39afaff31a063dc66eebe91b3c7bdd62e0152de4547bba07",
       "sha256": "0x8afa926b6bb8ad492fb25078b1dce09fd05faa5765e4e2b2672b3c99cf71eeb1",
       "urls": [
-        "bzzr://1bf2e4af9bebd83bf3dad7ff7bc6cfd1fa4571ea0627da66890cae3ae6f39c1d",
         "dweb:/ipfs/QmQZsPrUCGcTnFiBgdvbAFhw5qoUp61Eer1Rxe71Eg7Db1"
       ]
     },
@@ -524,7 +481,6 @@
       "keccak256": "0xf918ebb44bdc82a0129b4d0b2edeca7de44b5af66ded6765a784d23b2f344014",
       "sha256": "0x9e05051c3d42a49c8470cbed1f2bfa89fe76e930a9e5558c52ce5653cf794e25",
       "urls": [
-        "bzzr://ebb5a9f6594feb4096866be5f43fe1e780454d405efd07f891c411d1be7beb8a",
         "dweb:/ipfs/QmY5eKeMgFVxGgyzbVsmeEUurZyfQVUZ9hVoACf46iyN8R"
       ]
     },
@@ -536,7 +492,6 @@
       "keccak256": "0xa8d1fa05cbf6d30c9d6cf4c0080d040c1518db7944ba943ec4a816f1b6f0b1bd",
       "sha256": "0x9f6624e408497142bbd29efe0744ee25e445aeb7c932be401c0bc30478a6bb75",
       "urls": [
-        "bzzr://407abc296f3a4fbf71fdc1f413c5f32cdd66a2b525081a21524a6ab5608e870b",
         "dweb:/ipfs/QmRwNXSmQj5m522CJNC8d9DEMPQ2ut6kNmDZQr4oUdS4jw"
       ]
     },
@@ -548,7 +503,6 @@
       "keccak256": "0x1142bf5e71342697a0786a0032838299c3e106afd5c54960c9b44b5f60ac0760",
       "sha256": "0x35be28f68488b71f1de66148f915b91d64e062900e4fc175bf2eb8fb948810bd",
       "urls": [
-        "bzzr://312c6aae351990e74291d8cdf9d732768c5bcc57fefae1a0aa3720d911a239d5",
         "dweb:/ipfs/QmVXgA6QjWq8CTtvhysrru2QgjVdqx2Bd16iuADZ2eP9fC"
       ]
     },
@@ -560,7 +514,6 @@
       "keccak256": "0x7875c887df2e92df1163665db622d962e0336ccf9784549244f3595ed37e8570",
       "sha256": "0x37beed8c8b947eba644cfd8c20446e1ba5d74055e6856b646dd6ad4bb470d9ae",
       "urls": [
-        "bzzr://600161db2bf70cdd1b150e4e6dc5dd08b642092d75a96994290aa8c59134bba9",
         "dweb:/ipfs/QmSuT85oAvJFVfWj6PBRHgSAC4iQQ5uPTJFDpxC84aGtq9"
       ]
     },
@@ -572,7 +525,6 @@
       "keccak256": "0xa60603c327514c2acedd1bc917e769b74739e711ee341cc08bdad6d065c3fa14",
       "sha256": "0xf1649bfdb0e6e53be2758544836258cb4d02e0b381a9e43216aa2b2fad0c9b8e",
       "urls": [
-        "bzzr://8932ec9fc8a9fe70346f4fdc2f92820cb620c596149ab63047b4e25c982a1953",
         "dweb:/ipfs/QmTLGMSSAhzwhc7CEQphcZxdAEfUE5eVTFHeip6h8RCMEV"
       ]
     },
@@ -584,7 +536,6 @@
       "keccak256": "0x441fc0107c407d4bc18ab301c208cc8f3793f6d811627798283994d5cd74c985",
       "sha256": "0x2bb19d8cd69a32854acce1245b4492cfc5b5e751d322d2c6556d4a521bfcc3c8",
       "urls": [
-        "bzzr://d27138690388eafc0478a642bcfe12071f7478dac8ed4f270d53f064cb94f777",
         "dweb:/ipfs/QmbuPyqt1XkE7UXP7WgKV7PTLCQJYQd3Ytg8yzsTVc3qFM"
       ]
     },
@@ -596,7 +547,6 @@
       "keccak256": "0x48221990f9d74d82a093722f20706a2a43d79772552a6bef718752427259a792",
       "sha256": "0xa09350d5a182b3da799c203d1dadc4ce0e6fe3b96dc9ee1c9d73e9a9d9592e2a",
       "urls": [
-        "bzzr://c7ed1cfaf43061ae8e6760a949f4c1e43a2d961c9f4c867bed61eb3cd7390660",
         "dweb:/ipfs/QmXv1gpDqj9iVZzRoYbVhwFo5j2ooptQAYz7vp9hnAB3bp"
       ]
     },
@@ -608,7 +558,6 @@
       "keccak256": "0xae0015245fb38b3b333339930ab635958ec00b4bb062ca1a5f346d6f51d88602",
       "sha256": "0x082fd42cc96c28262459306f2854fe7049cc0d14473e126b2db6d30bf02f54d0",
       "urls": [
-        "bzzr://e3aa6e6ccaade31d61c1c24df8cf03a5fd32a95a3c7fbf652ef2fdc8368d044b",
         "dweb:/ipfs/QmeHkJw28pfTsVEpQXGJnaehKneXQUP2S6gwCDbmbmzAsn"
       ]
     },
@@ -620,7 +569,6 @@
       "keccak256": "0x7c96df0411896e573a12852f40beb45c9c6d4006b0eb4e304665b83692064f1b",
       "sha256": "0xa8129254b5247bbe003d6e54f35c0bba853694126744577289b6bdf1d35a1e4a",
       "urls": [
-        "bzzr://743e1144947432ad10792fcd4213ee95cb6ce49ef0029bba0c1daa8313ae400f",
         "dweb:/ipfs/QmRxqoK6QQPWcxqeYwN5GyE9SF71gcnW5UwRg9QPUjbmBg"
       ]
     },
@@ -632,7 +580,6 @@
       "keccak256": "0xe7810e0e9d8bdb79087d4a8ae84ea88d33422a37906fad7114531675790fd0f8",
       "sha256": "0x45c7f956197ce08b69f793ea610cf1ee65e12b6a518d6160cc28c8eeff41517c",
       "urls": [
-        "bzzr://08164ef3f682e8963d150b40478c8321a1ea93f5db6e00f7b325896edea813ba",
         "dweb:/ipfs/QmX2s1id8TC9Hdaemi6yWXMBaQbcT3pWdAU1gkda2PgNAM"
       ]
     },
@@ -644,7 +591,6 @@
       "keccak256": "0x0f348362eb3dbc20c7a6989a8d09adccb40e3f6ee731803d59992624fdf33992",
       "sha256": "0xbb78b6de3df7db6115a1033346c3e9df8a6b9c4fd038cc12d6bdf16abd29c952",
       "urls": [
-        "bzzr://3563864610d0b3402aed2f264298bf8efd5278337af9ddbf34800c58cf19fc11",
         "dweb:/ipfs/QmWrPCuuXkGx6WxronttXLYDdoRyyvbxaJHuwJpd6wLZaJ"
       ]
     },
@@ -656,7 +602,6 @@
       "keccak256": "0x9bdbe9621aaa58357dc8695d5d13370fa9a89b3dd71a3f1702ae4ae50457b378",
       "sha256": "0x801efaa3d0288637021667c0d116ee2b339e62cf26027f8c168259e0805e8b60",
       "urls": [
-        "bzzr://8830f7671dd8b5e9def1397dd1b262a083598f38c931e8dc9e3aff855752acdc",
         "dweb:/ipfs/QmcZSrp4jW4cYn8MskSs8VjHNGsTakgxiaHyFX4iqC9muG"
       ]
     },
@@ -668,7 +613,6 @@
       "keccak256": "0x6a34879f5ebf3e6405d18c1812aa540fe9903ad889cebc3dc0246d5a49cdf3cf",
       "sha256": "0x98fbe10755638ad5ccc0683810b961a803450e94b642af112593248a685aa4dc",
       "urls": [
-        "bzzr://4ffbd77aa5bdb73bec29e4d4e236a9dd907caff79296a3d94646760d8e5af78b",
         "dweb:/ipfs/QmbjW4apLQwPd8ALgCNEBax1C4tgF5Eg7dHdLgqgjTkgnA"
       ]
     },
@@ -680,7 +624,6 @@
       "keccak256": "0xc833a7ce648e47524699bfcff94bf0a5143f2f0ccca7b75703dc825fdd038c1d",
       "sha256": "0x3773e66c3ef14e2e47bdd7d06f30f952c199856df240d164c91c1f00806fbbc7",
       "urls": [
-        "bzzr://181a5c54edcc14ce2c5d5155c4efd56a204a49834409772ed85ad932857a9750",
         "dweb:/ipfs/QmbQEy69AoRM3h5vCzxe4aDCAxKDPFYwGQSGVQNMpHHDKy"
       ]
     },
@@ -692,7 +635,6 @@
       "keccak256": "0xd289b8db3cd371f4a5df8e57b5382b361fcb8d5112536797ec2dd90dda1a079d",
       "sha256": "0xa0a64aa092a616ae7145da908fc427fc3c296d3afdbfa8ea3468a22722d5d01c",
       "urls": [
-        "bzzr://9fd78b77716ce520e78aca45af8709101d0a9eb07ed8ddc07a166f6964a9df60",
         "dweb:/ipfs/QmVKPzEU56b2ercuGibmt1PNX6T38oiv1UTMZNmBUsexkc"
       ]
     },
@@ -704,7 +646,6 @@
       "keccak256": "0xd3ad11d172cf5b8ca7c7c0fb6b751611a85323becd788180af5b30fc8b4b4987",
       "sha256": "0x05ad8afa83df3b51d36fe9a84ea4467b3ed17585c903946985d6e2cd5e95685a",
       "urls": [
-        "bzzr://45e7aadac409633022704d4d4a63317c8d106edaeb67972bf160bcaac9746dcb",
         "dweb:/ipfs/QmWK8t2TGf4UEKFGkk8aa9TYtFcWU9NYqjwsYyso4VJNLC"
       ]
     },
@@ -716,7 +657,6 @@
       "keccak256": "0x0f29a363cfc30a28d2f82e241b3c6feafd04c6aa57cfd3969b6c70d6d64997ba",
       "sha256": "0x40555d6e826104cacd0c0b637c5fb573d5b6e2a6ac70110dc0333466c0115e1d",
       "urls": [
-        "bzzr://720bd9c72285bf715fae1ca378bd1bb24432d662ce6e8ea3605735d0585d8e61",
         "dweb:/ipfs/QmcpsbvXVFacMFTgAoKz5VXKdT1WFNFFEmsxGq9K4Ef6Sa"
       ]
     },
@@ -728,7 +668,6 @@
       "keccak256": "0x5a29ea217cdacf04d8611706771ee041571207db75e554c88e38c975308fbfbe",
       "sha256": "0x55b8072cc6ac154bf27f22177afe58be05f28c11ef51fc4e660313d3045a4268",
       "urls": [
-        "bzzr://3f6fdb64f1fd58f16285737aa4c46f5cf955aff0accc36a93a0012c84e1ac153",
         "dweb:/ipfs/Qmbsseaeu3GmMe4y3oqqonaVUkSYLqKB18gdrNiA6BdT2g"
       ]
     },
@@ -740,7 +679,6 @@
       "keccak256": "0x1fcec1bb8e66af87b944f82ccf8ff7690931f7872093f4b14647dce62174a3eb",
       "sha256": "0x5518641f6c4a286054f5c9f29146970ef72f2f34ee76ed23f5eb1f6d1dcfecdb",
       "urls": [
-        "bzzr://1c226f35bf118d903ccc943516761564497d8b0cfc79eba1206c924254af0240",
         "dweb:/ipfs/QmcpwuWTL3ZgcSX1WUs4L3WVZtctRSzm8eHhGXosn7cz3L"
       ]
     },
@@ -752,7 +690,6 @@
       "keccak256": "0x2bbcfb7135c6ae1a23be3ff24d00f423a5772b8c96afdeb29366243d9b9b586a",
       "sha256": "0xf185104ed5e2a90b3ce8dfc7283c5d0ffbb738d7c8da19e8635dd9fda34c337a",
       "urls": [
-        "bzzr://576d33181f5dc0c42bf0c1cdcd5fae565d0278b035c907fd5410b212ad9ffa05",
         "dweb:/ipfs/QmNUC4SV1jEWHv2VDck4WYToHgZrZZ4BDLvXJnj9DM6G9p"
       ]
     },
@@ -764,7 +701,6 @@
       "keccak256": "0xd6a9d389b2d303f226f9e5ecffcd33f610687b556cc254cf30589f72a6fb8b77",
       "sha256": "0xcce002688cf10fb0243a042503f3e9896aa991ab59b08b57971d42d68e99f83d",
       "urls": [
-        "bzzr://acba761d4123cfc40249bc922a66e9d190802bccf269431a5aaa80bf9f99803b",
         "dweb:/ipfs/QmSZzdgjm8M7gz44MKMQpFUhDG9HBdTNHf7BLmLrkagos6"
       ]
     },
@@ -776,7 +712,6 @@
       "keccak256": "0xff52724ea7d3e0913219c765b40f311f72fe1e5c95389020a165a1959e57e24f",
       "sha256": "0x1c100ce86a3167fd4c194290aafec0d3d94fe86c7a1aa0837c1346cc93d8b6ce",
       "urls": [
-        "bzzr://e40c2432e6e49c8ccf67ea1684d1fbdfb43fbbb7ad44264ecb17ce73ef3a7c7d",
         "dweb:/ipfs/Qmayevqr3TEHNqL2eAumCnFjgcMRp5Y1ckkwnfo9ewsCdF"
       ]
     },
@@ -788,7 +723,6 @@
       "keccak256": "0xcbc087311397f47993e7332637a999ac98a5661754ce33e4b265edcaaffdcd85",
       "sha256": "0xa6a8f9f9388c5fcd9222474e00270242c832e936b0f5257c20374d27ee5bd1ab",
       "urls": [
-        "bzzr://f908a6c0e311461118264568c0cff1a428fa2b401ca9b815b9c74b4e5995b347",
         "dweb:/ipfs/QmcpVjAEjNMrQYWqZ96pHJp2v7CrM63S2VQJDiLTgWx4eg"
       ]
     },
@@ -800,7 +734,6 @@
       "keccak256": "0x945af5c3c9d75a6ca7d48a4ee9df3201b0a34c273ba6b50aed6afb2a41dab845",
       "sha256": "0xc7c3ff484d2dd69350fc182d44ecf6057ff2885b96a1c3990ca362e9c8325335",
       "urls": [
-        "bzzr://d65c16cb03339d288f0bf103fd22e610532989be6f64529db52f794da0c15427",
         "dweb:/ipfs/Qma8sQw9vxvSvEUTNsz7DxPvuo9Lx8nLpdAFgzQxVaHbSV"
       ]
     },
@@ -812,7 +745,6 @@
       "keccak256": "0x1f546c34241257015e73eb90b7b7ed099399c5ed84964f266e651f3a9de0f493",
       "sha256": "0x38504e357632c15afed612c20ef878992ca8411ce3fb6afee37dec6ebd22ce02",
       "urls": [
-        "bzzr://a6ac5a8d50ade8d5df91dd9c6bf623a9246b721b17b991514ccdbeaee50ddd68",
         "dweb:/ipfs/QmShTho5JF2vrmnGwBWStrwTz89GNgiCfJKVoKKz1Dk1D7"
       ]
     },
@@ -824,7 +756,6 @@
       "keccak256": "0x3abbb7ac75c90ba7dc9d4aafe0f5c183c8d572d9c07303e892963774f8e6c53f",
       "sha256": "0x0898c23b0ac8cdabcee3b646b676da1205f4be7c0bec8a58de81b060c59b4c1c",
       "urls": [
-        "bzzr://8acc5ef01c96279bb7665995352fbc3a2e1519f44de68b05abc2343cf2e377df",
         "dweb:/ipfs/QmYU4oyuNdJmNrPbNj6p3zWzhWzbdWHhSidHvSC3AqS3Jp"
       ]
     },
@@ -836,7 +767,6 @@
       "keccak256": "0xef385c85cb7e3ab6faa28c7223c7f55b0d6a28e113420eb4d07aae5db1edb834",
       "sha256": "0x1188f5c24d33ec1ec2ce811a7a45bdc3c167f1ba71cbc2664016564d2fdd46ba",
       "urls": [
-        "bzzr://9e6b437fef68587b3c8ce3d930de77075ee6008611273ccfa2140f5c868e2ffb",
         "dweb:/ipfs/QmSUdtQRWmGe7kHX3FaJNiYp8TaPmDJFQQqwdYDBgUKq9T"
       ]
     },
@@ -848,7 +778,6 @@
       "keccak256": "0xb8027ceccd3892550e0389af02716a658123eb4530bc02fc437d167c38501101",
       "sha256": "0x4f6f2e6942a09051bbbc850d4fa9b0d907749612cb5db58cac0c87745435070f",
       "urls": [
-        "bzzr://317c789ec9854aa6037a49f5f9b1598a95e6046a17b55d37b776bd0d3af93c96",
         "dweb:/ipfs/QmQ27VGKwchmwWN2TmfYALfgU17D8MJxPxHSCt2jSuAWDE"
       ]
     },
@@ -860,7 +789,6 @@
       "keccak256": "0x728b089ccc3f1225ba7e7170fb88a75ae6b89c9d168f79493702f8b6bb725b7a",
       "sha256": "0x3421ee67a26ef4a720e79531ffd9b96deec89defbcd70bb4a33e968b12ddb938",
       "urls": [
-        "bzzr://e0e118ce0fdad202969c5ad18cffc482837c522ecdc86578a4fb208117e36cbd",
         "dweb:/ipfs/QmRGVXZ3rGb5zfnHCJEJTAgrDemFkKrxrcVKRFF9HAcF17"
       ]
     },
@@ -872,7 +800,6 @@
       "keccak256": "0x89e95cde55521904929e8dae6f0acf450db091d28a45dc824780a35c4c9b910d",
       "sha256": "0x86ee99f64fc7e36bfa046169b6a4d4c10eb35017ed11e0c970f01223b2f5db36",
       "urls": [
-        "bzzr://057db05ffb78d1d29087c7ae6f7cb9c34890b97d105fe791643cbf0ecf1626a6",
         "dweb:/ipfs/QmQZsG2rzoXmkhHMGgXJxzbdi9TCvt4yuV1akuAcEE4QMT"
       ]
     },
@@ -884,7 +811,6 @@
       "keccak256": "0xbcc6fd8ff1d27e4b1a1d277e2d36b3e135981472038401a0e0eee275d0b28846",
       "sha256": "0xcc5c663d1fe17d4eb4aca09253787ac86b8785235fca71d9200569e662677990",
       "urls": [
-        "bzzr://2ec2ee1c310b0f62231a74f0b18de7d669ae204288c895343153ca95a7913800",
         "dweb:/ipfs/QmWCTWH2NP3pSjcEPoYQ2ss6YPW98R2WmqX2mfQbLepvr4"
       ]
     },
@@ -896,7 +822,6 @@
       "keccak256": "0xa7dfe9ed26a2d2e9f1e7b1581838bd35d49ccbec36228ce232dabd3a2ddedd3f",
       "sha256": "0x1422e10454251d56fef62940fb2e209a6f467ae35f73bdce580bc0bad35851dd",
       "urls": [
-        "bzzr://9464141458eab56775a5be4186cc6a73440f609b26c3fa14c7b0a424ce128926",
         "dweb:/ipfs/Qmd32FsxALkBcWgRCD6zvFmZ3PvZN2jLtYVWBVpnVj5PFd"
       ]
     },
@@ -908,7 +833,6 @@
       "keccak256": "0x0dec1d0015c882a98259d9ed1c7a157c77cb4fb05dfe0e2b74484957501dce7c",
       "sha256": "0xd619d4f5d8fd988bc63262407e749e905ccc8d8ab1ccf0280da1d12b918894ce",
       "urls": [
-        "bzzr://b7ed2e4abec3c6e075fdd6369e3705accea9a7677be58a6ff05e94765e00d57a",
         "dweb:/ipfs/Qmax1ZEAvgqfyNmXBSTrmerSYWgsbCfiUMGqnQYQGUNEUA"
       ]
     },
@@ -920,7 +844,6 @@
       "keccak256": "0x6fab4e609b69b16f2ab6d3c9fc9262e52cb76ab93619325eaec590a5efe3178b",
       "sha256": "0xa79fff23aeb35be856e446827c44a9cfa4c382f29babd2f6a405ef73d1e2a4cc",
       "urls": [
-        "bzzr://4473d82fb0d080fafc4b1e4305dfaa042d081a1b9993024ba337cacdfdc29d3a",
         "dweb:/ipfs/QmZPQAFTJSBAg3GjSW7JS8h2yk9nBcAjCjYYEygz5GxNMt"
       ]
     },
@@ -932,7 +855,6 @@
       "keccak256": "0x7f7e17b585fcd8b3c5025210e478a330281a4bdbb6054569d81dc21d32394b61",
       "sha256": "0x10cdcc8d8ea4dde9fd8b953b95885dc737f24b8a31fea65f4715ffd007b80281",
       "urls": [
-        "bzzr://c21c33c4d4907b1712003b3428b6af25fc1089493bc2aec06d04a41210f698ec",
         "dweb:/ipfs/QmRkNwKe9t8KNVMViMGEVJotaZCiY8i1qJ4v5EV4UBRnaG"
       ]
     },
@@ -944,7 +866,6 @@
       "keccak256": "0x3285e72f53b0ce49958234d29e3c58aa2ac12e38c21ef59cb9940edd245ce76d",
       "sha256": "0x95738a27909a13502385e9fe8f8f3d8a873d2faf5d06ff617bc2fe3edb8c4bf9",
       "urls": [
-        "bzzr://1b149c02263e66a260c11be38c7b19ed946f1e6a59c77f15c4d8148d1d69887e",
         "dweb:/ipfs/QmSi3sQoQhUmQCxD6xaMtq3nYnWE8ydqYjqhe7kvRAfCUC"
       ]
     },
@@ -956,7 +877,6 @@
       "keccak256": "0x9f05bd40e25ff5ab7c6e657558ba71d472b30bff3359de15122271c4065b9c24",
       "sha256": "0x14d4ef013ea82ad95e91fd949b7fa7b78271a483ff1a79c43d6cc58b826f5bea",
       "urls": [
-        "bzzr://dfa7ef356ac5736c1f5cb2defc500390898881afa1b67913a832be445f026945",
         "dweb:/ipfs/QmXaKT1hqJCNuJX5uryXJzbHHUsH48GoGBhoYPoLCVrZUg"
       ]
     },
@@ -968,7 +888,6 @@
       "keccak256": "0x93d71d0692befba81239f7a0b7443ca117ff7fe9ae190ed32550db678d086aae",
       "sha256": "0xb3d19ab47657af37be4c551f83494248e99d7ba103b6072e8c08dbb62708e2b0",
       "urls": [
-        "bzzr://f46b7d64c5327360d840752b6acf354040ea61d43eac1d14e0f373f96e2b5d8c",
         "dweb:/ipfs/QmcK4egnnjdrkLsM8R5QeSBoYs59M1CxvRi331zaxoSEq4"
       ]
     },
@@ -980,7 +899,6 @@
       "keccak256": "0xcd862fb2d2e2f83738c2d08632cea128bee9278a4840053262b0e2495f9216ce",
       "sha256": "0x00656dc73224e4c0702940df10310bdc024b60f4a7598e774d305bc3b94f7d79",
       "urls": [
-        "bzzr://8a277ebe4f557a46c93f6e1a4ecffac34f7e0a60afe8a20508e42ae646571c20",
         "dweb:/ipfs/QmSJmnXuyPy4TtxnUSwD6f2vF5MSzcvN4cohtZfeJc8H6p"
       ]
     },
@@ -992,7 +910,6 @@
       "keccak256": "0xf3dd3636e7bca007430e091bcacc2dd9b9af72edb838a0e0d77de9610169f7c3",
       "sha256": "0x7d471cb9bae9a7f29c7ebf402f7e16fa8226b17ba9ab68a88ce107114479dc4d",
       "urls": [
-        "bzzr://53af1a8c08f9025b93c23759efa15c9eadaa3b20a8a590424c12d4a89a0b7503",
         "dweb:/ipfs/QmZCFxnqy312mEc99qxXLRs6UE57pgFM5XPMVmw6G1WXfS"
       ]
     },
@@ -1004,7 +921,6 @@
       "keccak256": "0xf1d882dae250037523afce650a3e6d2069810d7f7e18a5f861094587fd946b6c",
       "sha256": "0xe40eef83c24d4c42b47f461b01748a6ca89f1e09e778995b71debfa0de99e12a",
       "urls": [
-        "bzzr://1ff61f15fbeef7eb86e4a5df8046880cb31a07e354bc3d6339aa072e0eeb8e1d",
         "dweb:/ipfs/QmPLRuidw4wXZhaWbd24VYWthZrUftJwaXQKWHPPj9Gktz"
       ]
     },
@@ -1016,7 +932,6 @@
       "keccak256": "0x30e1130aa13ced52eb874d224dba7683ed4caf32291c4081f6b83230b341190d",
       "sha256": "0x8f15287c799ad2b33f241d1252226abda5d4bc3ef6be40b946923178fc57d397",
       "urls": [
-        "bzzr://892792c1a2975f25ec0f96083559933412c25e0c1100eb85c33b61d1b9a385e8",
         "dweb:/ipfs/QmTepA9fra5vjbooDmxjcmM8pYXj5Xz1KFt5d73N8S84NA"
       ]
     },
@@ -1028,7 +943,6 @@
       "keccak256": "0x6247a3e93a840acdfda0b111b27bd48e22ed2515bf67d0310864979fd4440155",
       "sha256": "0x38c8523ab67e0b3e21c48189d6bfb99ad6879b9ce02e0d802ec8be598bb2622d",
       "urls": [
-        "bzzr://f0fb303e649106358f518d1cb3c49b8c3f488a86f7e345a0d9f2029c2e3d7154",
         "dweb:/ipfs/QmdXcpr6U4kr7KmuYfduz7DRbvbyWViLoyoAEh5USqUKVu"
       ]
     },
@@ -1040,7 +954,6 @@
       "keccak256": "0x6968bdf9827c7aa35eccae41063e812250828bee530d23b59f0034f6c62eeb02",
       "sha256": "0xfc329945e0068e4e955d0a7b583776dc8d25e72ab657a044618a7ce7dd0519aa",
       "urls": [
-        "bzzr://c44d37faf405274cae14f988e4b0b5ebe66abbc2ea0828ff433d168e8e339bf5",
         "dweb:/ipfs/QmVgJUFru26w9nsKzEZ8WSrcc4JbtcTkbhuNq7Vb1juDqc"
       ]
     },
@@ -1052,7 +965,6 @@
       "keccak256": "0xdd0ddc6d53bbecac4ed0f0b78c4d9990841d250e0e4eda116e84c9d0e1c2f4a2",
       "sha256": "0x19d065749fb08cbff4f7b45284ac55853063865f6ae8621e4defa5d938b9a502",
       "urls": [
-        "bzzr://c701d26aee88e21ba5803b02561a031ca6f61abb6fe08fbb2b78c784789fe712",
         "dweb:/ipfs/QmX6LQNJ23wCfv3TCkbLS4nmazPAYgWTKred7CDTGLi8tX"
       ]
     },
@@ -1064,7 +976,6 @@
       "keccak256": "0x791bb778cf604f6dfd073e6b11673384aba23beab55accd3f29bb310b5c4d128",
       "sha256": "0xc8d3b7803c0eb2c3bdd34b2c3b9706e9d8c81b8829250e49245dacb984a62e05",
       "urls": [
-        "bzzr://a07c2d2704a44b2300cd130fcd2c834bed6edb203ee63f0529f78130c437b872",
         "dweb:/ipfs/Qme1Cmme2nGyy3V4KBcY2amBdZdykqiryYp5KjXcos4xZy"
       ]
     },
@@ -1076,7 +987,6 @@
       "keccak256": "0x8380e8a6f66e4b2547250b9cbee170a62e1e899df12f7c0c3effbc5df3c06137",
       "sha256": "0xe09a42980e44644be33a8455c87d095a4f0028e41a7dde1137f5d9a7605a2d62",
       "urls": [
-        "bzzr://00319ed318e2cd094791d858f56cd7031f60023b00cdd2f9bd2f0d96e5ad918d",
         "dweb:/ipfs/QmXuBDhncvou72S86KxNxeTcVH1pGhU6DCZYzbcVrbfY1p"
       ]
     },
@@ -1088,12 +998,59 @@
       "keccak256": "0xf8c5313dfe054e7f3c208905ee6bb4097a1c7a1dd360050f90fab4b182ac1c24",
       "sha256": "0xcc2d44c706905ccc382f484625dff61d741e0c24232d226f139a6835fc644f3f",
       "urls": [
-        "bzzr://fab9be6f2b588ade1d1805e2bc52896f9a51d283fa513daf8a70b3e6050524cc",
         "dweb:/ipfs/QmfNsBiCB9QDHh9fX8QRAJfFKubX2ahutAXnoWx4BfXosT"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.25+commit.b61c2a91",
+      "version": "0.8.25",
+      "build": "commit.b61c2a91",
+      "longVersion": "0.8.25+commit.b61c2a91",
+      "keccak256": "0xb530bf56ed297e663f77cb03e3c34f50edb38bc670f31eede8fcfb6217c52226",
+      "sha256": "0xcc3f94a70ac681b0304084acc1980aabe2a1bb3240d44ce76a8df0e1e77a2110",
+      "urls": [
+        "dweb:/ipfs/QmZCfDnCEPZYXUxkpEghPNj65T6gAQ7F6aL6jNjfVh9FYw"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.26+commit.8a97fa7a",
+      "version": "0.8.26",
+      "build": "commit.8a97fa7a",
+      "longVersion": "0.8.26+commit.8a97fa7a",
+      "keccak256": "0x1fe5674db955096ce35421344384d35b124e58d716f0e9518e8efe0a50604bc1",
+      "sha256": "0x0ff016aef2396b12d1fc65429d8ea6cf53c2ee4b041bb8925644615ee1c30ab9",
+      "urls": [
+        "dweb:/ipfs/QmXY5ZNZsz6x9hDo1ziDf2RLP3KWcEkVFmt8sGsG27c8Qh"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.27+commit.40a35a09",
+      "version": "0.8.27",
+      "build": "commit.40a35a09",
+      "longVersion": "0.8.27+commit.40a35a09",
+      "keccak256": "0xe033b512e547768c8b48c7638247eb5c3cd601a2f0d8acab89fa22225f7f5467",
+      "sha256": "0x8c406fa5cab9bd0a175da02c652072f814c3d06205a2fd6d92bc152599a6aabb",
+      "urls": [
+        "dweb:/ipfs/QmdziPFsVTBktFzNrBNXo9THdAs8Uo9pYCfNp9SNEjaziK"
+      ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.28+commit.7893614a",
+      "version": "0.8.28",
+      "build": "commit.7893614a",
+      "longVersion": "0.8.28+commit.7893614a",
+      "keccak256": "0x951a4c98500b11e065d8bd2a053f23678aa4dd536a93693e6f3a43ed71a97470",
+      "sha256": "0x81515b0e53deaa266d549545ccaac0a5a96e6d4e8201c77f673b2c710976d9ea",
+      "urls": [
+        "dweb:/ipfs/QmeUvFZkouz4maSCaGSf6pRS2RV7EoSDDSF5FXc1ZEkkvU"
       ]
     }
   ],
   "releases": {
+    "0.8.28": "solc-macosx-amd64-v0.8.28+commit.7893614a",
+    "0.8.27": "solc-macosx-amd64-v0.8.27+commit.40a35a09",
+    "0.8.26": "solc-macosx-amd64-v0.8.26+commit.8a97fa7a",
+    "0.8.25": "solc-macosx-amd64-v0.8.25+commit.b61c2a91",
     "0.8.24": "solc-macosx-amd64-v0.8.24+commit.e11b9ed9",
     "0.8.23": "solc-macosx-amd64-v0.8.23+commit.f704f362",
     "0.8.22": "solc-macosx-amd64-v0.8.22+commit.4fc1097e",
@@ -1186,5 +1143,5 @@
     "0.4.0": "solc-macosx-amd64-v0.4.0+commit.acd334c9",
     "0.3.6": "solc-macosx-amd64-v0.3.6+commit.988fe5e5"
   },
-  "latestRelease": "0.8.24"
+  "latestRelease": "0.8.28"
 }

--- a/pkgs/nethermind/default.nix
+++ b/pkgs/nethermind/default.nix
@@ -12,13 +12,13 @@
 }: let
   self = buildDotnetModule rec {
     pname = "nethermind";
-    version = "1.25.4";
+    version = "1.30.3";
 
     src = fetchFromGitHub {
       owner = "NethermindEth";
       repo = pname;
       rev = version;
-      hash = "sha256-J0kvmj6yG7tUv16nDfQ14mmKnGgJ/Gshkf8wCFRs1B0=";
+      hash = "sha256-J2G2ENgYfyUSNoi2tKIlbZzVXkxXqWP8Q+NihIzLiHo=";
       fetchSubmodules = true;
     };
 
@@ -34,11 +34,10 @@
       snappy
     ];
 
-    patches = [
-      ./001-Remove-Commit-Fallback.patch
+    projectFile = [
+      "src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj"
+      "src/Nethermind/Nethermind.Cli/Nethermind.Cli.csproj"
     ];
-
-    projectFile = "src/Nethermind/Nethermind.sln";
     nugetDeps = ./nuget-deps.nix;
 
     executables = [
@@ -46,8 +45,8 @@
       "nethermind"
     ];
 
-    dotnet-sdk = dotnetCorePackages.sdk_8_0;
-    dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
+    dotnet-sdk = dotnetCorePackages.sdk_9_0;
+    dotnet-runtime = dotnetCorePackages.aspnetcore_9_0;
 
     passthru = {
       # buildDotnetModule's `fetch-deps` uses `writeShellScript` instead of writeShellScriptBin making nix run .#nethermind.fetch-deps command to fail

--- a/pkgs/nethermind/nuget-deps.nix
+++ b/pkgs/nethermind/nuget-deps.nix
@@ -2,2318 +2,2214 @@
 # Please dont edit it manually, your changes might get overwritten!
 {fetchNuGet}: [
   (fetchNuGet {
-    pname = "Antlr4.Runtime.Standard";
-    version = "4.13.1";
-    sha256 = "14f9qhqagw0l3x0f1jfv001dp313mp1b9d0jirk99q6qwis93yln";
-  })
-  (fetchNuGet {
     pname = "AspNetCore.HealthChecks.UI";
-    version = "8.0.0";
-    sha256 = "1pw34cmcqd9c6agd6vd5lqfz1m47fsckzd9yv878chsh9c0x6sip";
+    version = "8.0.2";
+    hash = "sha256-/jLwdgzHRIeg9C1vNaj3F36IolQyHUIY/Ac1n3rWMeA=";
   })
   (fetchNuGet {
     pname = "AspNetCore.HealthChecks.UI.Client";
-    version = "8.0.0";
-    sha256 = "17ixaz1nkgmwhfiyn3gwkrk2ffw088c8ifq07v67idgz7pzhnjxi";
+    version = "8.0.1";
+    hash = "sha256-/E8EYdVVUZWQx9bGk/6LkgYuPVl8/pRpE0BAlufsNa0=";
   })
   (fetchNuGet {
     pname = "AspNetCore.HealthChecks.UI.Core";
-    version = "8.0.0";
-    sha256 = "1qhihaj1gl4sg31xjw8pwh0lz9m028jrchz3sbp6qafykmrs1m9c";
+    version = "8.0.1";
+    hash = "sha256-onXv+Ll77Ae5cEqBUJdZuyea7sX0jnr5hpFwQhF3cTU=";
   })
   (fetchNuGet {
     pname = "AspNetCore.HealthChecks.UI.Data";
-    version = "8.0.0";
-    sha256 = "1xy80hg97i9h5np2whkkqyr55rgg368b1vl69qdj6v0qfqc4ayc3";
+    version = "8.0.1";
+    hash = "sha256-mBt1DcWzZBJ8YGssxbPZ29nnm5r8+irvOPEkt4Rh0V8=";
   })
   (fetchNuGet {
     pname = "AspNetCore.HealthChecks.UI.InMemory.Storage";
-    version = "8.0.0";
-    sha256 = "19mfj7330hag45ajj1yfl9sp7ddvf95zw5f3s37i3jx4y6v1bf6b";
+    version = "8.0.1";
+    hash = "sha256-FeqWcIEVqFG4J9hAnFep7V3pKcOUPZzGGNN3YXeeZuI=";
   })
   (fetchNuGet {
-    pname = "Castle.Core";
-    version = "5.1.1";
-    sha256 = "1caf4878nvjid3cw3rw18p9cn53brfs5x8dkvf82xvcdwc3i0nd1";
+    pname = "Autofac";
+    version = "8.1.0";
+    hash = "sha256-eDULsT32tESiX89CZTwvL061LwmPjjsxMvU8sYvJYE4=";
+  })
+  (fetchNuGet {
+    pname = "Autofac";
+    version = "8.1.1";
+    hash = "sha256-///N/c/OmCa7DUVz9/hIA/rFsaJ4TMltqdrVk7Ycmq8=";
+  })
+  (fetchNuGet {
+    pname = "Autofac.Extensions.DependencyInjection";
+    version = "10.0.0";
+    hash = "sha256-ACQwFG8a5LMoqGyHI/YpwVyXZQYqM5+wnk0q2BbGVZ4=";
+  })
+  (fetchNuGet {
+    pname = "BinaryEncoding";
+    version = "1.4.0";
+    hash = "sha256-AP06LKHMY98FDSLSjxsc9oUzpbeQzcSTZl1DrVzVFxU=";
+  })
+  (fetchNuGet {
+    pname = "BouncyCastle.Cryptography";
+    version = "2.4.0";
+    hash = "sha256-DoDZNWtYM+0OLIclOEZ+tjcGXymGlXvdvq2ZMPmiAJA=";
   })
   (fetchNuGet {
     pname = "Ckzg.Bindings";
-    version = "0.4.0.696";
-    sha256 = "0szzn4s617a6m10vh6rq15fvdnxlfb0id1k7zqsxd4sy9gbj6xbj";
+    version = "2.0.1.1236";
+    hash = "sha256-51d1V5AnXc4MKivMnW6mfZB3tbmySqTARGRtmUM2ztc=";
   })
   (fetchNuGet {
     pname = "Colorful.Console";
     version = "1.2.15";
-    sha256 = "03g8367lchh42jn6iidj10dnlibr8wlbdarsx7zanp3f4z7lf4rw";
+    hash = "sha256-PBNHzyduXKv+6TqrtihHeUVqGwiyxWisFARCRo8Z6A0=";
+  })
+  (fetchNuGet {
+    pname = "Common.Logging";
+    version = "3.4.1";
+    hash = "sha256-1xeblzYhQCKveUv6z8Z17Dp1P6KKdR8xGykl7tpqbQc=";
+  })
+  (fetchNuGet {
+    pname = "Common.Logging.Core";
+    version = "3.4.1";
+    hash = "sha256-XhZ4hnefxjEcQm6Ls/OFPZCDONFs6j/tM9CKQA8DCBo=";
   })
   (fetchNuGet {
     pname = "ConcurrentHashSet";
     version = "1.3.0";
-    sha256 = "04jydfpzv1pwn60m23fl3qgdsvmcd2nrnn68rviixc031j7bhgp6";
-  })
-  (fetchNuGet {
-    pname = "coverlet.collector";
-    version = "6.0.0";
-    sha256 = "12j34vrkmph8lspbafnqmfnj2qvysz1jcrks2khw798s6dwv0j90";
-  })
-  (fetchNuGet {
-    pname = "coverlet.msbuild";
-    version = "6.0.0";
-    sha256 = "18qgg6d0ybrr70g69yqamgn5qvpyizlii1123cnj65amd0w2rxjl";
+    hash = "sha256-5j64jgwDsB7jzshYm61orG7dHh7UDVGBsfyG/a9rXhI=";
   })
   (fetchNuGet {
     pname = "Crc32.NET";
     version = "1.2.0";
-    sha256 = "0qaj3192k1vfji87zf50rhydn5mrzyzybrs2k4v7ap29k8i0vi5h";
-  })
-  (fetchNuGet {
-    pname = "DiffEngine";
-    version = "11.3.0";
-    sha256 = "0pg96189mw221g5ca6ls7g321v34vl6hsxmi7v5ddjjf1dmwp5k9";
+    hash = "sha256-sMQNIppJXHU2mULn5b//uRbbPMyguH9QlG6HKVIYUmE=";
   })
   (fetchNuGet {
     pname = "DnsClient";
-    version = "1.7.0";
-    sha256 = "0q6sl7nrwks1xl23z0r097g7b95d0j59r08c21dpbf13fyai9mw5";
+    version = "1.8.0";
+    hash = "sha256-Xc8BOCI9M8gSM5raVnPezA4yeO1eoyxXPPn9jh5/RaY=";
   })
   (fetchNuGet {
     pname = "dotnet-xunit";
     version = "2.3.1";
-    sha256 = "0w1zslkig6qk6rhw6ckfy331rnbfbnxr0gdy2pxgnc8rz2fj2s54";
-  })
-  (fetchNuGet {
-    pname = "EmptyFiles";
-    version = "4.4.0";
-    sha256 = "01i3gdnnsryzimr5nkgkgk40r0wcmwbd38f9zjrs9z5bhijzms6r";
+    hash = "sha256-pGghnfgZMfv6Fb49kLtdbtkcxvBuMsNhNhObFyfVP3A=";
   })
   (fetchNuGet {
     pname = "FastEnum";
-    version = "1.8.0";
-    sha256 = "0czqiqq7v02977wy0mr33z06xlfnw805s3051sqqvacil1n4adcv";
+    version = "2.0.2";
+    hash = "sha256-mgmP5CG5ZJc+tMwPaDBfq4YczBsTfkwfBzaM+nlqEow=";
   })
   (fetchNuGet {
-    pname = "FluentAssertions";
-    version = "6.0.0";
-    sha256 = "1p5m89rbaqbrn8vr3bs79j8fcdhasn6n3bcxhajp2f5p4mpzv83f";
+    pname = "FastEnum.Core";
+    version = "2.0.2";
+    hash = "sha256-BGHxwW0mddkmmuCRBxYF3RBR/mGl/uLt2oBNNdGaqUk=";
   })
   (fetchNuGet {
-    pname = "FluentAssertions";
-    version = "6.12.0";
-    sha256 = "04fhn67930zv3i0d8xbrbw5vwz99c83bbvgdwqiir55vw5xlys9c";
-  })
-  (fetchNuGet {
-    pname = "FluentAssertions.Json";
-    version = "6.1.0";
-    sha256 = "0mski8r35y4kp0r2q66v5zjck476xccqvaky77kcpjyf8vmbc5d6";
+    pname = "FastEnum.Generators";
+    version = "2.0.2";
+    hash = "sha256-IGLYl8wD0oF+yEsCR1kwpNdsp5XwDmzEWfqGuPOg2CE=";
   })
   (fetchNuGet {
     pname = "Fractions";
-    version = "7.2.1";
-    sha256 = "0fmvymy9xwippc9zzxks0hqzjzcl4vyxfddyp6yrrid9v5bd9ysq";
+    version = "7.3.0";
+    hash = "sha256-wr4I1mj1qrXjD2Z3dca70OBe14zZNGagDLW9/8xQtCU=";
   })
   (fetchNuGet {
     pname = "FSharp.Core";
     version = "6.0.2";
-    sha256 = "0q4z31i6vw38b6anwjfzxy3ncdazymddi1xyfskkb0s4744ilpi5";
+    hash = "sha256-JV4aCTlEgzWndr6H2Fr1XzVmh+/fSW6VWWjwbWIYn2A=";
   })
   (fetchNuGet {
     pname = "Google.Protobuf";
-    version = "3.25.1";
-    sha256 = "0zcw9vmv2bdai3zaip86s37lj3r5z4zvcs9mf5a9nih0hy4gzwsi";
+    version = "3.28.0";
+    hash = "sha256-Q/p1lM/7SD7WNVC6/V/MNKkH2rJiPOttHgRSJi3BzYk=";
+  })
+  (fetchNuGet {
+    pname = "Google.Protobuf";
+    version = "3.28.3";
+    hash = "sha256-jiA/FeYEEk/u9O1gtdnOzatym+/uHyaRJSdp34TOb1o=";
   })
   (fetchNuGet {
     pname = "Google.Protobuf.Tools";
-    version = "3.25.1";
-    sha256 = "07n74zkf0lfs6hkrdra0fkymw40h947j5j22c6mzygav3snzj6f2";
+    version = "3.28.3";
+    hash = "sha256-3scnHpxxBnDC+K8pY4fraJGepYOS4jnx0LWGIcAgv2U=";
   })
   (fetchNuGet {
     pname = "Grpc";
     version = "2.46.6";
-    sha256 = "1zj2j7h97qdns14z3ilfgqx3kir9p5a05kwsvyz3hpnx2z6j3ysj";
+    hash = "sha256-UvshzRfdXji+35rPAlS5Kcc5On6OxvFJ0Lbhk+CRQv4=";
   })
   (fetchNuGet {
     pname = "Grpc.Core";
     version = "2.46.6";
-    sha256 = "1lyy2l8xxjnfvrf9jxdffms70qqjlz41s0k3y53w637n5qif7hgz";
+    hash = "sha256-/8HjIi72DMNH8WMCHcinEmNwdHWudZlc3s7K3hEV3tM=";
   })
   (fetchNuGet {
     pname = "Grpc.Core.Api";
     version = "2.46.6";
-    sha256 = "1c5h83h2snvwvdzyiinqcls01jx87n7jgma3mvhhv01j2q8qqfhy";
+    hash = "sha256-HjqMERYygA3hrkPVJ489qMsANGXYxuh/23xbLeBAsLA=";
   })
   (fetchNuGet {
     pname = "Grpc.Tools";
-    version = "2.60.0";
-    sha256 = "0fb2g5wzsdbjv42f79s1k0s1y07aikdjac8ryn2y40syamjpz0ih";
+    version = "2.67.0";
+    hash = "sha256-ms/lbWwb9UuJHNl3T5X2mAulCHhQ3tEiqRLWBfUYoV0=";
   })
   (fetchNuGet {
     pname = "Humanizer.Core";
     version = "2.14.1";
-    sha256 = "1ai7hgr0qwd7xlqfd92immddyi41j3ag91h3594yzfsgsy6yhyqi";
+    hash = "sha256-EXvojddPu+9JKgOG9NSQgUTfWq1RpOYw7adxDPKDJ6o=";
   })
   (fetchNuGet {
     pname = "IdentityModel";
     version = "5.2.0";
-    sha256 = "1ynvlj2s3q7v5q8fpnql5f8ga0b84jqwgwgadsyqgpllsik5x2mc";
+    hash = "sha256-rIpeZtSU3oe9burxx7EkaAH1kCsU2+sQLvvgoYWk2/o=";
   })
   (fetchNuGet {
     pname = "IdentityModel.OidcClient";
     version = "5.2.1";
-    sha256 = "10572h3hd5yxm49axjl8xpsh1ni9ikix0xygxap7x4d2kkz5azd9";
+    hash = "sha256-qX1V/pyikX6u6s930OOMKdoA9e2Iyq4Sqd2XBgcUp4A=";
+  })
+  (fetchNuGet {
+    pname = "IPNetwork2";
+    version = "2.1.2";
+    hash = "sha256-E6pmGR1k7cETugh2EWRtdksnzlkdYf4s4BSWI2yoTjs=";
   })
   (fetchNuGet {
     pname = "Jint";
     version = "2.11.58";
-    sha256 = "1nw3mbr1sl198lkwl6bsnfajd3rgw83p63vgi1dackfvx6haywnv";
+    hash = "sha256-23KvoOnbTaZaiG8PcwfiL48mlbN6GconRSlQHfKqg9s=";
+  })
+  (fetchNuGet {
+    pname = "Keccak256";
+    version = "1.0.0";
+    hash = "sha256-QloI81OzR7RIRDQKEJUu/Q8++sujl2Jq0/oxblwDYRA=";
   })
   (fetchNuGet {
     pname = "KubernetesClient";
-    version = "12.1.1";
-    sha256 = "1awv6zg0p54nnjwfxmba54qmlpgxr9ywv5hccaq48dsv6vk2ygp1";
+    version = "14.0.2";
+    hash = "sha256-f7Fg41wsutHOJzzdm/tt25MZ4fhAOp0CK3Z1XUWCMEo=";
+  })
+  (fetchNuGet {
+    pname = "libsodium";
+    version = "1.0.16";
+    hash = "sha256-hSrMyXlZJXq79LcvYqO1pl96eDxJqyj9Tzw23XjARq8=";
+  })
+  (fetchNuGet {
+    pname = "libsodium";
+    version = "1.0.20";
+    hash = "sha256-BsitQQnUSm1YupzI5N/LFx0kPFdk1FP8VdM1S3uttvs=";
   })
   (fetchNuGet {
     pname = "Libuv";
     version = "1.9.0";
-    sha256 = "0ag6l9h1h4knf3hy1fjfrqm6mavr9zw35i0qrnnm8la4mdbcnd0f";
+    hash = "sha256-DjTLVqtEUVStzRjEMvhPeatqKs5OuuDhcHYSGGCi5ik=";
+  })
+  (fetchNuGet {
+    pname = "Makaretu.Dns";
+    version = "2.0.1";
+    hash = "sha256-zeIKCov4J6rKfbgsre0hEDVoFyHVGsrRAf/izZqTytA=";
+  })
+  (fetchNuGet {
+    pname = "Makaretu.Dns.Multicast";
+    version = "0.27.0";
+    hash = "sha256-B/9YIUNmmbjjyeqQdE2qWlr/KCaacFgZKrhvSwEER5Q=";
   })
   (fetchNuGet {
     pname = "MathNet.Numerics";
     version = "5.0.0";
-    sha256 = "0nlrl0rp7h665nafx0g42rqfxmm0pyvk3ydr2y4spilfrra44wj4";
+    hash = "sha256-RHJCVM6OxquJF7n5Mbe/oNbucBbkge6ULcbAczOgmVo=";
   })
   (fetchNuGet {
     pname = "MathNet.Numerics.FSharp";
     version = "5.0.0";
-    sha256 = "06x8ppnzlzmb1gswvygqp8n7x0p1jpx76f7g29h30ck6jzqf3xm4";
+    hash = "sha256-pPbh8JdmMjBgEu84c/qV4YJ+LLr4+c31C6t++u29qBs=";
   })
   (fetchNuGet {
     pname = "Microsoft.AspNetCore.Cryptography.Internal";
-    version = "8.0.0";
-    sha256 = "05qb9r6kz1x32v019za7psjyc7bx7hb7543ngavhmqdd7wz2ni0s";
+    version = "9.0.0";
+    hash = "sha256-+4KzOmzjd9tVvRnDyO6XDYE2PkQwLm/rIeBI83wXYMQ=";
   })
   (fetchNuGet {
     pname = "Microsoft.AspNetCore.DataProtection";
-    version = "8.0.0";
-    sha256 = "1al0d59q7anw2z66d2wkazk6vp4rfa55p42hp2ja8mz9mwa3047j";
+    version = "9.0.0";
+    hash = "sha256-H9bntbgGOP4nbTXSrEdd1MNIQP8dPKUCNL+upnHvGzQ=";
   })
   (fetchNuGet {
     pname = "Microsoft.AspNetCore.DataProtection.Abstractions";
-    version = "8.0.0";
-    sha256 = "18a225dxawbhaawz6pf5d6867kdk5lccwdl7an804ms10kyzh9x5";
+    version = "9.0.0";
+    hash = "sha256-VPNDPPjY5sRlGhuF1FAjuM4tcHNF+EVmj4dMxpNvVcw=";
   })
   (fetchNuGet {
     pname = "Microsoft.AspNetCore.DataProtection.Extensions";
-    version = "8.0.0";
-    sha256 = "1nfl57pbh9x8x9ry49p5ninkzlmkp4y1mkw89hhyszgpqazr532n";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.AspNetCore.Http.Abstractions";
-    version = "2.2.0";
-    sha256 = "13s8cm6jdpydxmr0rgmzrmnp1v2r7i3rs7v9fhabk5spixdgfy6b";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.AspNetCore.Http.Extensions";
-    version = "2.2.0";
-    sha256 = "118gp1mfb8ymcvw87fzgjqwlc1d1b0l0sbfki291ydg414cz3dfn";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.AspNetCore.Http.Features";
-    version = "2.2.0";
-    sha256 = "0xrlq8i61vzhzzy25n80m7wh2kn593rfaii3aqnxdsxsg6sfgnx1";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.AspNetCore.WebSockets";
-    version = "2.2.1";
-    sha256 = "0gzikr1z2fdz8nzy1m969jsrk2h97ld1hzgmbc6f036qmhiq26hr";
+    version = "9.0.0";
+    hash = "sha256-yeDHAgxFsPqi5xRpNvboA/ToiU73gDSYW4NHl5rWA5w=";
   })
   (fetchNuGet {
     pname = "Microsoft.Bcl.AsyncInterfaces";
     version = "6.0.0";
-    sha256 = "15gqy2m14fdlvy1g59207h5kisznm355kbw010gy19vh47z8gpz3";
+    hash = "sha256-49+H/iFwp+AfCICvWcqo9us4CzxApPKC37Q5Eqrw+JU=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Build.Tasks.Git";
+    version = "8.0.0";
+    hash = "sha256-vX6/kPij8vNAu8f7rrvHHhPrNph20IcufmrBgZNxpQA=";
   })
   (fetchNuGet {
     pname = "Microsoft.ClearScript.Core";
-    version = "7.4.4";
-    sha256 = "1i4sxv8v4sq1s7vkis3xc8rllwgwi40fz12890mlvf4xbzggk4ii";
+    version = "7.4.5";
+    hash = "sha256-6wRLv+fbo2SF9irQ8BwmUR7JcQAlyEk1Dov+teSXY+E=";
   })
   (fetchNuGet {
     pname = "Microsoft.ClearScript.V8";
-    version = "7.4.4";
-    sha256 = "1a7cc4a1lrpx9y2v75y9s4cj814akm1vj6lar2qxj5hhf8rnxk4m";
+    version = "7.4.5";
+    hash = "sha256-MXl1n1RF6z95IbpXmSGAwraP8EpvPli16ySFGfc/ZxY=";
   })
   (fetchNuGet {
     pname = "Microsoft.ClearScript.V8.ICUData";
-    version = "7.4.4";
-    sha256 = "0rwy35kb61bvm4ghx4kmhxnlm4bk2c7ddg2gl83zwamv41k261w6";
+    version = "7.4.5";
+    hash = "sha256-54bbiVJoXDrePISZHuEcOax+kgyaIftL684bt3EgYy8=";
   })
   (fetchNuGet {
     pname = "Microsoft.ClearScript.V8.Native.linux-arm64";
-    version = "7.4.4";
-    sha256 = "0iaiqxprzb097b9361m1zl6k12jgdb1ij04cr0wdvrjbk6lgc7lg";
+    version = "7.4.5";
+    hash = "sha256-pufUKVsXaKOc7FoKxHwtvMDzx2etOLOzTXvWhBRy1Ho=";
   })
   (fetchNuGet {
     pname = "Microsoft.ClearScript.V8.Native.linux-x64";
-    version = "7.4.4";
-    sha256 = "12kf79dwhcdwy6wsc7a2ryq8qf4d5jq1p7kwlbqbnl9b0k7yxhrk";
+    version = "7.4.5";
+    hash = "sha256-MCRTRO7WiWnWYdvYSwv1kvZakcVcvckio98SJLhYgoM=";
   })
   (fetchNuGet {
     pname = "Microsoft.ClearScript.V8.Native.osx-arm64";
-    version = "7.4.4";
-    sha256 = "0a5cyawb20yjhpwrb14gdbx1sjdfk1ls9gcn83fvwhvdzvk906dz";
+    version = "7.4.5";
+    hash = "sha256-SbcABxK8rPIE6SV1JBP2U3FYmrgaY7iB9sFQKNLyAVs=";
   })
   (fetchNuGet {
     pname = "Microsoft.ClearScript.V8.Native.osx-x64";
-    version = "7.4.4";
-    sha256 = "0vw5jvpz430fx7sbjv1i80l6npiymi2m37l6dl8bvlh565crk76g";
+    version = "7.4.5";
+    hash = "sha256-IvttjtyJXWVhuJNkqqxNpLwM3WtljHuHSaKtSkblAqE=";
   })
   (fetchNuGet {
     pname = "Microsoft.ClearScript.V8.Native.win-x64";
-    version = "7.4.4";
-    sha256 = "1kwv3rvmb4pp1kp9dw8v0nhjrxfci4xz39gxs5ck0j802w65g7b4";
+    version = "7.4.5";
+    hash = "sha256-WF4K7g1w510viiXHJJjKQrsD/mvb99tF76yBCljN1Qw=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.Analyzers";
     version = "1.1.0";
-    sha256 = "08r667hj2259wbim1p3al5qxkshydykmb7nd9ygbjlg4mmydkapc";
+    hash = "sha256-7KrZfK3kUbmeT82eVadvHurZcaFq3FDj4qkIIeExJiM=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.Analyzers";
     version = "3.3.3";
-    sha256 = "09m4cpry8ivm9ga1abrxmvw16sslxhy2k5sl14zckhqb1j164im6";
+    hash = "sha256-pkZiggwLw8k+CVSXKTzsVGsT+K49LxXUS3VH5PNlpCY=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.Common";
     version = "1.3.0";
-    sha256 = "097qi36jhyllpqj313nxzwc64a4f65p014gaj6fz4z5jcphkkk15";
+    hash = "sha256-Jcw54WWyfPKdkeqRAG4xjihiGP/djjAkvpR6KM2I+CQ=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.Common";
     version = "4.5.0";
-    sha256 = "0hjzca7v3qq4wqzi9chgxzycbaysnjgj28ps20695x61sia6i3da";
+    hash = "sha256-qo1oVNTB9JIMEPoiIZ+02qvF/O8PshQ/5gTjsY9iX0I=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.CSharp";
     version = "1.3.0";
-    sha256 = "0vpslncd5lk88ijb42qbp88dfrd0fg4kri44w6jpmxb3fcqazais";
+    hash = "sha256-OqqvMHNj9Xql4YTEPMlzoGXXELoLC7JkRGjS0pil+m4=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.CSharp";
     version = "4.5.0";
-    sha256 = "1l6v0ii5lapmfnfpjwi3j5bwlx8v9nvyani5pwvqzdfqsd5m7mp5";
+    hash = "sha256-5dZTS9PYtY83vyVa5bdNG3XKV5EjcnmddfUqWmIE29A=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.CSharp.Workspaces";
     version = "4.5.0";
-    sha256 = "0skg5a8i4fq6cndxcjwciai808p0zpqz9kbvck94mcywfzassv1a";
+    hash = "sha256-Kmyt1Xfcs0rSZHvN9PH94CKAooqMS9abZQY7EpEqb2o=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.VisualBasic";
     version = "1.3.0";
-    sha256 = "186chky80rryhzh5dh8j318ghyvn1a7r2876rlyadxdrs7aqv0ll";
+    hash = "sha256-lIKN1dG59aY8zeYgkY8Kdnv4UBgSwVbghz5ngPyEzKA=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.Workspaces.Common";
     version = "4.5.0";
-    sha256 = "1wjwsrnn5frahqciwaxsgalv80fs6xhqy6kcqy7hcsh7jrfc1kjq";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.CodeCoverage";
-    version = "17.8.0";
-    sha256 = "173wjadp3gan4x2jfjchngnc4ca4mb95h1sbb28jydfkfw0z1zvj";
+    hash = "sha256-WM7AXJYHagaPx2waj2E32gG0qXq6Kx4Zhiq7Ym3WXPI=";
   })
   (fetchNuGet {
     pname = "Microsoft.CSharp";
     version = "4.0.1";
-    sha256 = "0zxc0apx1gcx361jlq8smc9pfdgmyjh6hpka8dypc9w23nlsh6yj";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.CSharp";
-    version = "4.3.0";
-    sha256 = "0gw297dgkh0al1zxvgvncqs0j15lsna9l1wpqas4rflmys440xvb";
+    hash = "sha256-0huoqR2CJ3Z9Q2peaKD09TV3E6saYSqDGZ290K8CrH8=";
   })
   (fetchNuGet {
     pname = "Microsoft.CSharp";
     version = "4.7.0";
-    sha256 = "0gd67zlw554j098kabg887b5a6pq9kzavpa3jjy5w53ccjzjfy8j";
+    hash = "sha256-Enknv2RsFF68lEPdrf5M+BpV1kHoLTVRApKUwuk/pj0=";
   })
   (fetchNuGet {
     pname = "Microsoft.EntityFrameworkCore";
     version = "8.0.0";
-    sha256 = "1xhmax0xrvw4lyz1868f1sr3nbrcv3ckr5qnf61c8q9bwj06b9v7";
+    hash = "sha256-Z6dlgOQrYcSCcRaXPNnYLC87sg4OGRS+p4Tv3EFXFfY=";
   })
   (fetchNuGet {
     pname = "Microsoft.EntityFrameworkCore.Abstractions";
     version = "8.0.0";
-    sha256 = "019r991228nxv1fibsxg5z81rr7ydgy77c9v7yvlx35kfppxq4s3";
+    hash = "sha256-QxPc73WzjE63Pzuxc/xr/uQc0C+v6xVd2N0iIUJKOQU=";
   })
   (fetchNuGet {
     pname = "Microsoft.EntityFrameworkCore.Analyzers";
     version = "8.0.0";
-    sha256 = "1vcbad0pzkx5wadnd5inglx56x0yybdlxgknbhifdga0bx76j9sa";
+    hash = "sha256-SidpTl9AveYiXHa+TtvyHnRTOn02lmab4qXPf0FTi+0=";
   })
   (fetchNuGet {
     pname = "Microsoft.EntityFrameworkCore.Design";
     version = "8.0.0";
-    sha256 = "0pa1v87q4hzphv0h020adw7hn84803lrrxylk8h57j93axm5kmm0";
+    hash = "sha256-oNZZalcjyVMgmtT3nOkAiCALD28KCADBhvdDgg/aQV0=";
   })
   (fetchNuGet {
     pname = "Microsoft.EntityFrameworkCore.InMemory";
     version = "8.0.0";
-    sha256 = "0x78a5hjy73ncjnhi50x54wrn935kc3s0r9sjd5436xchcq6l4d4";
+    hash = "sha256-pBFqMIOsm0FKkzploAebZSSbOSkdlAitZHYcL2FR6HQ=";
   })
   (fetchNuGet {
     pname = "Microsoft.EntityFrameworkCore.Relational";
     version = "8.0.0";
-    sha256 = "0ngsxk717si11g4a01ah2np8gp8b3k09y23229anr9jrhykr1bw1";
+    hash = "sha256-ga+Qp4dZpmxVEmIIn8AcC92HrhVQBaDICyHqE87s+lk=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Caching.Abstractions";
     version = "8.0.0";
-    sha256 = "04m6ywsf9731z24nfd14z0ah8xl06619ba7mkdb4vg8h5jpllsn4";
+    hash = "sha256-xGpKrywQvU1Wm/WolYIxgHYEFfgkNGeJ+GGc5DT3phI=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Caching.Memory";
     version = "8.0.0";
-    sha256 = "0bv8ihd5i2gwr97qljwf56h8mdwspmlw0zs64qyk608fb3ciwi25";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.CommandLineUtils";
-    version = "1.1.1";
-    sha256 = "0g61kphvdira64g543qlf610sia02scdmki1566d5kr6v390qvbq";
+    hash = "sha256-RUQe2VgOATM9JkZ/wGm9mreKoCmOS4pPyvyJWBqMaC8=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Configuration";
     version = "3.1.0";
-    sha256 = "1rszgz0rd5kvib5fscz6ss3pkxyjwqy0xpd4f2ypgzf5z5g5d398";
+    hash = "sha256-KI1WXvnF/Xe9cKTdDjzm0vd5h9bmM+3KinuWlsF/X+c=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Configuration";
     version = "8.0.0";
-    sha256 = "080kab87qgq2kh0ijry5kfdiq9afyzb8s0k3jqi5zbbi540yq4zl";
+    hash = "sha256-9BPsASlxrV8ilmMCjdb3TiUcm5vFZxkBnAI/fNBSEyA=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Configuration.Abstractions";
     version = "3.1.0";
-    sha256 = "1f7h52kamljglx5k08ccryilvk6d6cvr9c26lcb6b2c091znzk0q";
+    hash = "sha256-GMxvf0iAiWUWo0awlDczzcxNo8+MITBLp0/SqqYo8Lg=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Configuration.Abstractions";
     version = "8.0.0";
-    sha256 = "1jlpa4ggl1gr5fs7fdcw04li3y3iy05w3klr9lrrlc7v8w76kq71";
+    hash = "sha256-4eBpDkf7MJozTZnOwQvwcfgRKQGcNXe0K/kF+h5Rl8o=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.Configuration.Abstractions";
+    version = "9.0.0";
+    hash = "sha256-xtG2USC9Qm0f2Nn6jkcklpyEDT3hcEZOxOwTc0ep7uc=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Configuration.Binder";
     version = "3.1.0";
-    sha256 = "13jj7jxihiswmhmql7r5jydbca4x5qj6h7zq10z17gagys6dc7pw";
+    hash = "sha256-/B7WjPZPvRM+CPgfaCQunSi2mpclH4orrFxHGLs8Uo4=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Configuration.Binder";
     version = "8.0.0";
-    sha256 = "1m0gawiz8f5hc3li9vd5psddlygwgkiw13d7div87kmkf4idza8r";
+    hash = "sha256-GanfInGzzoN2bKeNwON8/Hnamr6l7RTpYLA49CNXD9Q=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.DependencyInjection";
     version = "3.1.0";
-    sha256 = "1xc61dy07bn2q73mx1z3ylrw80xpa682qjby13gklnqq636a3gab";
+    hash = "sha256-S72hzDAYWzrfCH5JLJBRtwPEM/Xjh17HwcKuA3wLhvU=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.DependencyInjection";
     version = "5.0.0";
-    sha256 = "15sdwcyzz0qlybwbdq854bn3jk6kx7awx28gs864c4shhbqkppj4";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.DependencyInjection";
-    version = "6.0.0";
-    sha256 = "1wlhb2vygzfdjbdzy7waxblmrx0q3pdcqvpapnpmq9fcx5m8r6w1";
+    hash = "sha256-RN478YJQE0YM0g+JztXp00w57CIF4bb48hSD/z3jTZc=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.DependencyInjection";
     version = "8.0.0";
-    sha256 = "0i7qziz0iqmbk8zzln7kx9vd0lbx1x3va0yi3j1bgkjir13h78ps";
+    hash = "sha256-+qIDR8hRzreCHNEDtUcPfVHQdurzWPo/mqviCH78+EQ=";
   })
   (fetchNuGet {
-    pname = "Microsoft.Extensions.DependencyInjection.Abstractions";
-    version = "2.2.0";
-    sha256 = "1jyzfdr9651h3x6pxwhpfbb9mysfh8f8z1jvy4g117h9790r9zx5";
+    pname = "Microsoft.Extensions.DependencyInjection";
+    version = "9.0.0";
+    hash = "sha256-dAH52PPlTLn7X+1aI/7npdrDzMEFPMXRv4isV1a+14k=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.DependencyInjection.Abstractions";
     version = "3.1.0";
-    sha256 = "1pvms778xkyv1a3gfwrxnh8ja769cxi416n7pcidn9wvg15ifvbh";
+    hash = "sha256-cG0XS3ibJ9siu8eaQGJnyRwlEbQ9c/eGCtvPjs7Rdd8=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.DependencyInjection.Abstractions";
     version = "5.0.0";
-    sha256 = "17cz6s80va0ch0a6nqa1wbbbp3p8sqxb96lj4qcw67ivkp2yxiyj";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.DependencyInjection.Abstractions";
-    version = "6.0.0";
-    sha256 = "1vi67fw7q99gj7jd64gnnfr4d2c0ijpva7g9prps48ja6g91x6a9";
+    hash = "sha256-0sfuxZ07HsMZJpKatDrW6I671uJBYWsUgAyoDZA2n50=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.DependencyInjection.Abstractions";
     version = "8.0.0";
-    sha256 = "1zw0bpp5742jzx03wvqc8csnvsbgdqi0ls9jfc5i2vd3cl8b74pg";
+    hash = "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.DependencyInjection.Abstractions";
+    version = "8.0.1";
+    hash = "sha256-lzTYLpRDAi3wW9uRrkTNJtMmaYdtGJJHdBLbUKu60PM=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.DependencyInjection.Abstractions";
+    version = "9.0.0";
+    hash = "sha256-CncVwkKZ5CsIG2O0+OM9qXuYXh3p6UGyueTHSLDVL+c=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.DependencyModel";
     version = "8.0.0";
-    sha256 = "02jnx23hm1vid3yd9pw4gghzn6qkgdl5xfc5r0zrcxdax70rsh5a";
+    hash = "sha256-qkCdwemqdZY/yIW5Xmh7Exv74XuE39T8aHGHCofoVgo=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Diagnostics";
     version = "8.0.0";
-    sha256 = "0ghwkld91k20hcbmzg2137w81mzzdh8hfaapdwckhza0vipya4kw";
+    hash = "sha256-fBLlb9xAfTgZb1cpBxFs/9eA+BlBvF8Xg0DMkBqdHD4=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Diagnostics.Abstractions";
     version = "8.0.0";
-    sha256 = "15m4j6w9n8h0mj7hlfzb83hd3wn7aq1s7fxbicm16slsjfwzj82i";
+    hash = "sha256-USD5uZOaahMqi6u7owNWx/LR4EDrOwqPrAAim7iRpJY=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.Diagnostics.Abstractions";
+    version = "9.0.0";
+    hash = "sha256-wG1LcET+MPRjUdz3HIOTHVEnbG/INFJUqzPErCM79eY=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Diagnostics.HealthChecks";
     version = "8.0.0";
-    sha256 = "0l3a4cf7g31l61w68r9jjsd4fpxawlrjb58k5xf15yd5nahbiynq";
+    hash = "sha256-2Pq4oLKl+RJcLxOVJTPlql9HmpYyZWR4MDSMdxwjalA=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions";
     version = "8.0.0";
-    sha256 = "16qa4yxy17awjaag1xhpw574gfkjjjqs24sydl0rj25kwvk3c728";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.FileProviders.Abstractions";
-    version = "2.2.0";
-    sha256 = "1f83ffb4xjwljg8dgzdsa3pa0582q6b4zm0si467fgkybqzk3c54";
+    hash = "sha256-SBw25uazCJkBbV4TobGUcrpHTuEX9vCUklyd4LsnCps=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.FileProviders.Abstractions";
     version = "8.0.0";
-    sha256 = "1idq65fxwcn882c06yci7nscy9i0rgw6mqjrl7362prvvsd9f15r";
+    hash = "sha256-uQSXmt47X2HGoVniavjLICbPtD2ReQOYQMgy3l0xuMU=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.FileProviders.Abstractions";
+    version = "9.0.0";
+    hash = "sha256-mVfLjZ8VrnOQR/uQjv74P2uEG+rgW72jfiGdSZhIfDc=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Hosting.Abstractions";
     version = "8.0.0";
-    sha256 = "00d5dwmzw76iy8z40ly01hy9gly49a7rpf7k7m99vrid1kxp346h";
+    hash = "sha256-0JBx+wwt5p1SPfO4m49KxNOXPAzAU0A+8tEc/itvpQE=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.Hosting.Abstractions";
+    version = "9.0.0";
+    hash = "sha256-NhEDqZGnwCDFyK/NKn1dwLQExYE82j1YVFcrhXVczqY=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Http";
     version = "3.1.0";
-    sha256 = "02ipxf75rqzsbmmy5ka44hh8krmxgky9mdxmh8f7fkbclpg2s6cy";
+    hash = "sha256-nhkt3qVsTXccgrW3mvx8veaJICREzeJrXfrjXI7rNwo=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Http";
     version = "8.0.0";
-    sha256 = "09hmkhxipbpfmwz9q80746zp6cvbx1cqffxr5xjxv5cbjg5662aj";
+    hash = "sha256-UgljypOLld1lL7k7h1noazNzvyEHIJw+r+6uGzucFSY=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Logging";
     version = "3.1.0";
-    sha256 = "1d3yhqj1rav7vswm747j7w8fh8paybji4rz941hhlq4b12mfqfh4";
+    hash = "sha256-BDrsqgiLYAphIOlnEuXy6iLoED/ykFO53merHCSGfrQ=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Logging";
     version = "5.0.0";
-    sha256 = "1qa1l18q2jh9azya8gv1p8anzcdirjzd9dxxisb4911i9m1648i3";
+    hash = "sha256-IyJiQk0xhESWjr231L7MsbFvFbphP6T8VwlKgVGgQeE=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Logging";
     version = "6.0.0";
-    sha256 = "0fd9jii3y3irfcwlsiww1y9npjgabzarh33rn566wpcz24lijszi";
+    hash = "sha256-8WsZKRGfXW5MsXkMmNVf6slrkw+cR005czkOP2KUqTk=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Logging";
     version = "8.0.0";
-    sha256 = "0nppj34nmq25gnrg0wh1q22y4wdqbih4ax493f226azv8mkp9s1i";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.Logging.Abstractions";
-    version = "2.2.0";
-    sha256 = "02w7hp6jicr7cl5p456k2cmrjvvhm6spg5kxnlncw3b72358m5wl";
+    hash = "sha256-Meh0Z0X7KyOEG4l0RWBcuHHihcABcvCyfUXgasmQ91o=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Logging.Abstractions";
     version = "3.1.0";
-    sha256 = "1zyalrcksszmn9r5xjnirfh7847axncgzxkk3k5srbvlcch8fw8g";
+    hash = "sha256-D3GHIGN0r6zLHHP2/5jt6hB0oMvRyl5ysvVrPVmmyv8=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Logging.Abstractions";
     version = "5.0.0";
-    sha256 = "1yza38675dbv1qqnnhqm23alv2bbaqxp0pb7zinjmw8j2mr5r6wc";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.Logging.Abstractions";
-    version = "6.0.0";
-    sha256 = "0b75fmins171zi6bfdcq1kcvyrirs8n91mknjnxy4c3ygi1rrnj0";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.Logging.Abstractions";
-    version = "7.0.1";
-    sha256 = "0xv3sqc1lbx5j4yy6g2w3kakzvrpwqs2ihax6lqasj5sz5map6fk";
+    hash = "sha256-jJtcchUS8Spt/GddcDtWa4lN1RAVQ2sxDnu1cgwa6vs=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Logging.Abstractions";
     version = "8.0.0";
-    sha256 = "1klcqhg3hk55hb6vmjiq2wgqidsl81aldw0li2z98lrwx26msrr6";
+    hash = "sha256-Jmddjeg8U5S+iBTwRlVAVLeIHxc4yrrNgqVMOB7EjM4=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.Logging.Abstractions";
+    version = "9.0.0";
+    hash = "sha256-iBTs9twjWXFeERt4CErkIIcoJZU1jrd1RWCI8V5j7KU=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Logging.Configuration";
     version = "8.0.0";
-    sha256 = "1d9b734vnll935661wqkgl7ry60rlh5p876l2bsa930mvfsaqfcv";
+    hash = "sha256-mzmstNsVjKT0EtQcdAukGRifD30T82BMGYlSu8k4K7U=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Logging.Console";
     version = "8.0.0";
-    sha256 = "1mvp3ipw7k33v2qw2yrvc4vl5yzgpk3yxa94gg0gz7wmcmhzvmkd";
+    hash = "sha256-bdb9YWWVn//AeySp7se87/tCN2E7e8Gx2GPMw28cd9c=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.ObjectPool";
     version = "7.0.0";
-    sha256 = "15lz0qk2gr2q52i05ip51dzm9p4hzqlrammkc0hv2ng6g0z72697";
+    hash = "sha256-JxlxPnjmWbEhYLNWlSn+kNxUfwvlxgKiKFjkJyYGn5Y=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.ObjectPool";
-    version = "8.0.0";
-    sha256 = "0j76rwav1yxirb84zpik625xh991mw6xh0wnlzkspjxlc3j6n48p";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.Options";
-    version = "2.2.0";
-    sha256 = "1b20yh03fg4nmmi3vlf6gf13vrdkmklshfzl3ijygcs4c2hly6v0";
+    version = "9.0.0";
+    hash = "sha256-mX2Y2bHwScjXh1xQOweawmwo7jYLw+MhePibk/96dMY=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Options";
     version = "3.1.0";
-    sha256 = "0akccwhpn93a4qrssyb3rszdsp3j4p9hlxbsb7yhqb78xydaqhyh";
+    hash = "sha256-0EOsmu/oLAz9WXp1CtMlclzdvs5jea0zJmokeyFnbCo=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Options";
     version = "5.0.0";
-    sha256 = "1rdmgpg770x8qwaaa6ryc27zh93p697fcyvn5vkxp0wimlhqkbay";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.Options";
-    version = "6.0.0";
-    sha256 = "008pnk2p50i594ahz308v81a41mbjz9mwcarqhmrjpl2d20c868g";
+    hash = "sha256-Xq2JIa2Rg9vnLnZ75k4ydyT4j2A+G6UUx6iDc959teU=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Options";
     version = "8.0.0";
-    sha256 = "0p50qn6zhinzyhq9sy5svnmqqwhw2jajs2pbjh9sah504wjvhscz";
+    hash = "sha256-n2m4JSegQKUTlOsKLZUUHHKMq926eJ0w9N9G+I3FoFw=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.Options";
+    version = "8.0.2";
+    hash = "sha256-AjcldddddtN/9aH9pg7ClEZycWtFHLi9IPe1GGhNQys=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.Options";
+    version = "9.0.0";
+    hash = "sha256-DT5euAQY/ItB5LPI8WIp6Dnd0lSvBRP35vFkOXC68ck=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Options.ConfigurationExtensions";
     version = "8.0.0";
-    sha256 = "04nm8v5a3zp0ill7hjnwnja3s2676b4wffdri8hdk2341p7mp403";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.Primitives";
-    version = "2.2.0";
-    sha256 = "0znah6arbcqari49ymigg3wiy2hgdifz8zsq8vdc3ynnf45r7h0c";
+    hash = "sha256-A5Bbzw1kiNkgirk5x8kyxwg9lLTcSngojeD+ocpG1RI=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Primitives";
     version = "3.1.0";
-    sha256 = "1w1y22njywwysi8qjnj4m83qhbq0jr4mmjib0hfawz6cwamh7xrb";
+    hash = "sha256-K/cDq+LMfK4cBCvKWkmWAC+IB6pEWolR1J5zL60QPvA=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Primitives";
     version = "5.0.0";
-    sha256 = "0swqcknyh87ns82w539z1mvy804pfwhgzs97cr3nwqk6g5s42gd6";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Extensions.Primitives";
-    version = "6.0.0";
-    sha256 = "1kjiw6s4yfz9gm7mx3wkhp06ghnbs95icj9hi505shz9rjrg42q2";
+    hash = "sha256-pj1BdHlmYm5HZifp/yB3lwDkdw0/jcIF0vYg6O1kmGs=";
   })
   (fetchNuGet {
     pname = "Microsoft.Extensions.Primitives";
     version = "8.0.0";
-    sha256 = "0aldaz5aapngchgdr7dax9jw5wy7k7hmjgjpfgfv1wfif27jlkqm";
+    hash = "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Extensions.Primitives";
+    version = "9.0.0";
+    hash = "sha256-ZNLusK1CRuq5BZYZMDqaz04PIKScE2Z7sS2tehU7EJs=";
   })
   (fetchNuGet {
     pname = "Microsoft.IdentityModel.Abstractions";
-    version = "7.0.0";
-    sha256 = "0sc96z969qfybq5njsqm8hwhqv8jj6gysyjq7n9r9km1nqnhazmi";
+    version = "7.1.2";
+    hash = "sha256-QN2btwsc8XnOp8RxwSY4ntzpqFIrWRZg6ZZEGBZ6TQY=";
   })
   (fetchNuGet {
     pname = "Microsoft.IdentityModel.Abstractions";
-    version = "7.1.2";
-    sha256 = "01jdg8b1hi4nx5h1cn9baalfkp4y70kc2wf4lz77kw8w1fvrppa0";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.IdentityModel.JsonWebTokens";
-    version = "7.0.0";
-    sha256 = "12xa4yx19j5q7nbisl57jla8x6pby964cr9xkv0qm4834x4zdd3h";
+    version = "8.2.1";
+    hash = "sha256-+9aIQ5tVPM915SEaquiiVUYaW2wk2MvkYWEMTzGYEl4=";
   })
   (fetchNuGet {
     pname = "Microsoft.IdentityModel.JsonWebTokens";
     version = "7.1.2";
-    sha256 = "1y9yq07hr91aaxm7pahv3fc590dzydlffr4hs3zix1g45pvd4m4i";
+    hash = "sha256-kVTS9i3khR7/0JBk52jzv4FUmBsbqntqVyqkDA/APvk=";
   })
   (fetchNuGet {
-    pname = "Microsoft.IdentityModel.Logging";
-    version = "7.0.0";
-    sha256 = "0hv1qb51v6frvhybwcn6m3haq768jgdx59p17jn217fbjiprq14s";
+    pname = "Microsoft.IdentityModel.JsonWebTokens";
+    version = "8.2.1";
+    hash = "sha256-0tL7K87O8w2IOje7+WFZQiPiYFWLMqMRsVoHKVose+0=";
   })
   (fetchNuGet {
     pname = "Microsoft.IdentityModel.Logging";
     version = "7.1.2";
-    sha256 = "1yi7s2pm4f8vl6b0qck0nrfsrf1h4jwamznkzl75n1cwxpbdikp8";
+    hash = "sha256-6M7Y1u2cBVsO/dP+qrgkMLisXbZgMgyWoRs5Uq/QJ/o=";
   })
   (fetchNuGet {
-    pname = "Microsoft.IdentityModel.Tokens";
-    version = "7.0.0";
-    sha256 = "0cjdbi3ximvfz2nyp2vlxqskmscxw8drjighvy7dna3mi749isrh";
+    pname = "Microsoft.IdentityModel.Logging";
+    version = "8.2.1";
+    hash = "sha256-0FHmPBoogYIEAa7hxVvxIYy1jCCB3NmnVS5eoVWsjrU=";
   })
   (fetchNuGet {
     pname = "Microsoft.IdentityModel.Tokens";
     version = "7.1.2";
-    sha256 = "1q70c1ax9f5nggqp4g8nyfaz0481grsaxhp85cmjpmx8l3q35zx9";
+    hash = "sha256-qf8y8KCo1ysrK+jCrnR+ARHwlfMWPXLxe7a41FVg4OA=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.IdentityModel.Tokens";
+    version = "8.2.1";
+    hash = "sha256-kO/Xrv/XbJ0hKqA0PFWMKJA8EBCuAjBO7D6XoPH0l8k=";
   })
   (fetchNuGet {
     pname = "Microsoft.IO.RecyclableMemoryStream";
     version = "3.0.0";
-    sha256 = "1zl39k27r4zq75r1x1zr1yl4nzxpkxdnnv6dwd4qp0xr22my85aq";
+    hash = "sha256-WBXkqxC5g4tJ481sa1uft39LqA/5hx5yOfiTfMRMg/4=";
   })
   (fetchNuGet {
-    pname = "Microsoft.Net.Http.Headers";
-    version = "2.2.0";
-    sha256 = "0w6lrk9z67bcirq2cj2ldfhnizc6id77ba6i30hjzgqjlyhh1gx5";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NET.Test.Sdk";
-    version = "17.8.0";
-    sha256 = "1syvl3g0hbrcgfi9rq6pld8s8hqqww4dflf1lxn59ccddyyx0gmv";
+    pname = "Microsoft.IO.RecyclableMemoryStream";
+    version = "3.0.1";
+    hash = "sha256-unFg/5EcU/XKJbob4GtQC43Ydgi5VjeBGs7hfhj4EYo=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.App";
     version = "1.0.0";
-    sha256 = "0i09cs7a7hxn9n1nx49382csvc7560j4hbxr2c8bwa69nhf2rrjp";
+    hash = "sha256-V+YsHLTJKL4QE7kvSCQw5bCtmUAjkW6DTbbDo45mCUQ=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.DotNetHost";
     version = "1.0.1";
-    sha256 = "1qr4gnzlpwzv8jr7ijmdg13x2s9m35g4ma0bh18kci4ml7h9jb6a";
+    hash = "sha256-yiyZ4KGVRDZRgAuoSl4ZNWnRR3ityniyRPvzS799JOM=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.DotNetHostPolicy";
     version = "1.0.1";
-    sha256 = "0vbqww1bmlkz7xq05zxykv27xdrkl6nrjhs1iiszaa9ivf7nklz1";
+    hash = "sha256-4dNpj9sxKfV1jEFDma2hM7d+xJ6+/wJwP3/SugLneG0=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.DotNetHostResolver";
     version = "1.0.1";
-    sha256 = "109zs3bqhzh6mhbf2rfpwxmpb8fq57jr7wriyylynirsqh1lnql4";
+    hash = "sha256-hGJLA8Q6R+up9zHzk+Up2KF1a+fXZeEWrAZ+iNfQP4E=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.Jit";
     version = "1.0.2";
-    sha256 = "0jaan2wmg80lr0mhgfy70kb5cqjwv1a2ikmxgd0glpcxp7wr7pag";
+    hash = "sha256-T92T+bmdXfpAe73OKFTYXGJW1gTHuwcryBSgV7mwSkk=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.Platforms";
     version = "1.0.1";
-    sha256 = "01al6cfxp68dscl15z7rxfw9zvhm64dncsw09a1vmdkacsa2v6lr";
+    hash = "sha256-mZotlGZqtrqDSoBrZhsxFe6fuOv5/BIo0w2Z2x0zVAU=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.Platforms";
     version = "1.1.0";
-    sha256 = "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NETCore.Platforms";
-    version = "1.1.1";
-    sha256 = "164wycgng4mi9zqi2pnsf1pq6gccbqvw6ib916mqizgjmd8f44pj";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.NETCore.Platforms";
-    version = "5.0.0";
-    sha256 = "0mwpwdflidzgzfx2dlpkvvnkgkr2ayaf0s80737h4wa35gaj11rc";
+    hash = "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.Runtime.CoreCLR";
     version = "1.0.2";
-    sha256 = "1hxgsjyzh7hdgd34xwpn5s2myy1b1y9ms7xhvs6mkb75wap49bpc";
+    hash = "sha256-7K5EruLlrFmN3rAfXZMPK3hfhS728k5Gew0e+L3Ur8M=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.Targets";
     version = "1.0.1";
-    sha256 = "0ppdkwy6s9p7x9jix3v4402wb171cdiibq7js7i13nxpdky7074p";
+    hash = "sha256-lxxw/Gy32xHi0fLgFWNj4YTFBSBkjx5l6ucmbTyf7V4=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.Targets";
     version = "1.1.0";
-    sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
+    hash = "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.Windows.ApiSets";
     version = "1.0.1";
-    sha256 = "16k8chghkr25jf49banhzl839vs8n3vbfpg4wn4idi0hzjipix78";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.TestPlatform.ObjectModel";
-    version = "17.8.0";
-    sha256 = "0b0i7lmkrcfvim8i3l93gwqvkhhhfzd53fqfnygdqvkg6np0cg7m";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.TestPlatform.TestHost";
-    version = "17.8.0";
-    sha256 = "0f5jah93kjkvxwmhwb78lw11m9pkkq9fvf135hpymmmpxqbdh97q";
+    hash = "sha256-6PR4o/wQxBaJ5eRdt/awSO80EP3QqpWIk0XkCR9kaJo=";
   })
   (fetchNuGet {
     pname = "Microsoft.VisualBasic";
     version = "10.0.1";
-    sha256 = "0q6vv9qfkbwn7gz8qf1gfcn33r87m260hsxdsk838mcbqmjz6wgc";
+    hash = "sha256-7HHzZcWLVTTQ1K1rCIyoB+UxLHMvOIz+O5av6XDa22A=";
   })
   (fetchNuGet {
     pname = "Microsoft.VisualStudio.Azure.Containers.Tools.Targets";
-    version = "1.19.5";
-    sha256 = "0m0j33fj8kgfdzhr96b1fzyyqba9xrsyvbm1vb1v97w67p5m3vk7";
+    version = "1.21.0";
+    hash = "sha256-umtCr5DOLI0PqpXhIWg1C1LLiurCt5dEfs6d+4G6HcU=";
   })
   (fetchNuGet {
     pname = "Microsoft.Win32.Primitives";
     version = "4.0.1";
-    sha256 = "1n8ap0cmljbqskxpf8fjzn7kh1vvlndsa75k01qig26mbw97k2q7";
+    hash = "sha256-B4t5El/ViBdxALMcpZulewc4j/3SIXf71HhJWhm4Ctk=";
   })
   (fetchNuGet {
     pname = "Microsoft.Win32.Primitives";
     version = "4.3.0";
-    sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
+    hash = "sha256-mBNDmPXNTW54XLnPAUwBRvkIORFM7/j0D0I2SyQPDEg=";
   })
   (fetchNuGet {
     pname = "Microsoft.Win32.Registry";
     version = "4.0.0";
-    sha256 = "1spf4m9pikkc19544p29a47qnhcd885klncahz133hbnyqbkmz9k";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.Win32.Registry";
-    version = "5.0.0";
-    sha256 = "102hvhq2gmlcbq8y2cb7hdr2dnmjzfp2k3asr1ycwrfacwyaak7n";
+    hash = "sha256-M/06F/Z2wTHCh4pZOgtCjUGLD1FJXEJKCmzOeFMl7uo=";
   })
   (fetchNuGet {
     pname = "Mono.TextTemplating";
     version = "2.2.1";
-    sha256 = "1ih6399x4bxzchw7pq5195imir9viy2r1w702vy87vrarxyjqdp1";
+    hash = "sha256-4TYsfc8q74P8FuDwkIWPO+VYY0mh4Hs4ZL8v0lMaBsY=";
+  })
+  (fetchNuGet {
+    pname = "Multiformats.Base";
+    version = "2.0.1";
+    hash = "sha256-DJWKq2kllwCuu8qCZ+qUriyn0955XGGNsYL0+lX8Mzg=";
+  })
+  (fetchNuGet {
+    pname = "Multiformats.Base";
+    version = "2.0.2";
+    hash = "sha256-iC4N5IFJWH5ctjknowleq+AsQLaWMOwcwXfHhwwY8Xw=";
+  })
+  (fetchNuGet {
+    pname = "Multiformats.Hash";
+    version = "1.5.0";
+    hash = "sha256-Muq09iF6q755Qr1d5x+aDT38aLBQy116XfHpE94/29E=";
+  })
+  (fetchNuGet {
+    pname = "murmurhash";
+    version = "1.0.2";
+    hash = "sha256-UHhb+MqCORaCHt/hFDS6FR662qwytmMeeNxVq5clkX4=";
+  })
+  (fetchNuGet {
+    pname = "NBitcoin.Secp256k1";
+    version = "3.1.5";
+    hash = "sha256-iT6+8Ohm0hGy3DlSBlhyhOGjc6EdGlAz1bC1QcafPr8=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Crypto.Bls";
+    version = "1.0.4";
+    hash = "sha256-gd8Z89j7FkemjxAgwH2SZC5rwBA8BJNsUBVBYf4KhUg=";
   })
   (fetchNuGet {
     pname = "Nethermind.Crypto.Pairings";
-    version = "1.0.1";
-    sha256 = "1d8n97snf30iymdzjn6528655cw0skpb3jb2kywbh5hj9f2nl7mp";
+    version = "1.1.1";
+    hash = "sha256-KSa0UpyoBxfLKWRcYEDHG2d0/91A6/AX1ItIxDyTufw=";
   })
   (fetchNuGet {
     pname = "Nethermind.Crypto.SecP256k1";
-    version = "1.1.1";
-    sha256 = "1vdj5625rk9zwnc9qajnpkszcsn85z9mnhq7gph5c0kd8fg70nx7";
+    version = "1.4.0";
+    hash = "sha256-kknLTf8C9h9ixSupqHmwHDdcQhEeVNCCiTN0KKK6N3E=";
   })
   (fetchNuGet {
     pname = "Nethermind.DotNetty.Buffers";
     version = "1.0.1";
-    sha256 = "1xc4r3yxpcbh7wm1vb3jwl8k7d5p1mgx6zy5g5hcdsa1bi6ga9h3";
+    hash = "sha256-Ayb1TFxB6cZgecV/018Nt7QzEeVyrB0qP3Cx2/3IhPU=";
   })
   (fetchNuGet {
     pname = "Nethermind.DotNetty.Codecs";
     version = "1.0.1";
-    sha256 = "087xg301vrvl70jzpb5wf9ii74waqbjzgyrx0w7g21ljhcsmsls7";
+    hash = "sha256-R1NdNYOSBvEOBz379+XCipMTY3K8rPslOHTnHcB4/SA=";
   })
   (fetchNuGet {
     pname = "Nethermind.DotNetty.Common";
     version = "1.0.1";
-    sha256 = "0lrch8lhviki176hcihzzw79lfzwz5py6igpc56z342ijham0alv";
+    hash = "sha256-mypQFZRRkPFNYfdF42/5/DuaDv8fRgbNCXHGDSmCLFM=";
   })
   (fetchNuGet {
     pname = "Nethermind.DotNetty.Handlers";
     version = "1.0.1";
-    sha256 = "10vlficmv30cl90d91h9ik522h76yahb187vfcmxpay61jg428j8";
+    hash = "sha256-SCJBngzGq9src/ugsKDy5kAhyowJhtRAogyMXVl0dIM=";
   })
   (fetchNuGet {
     pname = "Nethermind.DotNetty.Transport";
     version = "1.0.1";
-    sha256 = "1sdx03x17y50m0p08hh35r2hjr70ynclrqbzhygxxsq6ia75gz53";
+    hash = "sha256-o/xXjooG696fh3/hTJn14GQJRS4DQgQuqKD4E/oAvek=";
   })
   (fetchNuGet {
     pname = "Nethermind.Gmp";
     version = "1.0.1";
-    sha256 = "1x9in44pvg2jjiqrf8q9l4qyqilcbx6hr2ywgk42gjxri27agnih";
+    hash = "sha256-MNqnjoi5yyfIfNyLDE1fjEbsMaEJI5dxlFK8fQmxMfU=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p";
+    version = "1.0.0-preview.34";
+    hash = "sha256-aEZ8P9sv6NI+/X99DE7yGIel7YEcSLVURR7DT7ghgPU=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Core";
+    version = "1.0.0-preview.34";
+    hash = "sha256-o/fyY6/JRCyE2iGwVrtTvCszuACBya6rMbsDfLqUto8=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.Identify";
+    version = "1.0.0-preview.34";
+    hash = "sha256-Os1Yy08KrcN/jeVtcLhQkOYpFa+A54zOgugghXYSNVY=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.IpTcp";
+    version = "1.0.0-preview.34";
+    hash = "sha256-e/C6SL9/PfJif+4rQpJjhVbA1OOGHagBvB8/X8ATZsk=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.MDns";
+    version = "1.0.0-preview.34";
+    hash = "sha256-wqWbVsqd+PF3Gs+1FnM3H1hR14AmMyviIYwKQCBmEfA=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.Multistream";
+    version = "1.0.0-preview.34";
+    hash = "sha256-Eh3IH3PtALQMmbM97aF3zwzL+VTvgdromqvC/6A4JsQ=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.Noise";
+    version = "1.0.0-preview.34";
+    hash = "sha256-lhxgcPVuaVL7hV5uNEX81D3/pU+57hsK2X3icV18IOw=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.Ping";
+    version = "1.0.0-preview.34";
+    hash = "sha256-z7bQw1jHZNN5ACy7JlgFk50KCcahnhw1JB4VV+G6TYQ=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.Plaintext";
+    version = "1.0.0-preview.34";
+    hash = "sha256-DYG/lRcIMjqZyKbNshFfaMHBs7rTlUZ+3wgRcPsaV4E=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.Pubsub";
+    version = "1.0.0-preview.34";
+    hash = "sha256-892CHcW0ANwyccghHKfF2RMjtVE70j59uoSv4MmANb4=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.PubsubPeerDiscovery";
+    version = "1.0.0-preview.34";
+    hash = "sha256-0xYOv5Sw7sNG2o+tSPEQlbw4P4StuRgL96MSneSTpW4=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.Quic";
+    version = "1.0.0-preview.34";
+    hash = "sha256-GF2PlTu6bljX9uAtLMeWoEZ9xXTnRtLJd1fBmHhDhEo=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.Tls";
+    version = "1.0.0-preview.34";
+    hash = "sha256-8Um4KYYCrjWNuiJvJRw8RQHrgncBDLNMj5K5G2De6g4=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Libp2p.Protocols.Yamux";
+    version = "1.0.0-preview.34";
+    hash = "sha256-gA7BA6Ri96nb7Zg6snNDou0YMF5P0pPE+9kjNmNtxew=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Multiformats.Address";
+    version = "1.1.5";
+    hash = "sha256-qApAUHgYyB2FbjEhVbRlU8fJvXE36XPg/8u/BeAjubc=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Multiformats.Base";
+    version = "2.0.3-preview.1";
+    hash = "sha256-xgp/eIhxiB6zrql0/fz1DcpDjBDK6Q+ZiT88stPNyJk=";
+  })
+  (fetchNuGet {
+    pname = "Nethermind.Multiformats.Hash";
+    version = "1.5.2-preview.1";
+    hash = "sha256-tWJyFG0shqo3Os1n3ojM+iNFCmrKjqt/mZihvLANUDs=";
   })
   (fetchNuGet {
     pname = "Nethermind.Numerics.Int256";
     version = "1.2.0";
-    sha256 = "0swsv0kbcmpyhlya7lxpghzzjrcz144d3pa17n4c3hxqasgf93fv";
+    hash = "sha256-243knla4w8GIPUHd0QgJn2X5P3y306M8hf5WtibYmms=";
   })
   (fetchNuGet {
     pname = "NETStandard.Library";
     version = "1.6.0";
-    sha256 = "0nmmv4yw7gw04ik8ialj3ak0j6pxa9spih67hnn1h2c38ba8h58k";
+    hash = "sha256-ExWI1EKDCRishcfAeHVS/RoJphqSqohmJIC/wz3ZtVo=";
   })
   (fetchNuGet {
     pname = "NETStandard.Library";
     version = "1.6.1";
-    sha256 = "1z70wvsx2d847a2cjfii7b83pjfs34q05gb037fdjikv5kbagml8";
+    hash = "sha256-iNan1ix7RtncGWC9AjAZ2sk70DoxOsmEOgQ10fXm4Pw=";
   })
   (fetchNuGet {
     pname = "NETStandard.Library";
     version = "2.0.0";
-    sha256 = "1bc4ba8ahgk15m8k4nd7x406nhi0kwqzbgjk2dmw52ss553xz7iy";
-  })
-  (fetchNuGet {
-    pname = "Newtonsoft.Json";
-    version = "10.0.3";
-    sha256 = "06vy67bkshclpz69kps4vgzc9h2cgg41c8vlqmdbwclfky7c4haq";
+    hash = "sha256-Pp7fRylai8JrE1O+9TGfIEJrAOmnWTJRLWE+qJBahK0=";
   })
   (fetchNuGet {
     pname = "Newtonsoft.Json";
     version = "13.0.1";
-    sha256 = "0fijg0w6iwap8gvzyjnndds0q4b8anwxxvik7y8vgq97dram4srb";
-  })
-  (fetchNuGet {
-    pname = "Newtonsoft.Json";
-    version = "13.0.3";
-    sha256 = "0xrwysmrn4midrjal8g2hr1bbg38iyisl0svamb11arqws4w2bw7";
+    hash = "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo=";
   })
   (fetchNuGet {
     pname = "Nito.Collections.Deque";
     version = "1.2.1";
-    sha256 = "13rmaxawcmri2z0vwf6mvmi59x12qhrl29d5qxlj6ryb6w9wj5ha";
+    hash = "sha256-ChbJEzfLZyNpx6UlQTPEIvRUYt3VOL7BFzFXxlVXNY8=";
   })
   (fetchNuGet {
     pname = "NLog";
-    version = "5.2.8";
-    sha256 = "1z3h20m5rjnizm1jbf5j0vpdc1f373rzzkg6478p1lxv5j385c12";
+    version = "5.2.5";
+    hash = "sha256-QCYHzZ45Gf30NzJaVmGR8kKhIkfrVVjl+J+dliJe3gk=";
+  })
+  (fetchNuGet {
+    pname = "NLog";
+    version = "5.3.4";
+    hash = "sha256-Cwr1Wu9VbOcRz3GdVKkt7lIpNwC1E4Hdb0g+qEkEr3k=";
   })
   (fetchNuGet {
     pname = "NLog.Targets.Seq";
-    version = "3.0.0";
-    sha256 = "0g8nr46mdc447n3hbkgmhdd7k65mg4zx7ydm349ddr0pwjivcm3f";
+    version = "4.0.1";
+    hash = "sha256-hilyo/xy5YLJEujIbJ6yOiCPeQPA+g1tF77rts1mK5o=";
   })
   (fetchNuGet {
-    pname = "NSubstitute";
-    version = "5.1.0";
-    sha256 = "0vjl2pgw4b6366x47xyc0nfz33rx96bwjpnn0diq8mksaxn6w6ir";
+    pname = "Noise.NET";
+    version = "1.0.0";
+    hash = "sha256-SuoaJ8ozz1XwCGLSprSnghxhD8SisrVmQWo9JOV5RVI=";
   })
   (fetchNuGet {
-    pname = "NuGet.Frameworks";
-    version = "6.5.0";
-    sha256 = "0s37d1p4md0k6d4cy6sq36f2dgkd9qfbzapxhkvi8awwh0vrynhj";
-  })
-  (fetchNuGet {
-    pname = "NUnit";
-    version = "3.14.0";
-    sha256 = "19p8911lrfds1k9rv47jk1bbn665s0pvghkd06gzbg78j6mzzqqa";
-  })
-  (fetchNuGet {
-    pname = "NUnit.Analyzers";
-    version = "3.9.0";
-    sha256 = "13bk0kfh1c0xzmr5vzlwl7afzhz60xrw402mpkgfj954dv4s2agq";
-  })
-  (fetchNuGet {
-    pname = "NUnit3TestAdapter";
-    version = "4.5.0";
-    sha256 = "1srx1629s0k1kmf02nmz251q07vj6pv58mdafcr5dr0bbn1fh78i";
+    pname = "NonBlocking";
+    version = "2.1.2";
+    hash = "sha256-orioa8JnOStiukyKGIuR3RFqeupdeqsFZrAWqn5mm0U=";
   })
   (fetchNuGet {
     pname = "Open.NAT.Core";
     version = "2.1.0.5";
-    sha256 = "0f6c7m1x1kssicbi6q60jys3fnbj6zs69v37wdsmvbqgc0pvk89f";
+    hash = "sha256-LqG5L2APr11142fsZPQ3clk3tJfAYBMXi1rP0EM9zDg=";
+  })
+  (fetchNuGet {
+    pname = "PierTwo.Lantern.Discv5.Enr";
+    version = "1.0.0-preview.4";
+    hash = "sha256-XOOAzwoYQL/Ocfj6MWlkezKtyPBpaPX9PHLUI7SCebM=";
+  })
+  (fetchNuGet {
+    pname = "PierTwo.Lantern.Discv5.Rlp";
+    version = "1.0.0-preview.4";
+    hash = "sha256-ItPfssDuUz6Qe2HR9CzRaB90DXBcr0Dsq7k590PxUwU=";
+  })
+  (fetchNuGet {
+    pname = "PierTwo.Lantern.Discv5.WireProtocol";
+    version = "1.0.0-preview.4";
+    hash = "sha256-10rZxyzjaVOGzsVSQUwCEEIKXG75jHNOg59lmP0ehy8=";
   })
   (fetchNuGet {
     pname = "Polly";
-    version = "8.2.0";
-    sha256 = "0gxdi4sf60vpxsb258v592ykkq9a3dq2awayp99yy9djys8bglks";
+    version = "8.5.0";
+    hash = "sha256-oXIqYMkFXoF/9y704LJSX5Non9mry19OSKA7JFviu5Q=";
   })
   (fetchNuGet {
     pname = "Polly.Core";
-    version = "8.2.0";
-    sha256 = "00b4jbyiyslqvswy4j2lfw0rl0gq8m4v5fj2asb96i6l224bs7d3";
+    version = "8.5.0";
+    hash = "sha256-vN/OoQi5F8+oKNO46FwjPcKrgfhGMGjAQ2yCQUlHtOc=";
   })
   (fetchNuGet {
     pname = "Portable.BouncyCastle";
-    version = "1.9.0";
-    sha256 = "0kphjwz4hk2nki3b4f9z096xzd520nrpvi3cjib8fkjk6zhwrr8q";
+    version = "1.8.5";
+    hash = "sha256-qzDf3ZR4JrB1KNgV1PQUihAXG7k/lWVwdMUxs+8d5iI=";
   })
   (fetchNuGet {
     pname = "prometheus-net";
-    version = "8.0.1";
-    sha256 = "0fcx4479bagn11830sjm4k13d5g947w8i8bxnzsn1v1nyrva7fvl";
-  })
-  (fetchNuGet {
-    pname = "prometheus-net";
-    version = "8.2.0";
-    sha256 = "19m9lkpc4h9a0jmn66p61x8960gk9fidcwic70nrvjhmd5m201fj";
+    version = "8.2.1";
+    hash = "sha256-NxHeXd4fwwc4MMsT6mrfX81czjHnq2GMStWTabZxMDw=";
   })
   (fetchNuGet {
     pname = "prometheus-net.AspNetCore";
-    version = "8.2.0";
-    sha256 = "1lilk7xw19wgl2i7cjbf09ssd4jicla45wj29hfy6d1bzcnd6yn8";
+    version = "8.2.1";
+    hash = "sha256-dhrATENkD/1GfSPBkAd3GvyHvzR5q+c+k22UTp33z+c=";
   })
   (fetchNuGet {
     pname = "Pyroscope";
-    version = "0.8.14";
-    sha256 = "0m1xm0ppqj0h5a9lxfl7wnzcq75ds8c4m44ibsglni2q02vh800a";
+    version = "0.9.0";
+    hash = "sha256-lORvEaEXH4zLdMBHo0NfmyzGzToW38+IcNvmzMsY4ug=";
   })
   (fetchNuGet {
     pname = "ReadLine";
     version = "2.0.1";
-    sha256 = "1bc7aiyh99kkf4indrqzlf3y6517xhxh02nizybkp4hbxga1caih";
-  })
-  (fetchNuGet {
-    pname = "RichardSzalay.MockHttp";
-    version = "7.0.0";
-    sha256 = "167r48r1mbjgq8wc9w7lhh63vy853sc2dvxjld372zh8mqi5aasz";
+    hash = "sha256-MCoW1OsLkjuX/9EKADvsJxTjh6Mf52YjcXOmBH1Uh60=";
   })
   (fetchNuGet {
     pname = "RocksDB";
-    version = "8.3.2.39829";
-    sha256 = "0mkgcr53wcsgb3jzc82p7n0qblj9i65sx0q19sf0s7lf6dlcb5qw";
+    version = "9.4.0.50294";
+    hash = "sha256-SHt+2Kaj2eCqoeeH28EGlyRUi+g9Y3e9OzVvp946F7I=";
+  })
+  (fetchNuGet {
+    pname = "runtime.any.System.Collections";
+    version = "4.0.11";
+    hash = "sha256-4L3fXzSgw8UaCTvdb3cEyihka3K8JHBz/Ujsx0JdhPQ=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Collections";
     version = "4.3.0";
-    sha256 = "0bv5qgm6vr47ynxqbnkc7i797fdi8gbjjxii173syrx14nmrkwg0";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Diagnostics.Tools";
-    version = "4.3.0";
-    sha256 = "1wl76vk12zhdh66vmagni66h5xbhgqq7zkdpgw21jhxhvlbcl8pk";
+    hash = "sha256-4PGZqyWhZ6/HCTF2KddDsbmTTjxs2oW79YfkberDZS8=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Diagnostics.Tracing";
-    version = "4.3.0";
-    sha256 = "00j6nv2xgmd3bi347k00m7wr542wjlig53rmj28pmw7ddcn97jbn";
+    version = "4.1.0";
+    hash = "sha256-+PJZWFl6hkqryCerWVtbG+ppIGvZf2l6fu2HWyGqMRA=";
+  })
+  (fetchNuGet {
+    pname = "runtime.any.System.Globalization";
+    version = "4.0.11";
+    hash = "sha256-BgmoUM3WsMUCjtO9KmtjPKsjYRAEVjp74KvEa8zNgAg=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Globalization";
     version = "4.3.0";
-    sha256 = "1daqf33hssad94lamzg01y49xwndy2q97i2lrb7mgn28656qia1x";
+    hash = "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU=";
   })
   (fetchNuGet {
-    pname = "runtime.any.System.Globalization.Calendars";
-    version = "4.3.0";
-    sha256 = "1ghhhk5psqxcg6w88sxkqrc35bxcz27zbqm2y5p5298pv3v7g201";
+    pname = "runtime.any.System.IO";
+    version = "4.1.0";
+    hash = "sha256-ZbG7B6GOO90k/prj/Z60UGloQUrBepsvmlPQGuV0Wk0=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.IO";
     version = "4.3.0";
-    sha256 = "0l8xz8zn46w4d10bcn3l4yyn4vhb3lrj2zw8llvz7jk14k4zps5x";
+    hash = "sha256-vej7ySRhyvM3pYh/ITMdC25ivSd0WLZAaIQbYj/6HVE=";
+  })
+  (fetchNuGet {
+    pname = "runtime.any.System.Reflection";
+    version = "4.1.0";
+    hash = "sha256-BtdDCQLHDdAgO9qhwE0JBuUqFKc7l9On8p+VlgrQbBo=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Reflection";
     version = "4.3.0";
-    sha256 = "02c9h3y35pylc0zfq3wcsvc5nqci95nrkq0mszifc0sjx7xrzkly";
+    hash = "sha256-ns6f++lSA+bi1xXgmW1JkWFb2NaMD+w+YNTfMvyAiQk=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Reflection.Extensions";
-    version = "4.3.0";
-    sha256 = "0zyri97dfc5vyaz9ba65hjj1zbcrzaffhsdlpxc9bh09wy22fq33";
+    version = "4.0.1";
+    hash = "sha256-ef4sBhwHzEPZqsw6xn8cJtCe6Xhjr7UB1Cy99GUkYxY=";
+  })
+  (fetchNuGet {
+    pname = "runtime.any.System.Reflection.Primitives";
+    version = "4.0.1";
+    hash = "sha256-H2ZzRIWLN6FbSh8+q4OXqhssn3nGRnv7/NiV3OO+uf8=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Reflection.Primitives";
     version = "4.3.0";
-    sha256 = "0x1mm8c6iy8rlxm8w9vqw7gb7s1ljadrn049fmf70cyh42vdfhrf";
+    hash = "sha256-LkPXtiDQM3BcdYkAm5uSNOiz3uF4J45qpxn5aBiqNXQ=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Resources.ResourceManager";
-    version = "4.3.0";
-    sha256 = "03kickal0iiby82wa5flar18kyv82s9s6d4xhk5h4bi5kfcyfjzl";
+    version = "4.0.1";
+    hash = "sha256-eZasny65yEQESxMJHOBaqJQzlrd8CIOIc1ks6+HRr8o=";
+  })
+  (fetchNuGet {
+    pname = "runtime.any.System.Runtime";
+    version = "4.1.0";
+    hash = "sha256-FZC+BNSzSkN3rObLJJAqwW/vNnJ+PiwdvNNufuISWVY=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Runtime";
     version = "4.3.0";
-    sha256 = "1cqh1sv3h5j7ixyb7axxbdkqx6cxy00p4np4j91kpm492rf4s25b";
+    hash = "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM=";
+  })
+  (fetchNuGet {
+    pname = "runtime.any.System.Runtime.Handles";
+    version = "4.0.1";
+    hash = "sha256-WlmU4OzK6IpszOCuEb5pdh4dwpkuoBQTYRuT4SF+XM8=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Runtime.Handles";
     version = "4.3.0";
-    sha256 = "0bh5bi25nk9w9xi8z23ws45q5yia6k7dg3i4axhfqlnj145l011x";
+    hash = "sha256-PQRACwnSUuxgVySO1840KvqCC9F8iI9iTzxNW0RcBS4=";
+  })
+  (fetchNuGet {
+    pname = "runtime.any.System.Runtime.InteropServices";
+    version = "4.1.0";
+    hash = "sha256-H9FNiCk+Qrm+15K+Rje+wnQxwUmkVx60x+FWBoGLqD4=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Runtime.InteropServices";
     version = "4.3.0";
-    sha256 = "0c3g3g3jmhlhw4klrc86ka9fjbl7i59ds1fadsb2l8nqf8z3kb19";
+    hash = "sha256-Kaw5PnLYIiqWbsoF3VKJhy7pkpoGsUwn4ZDCKscbbzA=";
+  })
+  (fetchNuGet {
+    pname = "runtime.any.System.Text.Encoding";
+    version = "4.0.11";
+    hash = "sha256-pyaH3Lcuv/pEM9NSFWlLcljav/Ksnwwk7cjPEH99m1Q=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Text.Encoding";
     version = "4.3.0";
-    sha256 = "0aqqi1v4wx51h51mk956y783wzags13wa7mgqyclacmsmpv02ps3";
+    hash = "sha256-Q18B9q26MkWZx68exUfQT30+0PGmpFlDgaF0TnaIGCs=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Text.Encoding.Extensions";
-    version = "4.3.0";
-    sha256 = "0lqhgqi0i8194ryqq6v2gqx0fb86db2gqknbm0aq31wb378j7ip8";
+    version = "4.0.11";
+    hash = "sha256-5yD9kqovaIcqclgIpFVT90UOSQb/Ob0i5Went2/vOTQ=";
+  })
+  (fetchNuGet {
+    pname = "runtime.any.System.Threading.Tasks";
+    version = "4.0.11";
+    hash = "sha256-c/8eunlNexFpzZ+GvNF0p1hi5Xo0VPo7LnkhjRO47eM=";
   })
   (fetchNuGet {
     pname = "runtime.any.System.Threading.Tasks";
     version = "4.3.0";
-    sha256 = "03mnvkhskbzxddz4hm113zsch1jyzh2cs450dk3rgfjp8crlw1va";
-  })
-  (fetchNuGet {
-    pname = "runtime.any.System.Threading.Timer";
-    version = "4.3.0";
-    sha256 = "0aw4phrhwqz9m61r79vyfl5la64bjxj8l34qnrcwb28v49fg2086";
+    hash = "sha256-agdOM0NXupfHbKAQzQT8XgbI9B8hVEh+a/2vqeHctg4=";
   })
   (fetchNuGet {
     pname = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "16rnxzpk5dpbbl1x354yrlsbvwylrq456xzpsha1n9y3glnhyx9d";
-  })
-  (fetchNuGet {
-    pname = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "0rwpqngkqiapqc5c2cpkj7idhngrgss5qpnqg0yh40mbyflcxf8i";
+    hash = "sha256-LXUPLX3DJxsU1Pd3UwjO1PO9NM2elNEDXeu2Mu/vNps=";
   })
   (fetchNuGet {
     pname = "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "0hkg03sgm2wyq8nqk6dbm9jh5vcq57ry42lkqdmfklrw89lsmr59";
-  })
-  (fetchNuGet {
-    pname = "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "1n06gxwlinhs0w7s8a94r1q3lwqzvynxwd3mp10ws9bg6gck8n4r";
+    hash = "sha256-qeSqaUI80+lqw5MK4vMpmO0CZaqrmYktwp6L+vQAb0I=";
   })
   (fetchNuGet {
     pname = "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "0c2p354hjx58xhhz7wv6div8xpi90sc6ibdm40qin21bvi7ymcaa";
-  })
-  (fetchNuGet {
-    pname = "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "0404wqrc7f2yc0wxv71y3nnybvqx8v4j9d47hlscxy759a525mc3";
+    hash = "sha256-SrHqT9wrCBsxILWtaJgGKd6Odmxm8/Mh7Kh0CUkZVzA=";
   })
   (fetchNuGet {
     pname = "runtime.native.System";
     version = "4.0.0";
-    sha256 = "1ppk69xk59ggacj9n7g6fyxvzmk1g5p4fkijm0d7xqfkig98qrkf";
+    hash = "sha256-bmaM0ovT4X4aqDJOR255Yda/u3fmHZskU++lMnsy894=";
   })
   (fetchNuGet {
     pname = "runtime.native.System";
     version = "4.3.0";
-    sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
+    hash = "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y=";
   })
   (fetchNuGet {
     pname = "runtime.native.System.IO.Compression";
     version = "4.1.0";
-    sha256 = "0d720z4lzyfcabmmnvh0bnj76ll7djhji2hmfh3h44sdkjnlkknk";
-  })
-  (fetchNuGet {
-    pname = "runtime.native.System.IO.Compression";
-    version = "4.3.0";
-    sha256 = "1vvivbqsk6y4hzcid27pqpm5bsi6sc50hvqwbcx8aap5ifrxfs8d";
+    hash = "sha256-085JrZxNEwIHdBWKKKFsh1JzpF0AblvrUsz5T8kH4jQ=";
   })
   (fetchNuGet {
     pname = "runtime.native.System.Net.Http";
     version = "4.0.1";
-    sha256 = "1hgv2bmbaskx77v8glh7waxws973jn4ah35zysnkxmf0196sfxg6";
-  })
-  (fetchNuGet {
-    pname = "runtime.native.System.Net.Http";
-    version = "4.3.0";
-    sha256 = "1n6rgz5132lcibbch1qlf0g9jk60r0kqv087hxc0lisy50zpm7kk";
+    hash = "sha256-5nWnTQrA1T6t9r8MqIiV4yTNu+IH0of2OX1qteoS+8E=";
   })
   (fetchNuGet {
     pname = "runtime.native.System.Net.Security";
     version = "4.0.1";
-    sha256 = "1nk4pf8vbrgf73p0skhwmzhgz1hax3j123ilhwdncr47l3x1dbhk";
+    hash = "sha256-E64W+qCHZGYbhzQOEeToCob/4K8cTg3uOO7ltZG7ZNo=";
   })
   (fetchNuGet {
     pname = "runtime.native.System.Security.Cryptography";
     version = "4.0.0";
-    sha256 = "0k57aa2c3b10wl3hfqbgrl7xq7g8hh3a3ir44b31dn5p61iiw3z9";
-  })
-  (fetchNuGet {
-    pname = "runtime.native.System.Security.Cryptography.Apple";
-    version = "4.3.0";
-    sha256 = "1b61p6gw1m02cc1ry996fl49liiwky6181dzr873g9ds92zl326q";
+    hash = "sha256-6Q8eYzC32BbGIiTHoQaE6B3cD81vYQcH5SCswYRSp0w=";
   })
   (fetchNuGet {
     pname = "runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
-  })
-  (fetchNuGet {
-    pname = "runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "0zy5r25jppz48i2bkg8b9lfig24xixg6nm3xyr1379zdnqnpm8f6";
+    hash = "sha256-Jy01KhtcCl2wjMpZWH+X3fhHcVn+SyllWFY8zWlz/6I=";
   })
   (fetchNuGet {
     pname = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "0qyynf9nz5i7pc26cwhgi8j62ps27sqmf78ijcfgzab50z9g8ay3";
-  })
-  (fetchNuGet {
-    pname = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "096ch4n4s8k82xga80lfmpimpzahd2ip1mgwdqgar0ywbbl6x438";
+    hash = "sha256-wyv00gdlqf8ckxEdV7E+Ql9hJIoPcmYEuyeWb5Oz3mM=";
   })
   (fetchNuGet {
     pname = "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "1klrs545awhayryma6l7g2pvnp9xy4z0r1i40r80zb45q3i9nbyf";
-  })
-  (fetchNuGet {
-    pname = "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "1dm8fifl7rf1gy7lnwln78ch4rw54g0pl5g1c189vawavll7p6rj";
-  })
-  (fetchNuGet {
-    pname = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple";
-    version = "4.3.0";
-    sha256 = "10yc8jdrwgcl44b4g93f1ds76b176bajd3zqi2faf5rvh1vy9smi";
+    hash = "sha256-zi+b4sCFrA9QBiSGDD7xPV27r3iHGlV99gpyVUjRmc4=";
   })
   (fetchNuGet {
     pname = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "0zcxjv5pckplvkg0r6mw3asggm7aqzbdjimhvsasb0cgm59x09l3";
-  })
-  (fetchNuGet {
-    pname = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "1m9z1k9kzva9n9kwinqxl97x2vgl79qhqjlv17k9s2ymcyv2bwr6";
+    hash = "sha256-gybQU6mPgaWV3rBG2dbH6tT3tBq8mgze3PROdsuWnX0=";
   })
   (fetchNuGet {
     pname = "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "0vhynn79ih7hw7cwjazn87rm9z9fj0rvxgzlab36jybgcpcgphsn";
-  })
-  (fetchNuGet {
-    pname = "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "1cpx56mcfxz7cpn57wvj18sjisvzq8b5vd9rw16ihd2i6mcp3wa1";
+    hash = "sha256-VsP72GVveWnGUvS/vjOQLv1U80H2K8nZ4fDAmI61Hm4=";
   })
   (fetchNuGet {
     pname = "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "160p68l2c7cqmyqjwxydcvgw7lvl1cr0znkw8fp24d1by9mqc8p3";
-  })
-  (fetchNuGet {
-    pname = "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "15gsm1a8jdmgmf8j5v1slfz8ks124nfdhk2vxs2rw3asrxalg8hi";
+    hash = "sha256-4yKGa/IrNCKuQ3zaDzILdNPD32bNdy6xr5gdJigyF5g=";
   })
   (fetchNuGet {
     pname = "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "15zrc8fgd8zx28hdghcj5f5i34wf3l6bq5177075m2bc2j34jrqy";
-  })
-  (fetchNuGet {
-    pname = "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "0q0n5q1r1wnqmr5i5idsrd9ywl33k0js4pngkwq9p368mbxp8x1w";
+    hash = "sha256-HmdJhhRsiVoOOCcUvAwdjpMRiyuSwdcgEv2j9hxi+Zc=";
   })
   (fetchNuGet {
     pname = "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
     version = "4.3.0";
-    sha256 = "1p4dgxax6p7rlgj4q73k73rslcnz4wdcv8q2flg1s8ygwcm58ld5";
-  })
-  (fetchNuGet {
-    pname = "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
-    version = "4.3.2";
-    sha256 = "1x0g58pbpjrmj2x2qw17rdwwnrcl0wvim2hdwz48lixvwvp22n9c";
-  })
-  (fetchNuGet {
-    pname = "runtime.unix.Microsoft.Win32.Primitives";
-    version = "4.3.0";
-    sha256 = "0y61k9zbxhdi0glg154v30kkq7f8646nif8lnnxbvkjpakggd5id";
+    hash = "sha256-pVFUKuPPIx0edQKjzRon3zKq8zhzHEzko/lc01V/jdw=";
   })
   (fetchNuGet {
     pname = "runtime.unix.System.Console";
-    version = "4.3.0";
-    sha256 = "1pfpkvc6x2if8zbdzg9rnc5fx51yllprl8zkm5npni2k50lisy80";
+    version = "4.0.0";
+    hash = "sha256-5v6iE2bDhUx8IyOHpc+nR/2IhzRfCAkEWEB6QSS1JmE=";
+  })
+  (fetchNuGet {
+    pname = "runtime.unix.System.Diagnostics.Debug";
+    version = "4.0.11";
+    hash = "sha256-TTzJP6sR0/mDbbU3+ySnt9LVEcPPLfiAzxnfTaJazRY=";
   })
   (fetchNuGet {
     pname = "runtime.unix.System.Diagnostics.Debug";
     version = "4.3.0";
-    sha256 = "1lps7fbnw34bnh3lm31gs5c0g0dh7548wfmb8zz62v0zqz71msj5";
+    hash = "sha256-ReoazscfbGH+R6s6jkg5sIEHWNEvjEoHtIsMbpc7+tI=";
   })
   (fetchNuGet {
     pname = "runtime.unix.System.IO.FileSystem";
-    version = "4.3.0";
-    sha256 = "14nbkhvs7sji5r1saj2x8daz82rnf9kx28d3v2qss34qbr32dzix";
+    version = "4.0.1";
+    hash = "sha256-CnI6JdiFHRJZiH6i88UKFOjIwINxDnb8B1HBZZunlgs=";
   })
   (fetchNuGet {
-    pname = "runtime.unix.System.Net.Primitives";
-    version = "4.3.0";
-    sha256 = "0bdnglg59pzx9394sy4ic66kmxhqp8q8bvmykdxcbs5mm0ipwwm4";
-  })
-  (fetchNuGet {
-    pname = "runtime.unix.System.Net.Sockets";
-    version = "4.3.0";
-    sha256 = "03npdxzy8gfv035bv1b9rz7c7hv0rxl5904wjz51if491mw0xy12";
+    pname = "runtime.unix.System.Private.Uri";
+    version = "4.0.1";
+    hash = "sha256-1Q50COfWkU4/y9eBWj0jPDp3qvy19vRCZnDKQthrhUU=";
   })
   (fetchNuGet {
     pname = "runtime.unix.System.Private.Uri";
     version = "4.3.0";
-    sha256 = "1jx02q6kiwlvfksq1q9qr17fj78y5v6mwsszav4qcz9z25d5g6vk";
+    hash = "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs=";
+  })
+  (fetchNuGet {
+    pname = "runtime.unix.System.Runtime.Extensions";
+    version = "4.1.0";
+    hash = "sha256-xB8TkAadhz7gi8Ag3+uYtLdfjtxO8dCLrd/FzU7jLHQ=";
   })
   (fetchNuGet {
     pname = "runtime.unix.System.Runtime.Extensions";
     version = "4.3.0";
-    sha256 = "0pnxxmm8whx38dp6yvwgmh22smknxmqs5n513fc7m4wxvs1bvi4p";
+    hash = "sha256-l8S9gt6dk3qYG6HYonHtdlYtBKyPb29uQ6NDjmrt3V4=";
   })
   (fetchNuGet {
     pname = "SCrypt";
     version = "2.0.0.2";
-    sha256 = "03ira8iv45zcsv613bic0ak31v9am13x29dsj3j17xzhx65rg926";
+    hash = "sha256-RqSXi+nw9xPkkLol0UeoKu0wpgIsrhHM1uwXsiNSOQ4=";
   })
   (fetchNuGet {
-    pname = "Seq.Api";
-    version = "2023.4.0";
-    sha256 = "17lpyf33gf0497ra0zp5b2wspwgqw03hlaadj341s8wsnypiwrm1";
+    pname = "SimpleBase";
+    version = "1.3.1";
+    hash = "sha256-FtRIcfLYXxUftEhq8kHgNNkahde6Fv2hPVGZNezCW1Y=";
   })
   (fetchNuGet {
-    pname = "Shouldly";
-    version = "4.2.1";
-    sha256 = "03v0krqpgik60y7w6zwkr45v1rwbrvncf56s8mf5c958a549wswn";
+    pname = "SimpleBase";
+    version = "4.0.0";
+    hash = "sha256-HRXFnqOOgyFtRCZG7coVuNARkEz4j4WHKvacUuPqyEA=";
   })
   (fetchNuGet {
-    pname = "Snappy.Standard";
-    version = "0.2.0";
-    sha256 = "1dbrp35r1k6gdpqx576kcrplxbdxs32223pl4ds9hwhpf1fjac65";
+    pname = "Snappier";
+    version = "1.1.6";
+    hash = "sha256-Jjup/ZtgjAG8/yw0pM3mW01wjhNKrZpAyetGt4iFOmY=";
   })
   (fetchNuGet {
     pname = "System.AppContext";
     version = "4.1.0";
-    sha256 = "0fv3cma1jp4vgj7a8hqc9n7hr1f1kjp541s6z0q1r6nazb4iz9mz";
+    hash = "sha256-v6YfyfrKmhww+EYHUq6cwYUMj00MQ6SOfJtcGVRlYzs=";
   })
   (fetchNuGet {
     pname = "System.AppContext";
     version = "4.3.0";
-    sha256 = "1649qvy3dar900z3g817h17nl8jp4ka5vcfmsr05kh0fshn7j3ya";
+    hash = "sha256-yg95LNQOwFlA1tWxXdQkVyJqT4AnoDc+ACmrNvzGiZg=";
   })
   (fetchNuGet {
     pname = "System.Buffers";
     version = "4.0.0";
-    sha256 = "13s659bcmg9nwb6z78971z1lr6bmh2wghxi1ayqyzl4jijd351gr";
+    hash = "sha256-+YUymoyS0O+xVyF2+LiAdZlMww8nofPN4ja9ylYqRo8=";
   })
   (fetchNuGet {
     pname = "System.Buffers";
-    version = "4.3.0";
-    sha256 = "0fgns20ispwrfqll4q1zc1waqcmylb3zc50ys9x8zlwxh9pmd9jy";
+    version = "4.4.0";
+    hash = "sha256-KTxAhYawFG2V5VX1jw3pzx3IrQXRgn1TsvgjPgxAbqA=";
   })
   (fetchNuGet {
     pname = "System.Buffers";
     version = "4.5.0";
-    sha256 = "1ywfqn4md6g3iilpxjn5dsr0f5lx6z0yvhqp4pgjcamygg73cz2c";
+    hash = "sha256-THw2znu+KibfJRfD7cE3nRYHsm7Fyn5pjOOZVonFjvs=";
   })
   (fetchNuGet {
     pname = "System.CodeDom";
     version = "4.4.0";
-    sha256 = "1zgbafm5p380r50ap5iddp11kzhr9khrf2pnai6k593wjar74p1g";
-  })
-  (fetchNuGet {
-    pname = "System.CodeDom";
-    version = "6.0.0";
-    sha256 = "1i55cxp8ycc03dmxx4n22qi6jkwfl23cgffb95izq7bjar8avxxq";
+    hash = "sha256-L1xyspJ8pDJNVPYKl+FMGf4Zwm0tlqtAyQCNW6pT6/0=";
   })
   (fetchNuGet {
     pname = "System.Collections";
     version = "4.0.11";
-    sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
+    hash = "sha256-puoFMkx4Z55C1XPxNw3np8nzNGjH+G24j43yTIsDRL0=";
   })
   (fetchNuGet {
     pname = "System.Collections";
     version = "4.3.0";
-    sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
+    hash = "sha256-afY7VUtD6w/5mYqrce8kQrvDIfS2GXDINDh73IjxJKc=";
   })
   (fetchNuGet {
     pname = "System.Collections.Concurrent";
     version = "4.0.12";
-    sha256 = "07y08kvrzpak873pmyxs129g1ch8l27zmg51pcyj2jvq03n0r0fc";
+    hash = "sha256-zIEM7AB4SyE9u6G8+o+gCLLwkgi6+3rHQVPdn/dEwB8=";
   })
   (fetchNuGet {
     pname = "System.Collections.Concurrent";
     version = "4.3.0";
-    sha256 = "0wi10md9aq33jrkh2c24wr2n9hrpyamsdhsxdcnf43b7y86kkii8";
+    hash = "sha256-KMY5DfJnDeIsa13DpqvyN8NkReZEMAFnlmNglVoFIXI=";
   })
   (fetchNuGet {
     pname = "System.Collections.Immutable";
     version = "1.2.0";
-    sha256 = "1jm4pc666yiy7af1mcf7766v710gp0h40p228ghj6bavx7xfa38m";
+    hash = "sha256-FQ3l+ulbLSPhQ0JcQCC4D4SzjTnHsRqcOj56Ywy7pMo=";
   })
   (fetchNuGet {
     pname = "System.Collections.Immutable";
     version = "1.5.0";
-    sha256 = "1d5gjn5afnrf461jlxzawcvihz195gayqpcfbv6dd7pxa9ialn06";
+    hash = "sha256-BliqYlL9ntbMXo5d7NUrKXwYN+PqdyqDIS5bp4qVr7Q=";
   })
   (fetchNuGet {
     pname = "System.Collections.Immutable";
     version = "6.0.0";
-    sha256 = "1js98kmjn47ivcvkjqdmyipzknb9xbndssczm8gq224pbaj1p88c";
+    hash = "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs=";
   })
   (fetchNuGet {
-    pname = "System.Collections.NonGeneric";
-    version = "4.3.0";
-    sha256 = "07q3k0hf3mrcjzwj8fwk6gv3n51cb513w4mgkfxzm3i37sc9kz7k";
-  })
-  (fetchNuGet {
-    pname = "System.Collections.Specialized";
-    version = "4.3.0";
-    sha256 = "1sdwkma4f6j85m3dpb53v9vcgd0zyc9jb33f8g63byvijcj39n20";
+    pname = "System.CommandLine";
+    version = "2.0.0-beta4.24517.1";
+    hash = "sha256-NCE8uFrWVCEbCQc/vH737bJAHSs3UhphR3r/v9figdY=";
+    url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/flat2/system.commandline/2.0.0-beta4.24517.1/system.commandline.2.0.0-beta4.24517.1.nupkg";
   })
   (fetchNuGet {
     pname = "System.ComponentModel";
     version = "4.0.1";
-    sha256 = "0v4qpmqlzyfad2kswxxj2frnaqqhz9201c3yn8fmmarx5vlzg52z";
-  })
-  (fetchNuGet {
-    pname = "System.ComponentModel";
-    version = "4.3.0";
-    sha256 = "0986b10ww3nshy30x9sjyzm0jx339dkjxjj3401r3q0f6fx2wkcb";
+    hash = "sha256-X5T36S49q1odsn6wAET6EGNlsxOyd66naMr5T3G9mGw=";
   })
   (fetchNuGet {
     pname = "System.ComponentModel.Annotations";
     version = "4.1.0";
-    sha256 = "0l6m3z6h2qjjam1rp1fzk7zz5czjjazmw78rbh72x25y6kmyn6wf";
+    hash = "sha256-jhvr6zS+iC4OXBkdXr+S8rPy/5nfhZtDVVJiAc0f1VA=";
   })
   (fetchNuGet {
-    pname = "System.ComponentModel.Annotations";
-    version = "4.5.0";
-    sha256 = "1jj6f6g87k0iwsgmg3xmnn67a14mq88np0l1ys5zkxhkvbc8976p";
-  })
-  (fetchNuGet {
-    pname = "System.ComponentModel.Primitives";
-    version = "4.3.0";
-    sha256 = "1svfmcmgs0w0z9xdw2f2ps05rdxmkxxhf0l17xk9l1l8xfahkqr0";
-  })
-  (fetchNuGet {
-    pname = "System.ComponentModel.TypeConverter";
-    version = "4.3.0";
-    sha256 = "17ng0p7v3nbrg3kycz10aqrrlw4lz9hzhws09pfh8gkwicyy481x";
+    pname = "System.Composition";
+    version = "1.2.0";
+    hash = "sha256-HqqQt/STMfAFN1FAtmiwDIsxiQRS3RxipLmnrwX4KTs=";
   })
   (fetchNuGet {
     pname = "System.Composition";
     version = "6.0.0";
-    sha256 = "1p7hysns39cc24af6dwd4m48bqjsrr3clvi4aws152mh2fgyg50z";
+    hash = "sha256-H5TnnxOwihI0VyRuykbOWuKFSCWNN+MUEYyloa328Nw=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.AttributedModel";
+    version = "1.2.0";
+    hash = "sha256-QP2MEHz5nRWOdJJLrOMYuoj1pu6edrvKxr7HhMhrwHg=";
   })
   (fetchNuGet {
     pname = "System.Composition.AttributedModel";
     version = "6.0.0";
-    sha256 = "1mqrblb0l65hw39d0hnspqcv85didpn4wbiwhfgj4784wzqx2w6k";
+    hash = "sha256-03DR8ecEHSKfgzwuTuxtsRW0Gb7aQtDS4LAYChZdGdc=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.Convention";
+    version = "1.2.0";
+    hash = "sha256-SnU2yZ4eX1V5ImAplfEpeE3N6CAhmEbk2nsv38rb3Kc=";
   })
   (fetchNuGet {
     pname = "System.Composition.Convention";
     version = "6.0.0";
-    sha256 = "02km3yb94p1c4s7liyhkmda0g71zm1rc8ijsfmy4bnlkq15xjw3b";
+    hash = "sha256-a3DZS8CT2kV8dVpGxHKoP5wHVKsT+kiPJixckpYfdQo=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.Hosting";
+    version = "1.2.0";
+    hash = "sha256-+Ft2GwIQomlWBij/24jLz5/FNKiUcyrEQdoj0FZHxNU=";
   })
   (fetchNuGet {
     pname = "System.Composition.Hosting";
     version = "6.0.0";
-    sha256 = "0big5nk8c44rxp6cfykhk7rxvn2cgwa99w6c3v2a36adc3lj36ky";
+    hash = "sha256-fpoh6WBNmaHEHszwlBR/TNjd85lwesfM7ZkQhqYtLy4=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.Runtime";
+    version = "1.2.0";
+    hash = "sha256-PzalBZ2GSbe2N+DMalPA/q6lLytCcRUcxKSJ3bYCV68=";
   })
   (fetchNuGet {
     pname = "System.Composition.Runtime";
     version = "6.0.0";
-    sha256 = "0vq5ik63yii1784gsa2f2kx9w6xllmm8b8rk0arid1jqdj1nyrlw";
+    hash = "sha256-nGZvg2xYhhazAjOjhWqltBue+hROKP0IOiFGP8yMBW8=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.TypedParts";
+    version = "1.2.0";
+    hash = "sha256-JchMANzR3TwkuhtJxyEAD2l20ATpGrmFhUGNg1uGkaw=";
   })
   (fetchNuGet {
     pname = "System.Composition.TypedParts";
     version = "6.0.0";
-    sha256 = "0y9pq3y60nyrpfy51f576a0qjjdh61mcv8vnik32pm4bz56h9q72";
+    hash = "sha256-4uAETfmL1CvGjHajzWowsEmJgTKnuFC8u9lbYPzAN3k=";
   })
   (fetchNuGet {
     pname = "System.Configuration.ConfigurationManager";
-    version = "4.4.0";
-    sha256 = "1hjgmz47v5229cbzd2pwz2h0dkq78lb2wp9grx8qr72pb5i0dk7v";
-  })
-  (fetchNuGet {
-    pname = "System.Configuration.ConfigurationManager";
-    version = "8.0.0";
-    sha256 = "08dadpd8lx6x7craw3h3444p7ncz4wk0a3j1681lyhhd56ln66f6";
+    version = "9.0.0";
+    hash = "sha256-+pLnTC0YDP6Kjw5DVBiFrV/Q3x5is/+6N6vAtjvhVWk=";
   })
   (fetchNuGet {
     pname = "System.Console";
     version = "4.0.0";
-    sha256 = "0ynxqbc3z1nwbrc11hkkpw9skw116z4y9wjzn7id49p9yi7mzmlf";
+    hash = "sha256-jtZfT/TpJtLisV/y5Mk3IfCpE79zwhBYXtyGP9jC3Xo=";
   })
   (fetchNuGet {
     pname = "System.Console";
     version = "4.3.0";
-    sha256 = "1flr7a9x920mr5cjsqmsy9wgnv3lvd0h1g521pdr1lkb2qycy7ay";
+    hash = "sha256-Xh3PPBZr0pDbDaK8AEHbdGz7ePK6Yi1ZyRWI1JM6mbo=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.Debug";
     version = "4.0.11";
-    sha256 = "0gmjghrqmlgzxivd2xl50ncbglb7ljzb66rlx8ws6dv8jm0d5siz";
+    hash = "sha256-P+rSQJVoN6M56jQbs76kZ9G3mAWFdtF27P/RijN8sj4=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.Debug";
     version = "4.3.0";
-    sha256 = "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y";
+    hash = "sha256-fkA79SjPbSeiEcrbbUsb70u9B7wqbsdM9s1LnoKj0gM=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.DiagnosticSource";
     version = "4.0.0";
-    sha256 = "1n6c3fbz7v8d3pn77h4v5wvsfrfg7v1c57lg3nff3cjyh597v23m";
+    hash = "sha256-dYh9UoFesuGcHY+ewsI+z2WnNy+bwHPsHQ3t85cbzNg=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.DiagnosticSource";
-    version = "4.3.0";
-    sha256 = "0z6m3pbiy0qw6rn3n209rrzf9x1k4002zh90vwcrsym09ipm2liq";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.DiagnosticSource";
-    version = "6.0.0";
-    sha256 = "0rrihs9lnb1h6x4h0hn6kgfnh58qq7hx8qq99gh6fayx4dcnx3s5";
+    version = "7.0.0";
+    hash = "sha256-9Wk8cHSkjKtqkN6xW7KnXoQVtF/VNbKeBq79WqDesMs=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.DiagnosticSource";
     version = "8.0.0";
-    sha256 = "0nzra1i0mljvmnj1qqqg37xs7bl71fnpl68nwmdajchh65l878zr";
+    hash = "sha256-+aODaDEQMqla5RYZeq0Lh66j+xkPYxykrVvSCmJQ+Vs=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.DiagnosticSource";
+    version = "8.0.1";
+    hash = "sha256-zmwHjcJgKcbkkwepH038QhcnsWMJcHys+PEbFGC0Jgo=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.EventLog";
-    version = "6.0.0";
-    sha256 = "08y1x2d5w2hnhkh9r1998pjc7r4qp0rmzax062abha85s11chifd";
-  })
-  (fetchNuGet {
-    pname = "System.Diagnostics.EventLog";
-    version = "8.0.0";
-    sha256 = "1xnvcidh2qf6k7w8ij1rvj0viqkq84cq47biw0c98xhxg5rk3pxf";
+    version = "9.0.0";
+    hash = "sha256-tPvt6yoAp56sK/fe+/ei8M65eavY2UUhRnbrREj/Ems=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.FileVersionInfo";
     version = "4.0.0";
-    sha256 = "1s5vxhy7i09bmw51kxqaiz9zaj9am8wsjyz13j85sp23z267hbv3";
+    hash = "sha256-Yy94jPhDXF2QHOF7qTmqKkn1048K9xkKryuBeDzsu+g=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.Process";
     version = "4.1.0";
-    sha256 = "061lrcs7xribrmq7kab908lww6kn2xn1w3rdc41q189y0jibl19s";
+    hash = "sha256-OgW6ogQ+oYADYS0PHmwXdhrOKQJpqXlwzSvmfjTLNBg=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.StackTrace";
     version = "4.0.1";
-    sha256 = "0q29axqklpl36vvyni5h1cyb02lfvvkqprb9wfvcdca3181q5al2";
+    hash = "sha256-gqqCAwpDsca242nli+fejgqwPAuwROv3NoNeOnFXSWA=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.Tools";
     version = "4.0.1";
-    sha256 = "19cknvg07yhakcvpxg3cxa0bwadplin6kyxd8mpjjpwnp56nl85x";
+    hash = "sha256-vSBqTbmWXylvRa37aWyktym+gOpsvH43mwr6A962k6U=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.Tools";
     version = "4.3.0";
-    sha256 = "0in3pic3s2ddyibi8cvgl102zmvp9r9mchh82ns9f0ms4basylw1";
+    hash = "sha256-gVOv1SK6Ape0FQhCVlNOd9cvQKBvMxRX9K0JPVi8w0Y=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.Tracing";
     version = "4.1.0";
-    sha256 = "1d2r76v1x610x61ahfpigda89gd13qydz6vbwzhpqlyvq8jj6394";
+    hash = "sha256-JA0jJcLbU3zh52ub3zweob2EVHvxOqiC6SCYHrY5WbQ=";
   })
   (fetchNuGet {
     pname = "System.Diagnostics.Tracing";
     version = "4.3.0";
-    sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
+    hash = "sha256-hCETZpHHGVhPYvb4C0fh4zs+8zv4GPoixagkLZjpa9Q=";
   })
   (fetchNuGet {
     pname = "System.Dynamic.Runtime";
     version = "4.0.11";
-    sha256 = "1pla2dx8gkidf7xkciig6nifdsb494axjvzvann8g2lp3dbqasm9";
-  })
-  (fetchNuGet {
-    pname = "System.Dynamic.Runtime";
-    version = "4.3.0";
-    sha256 = "1d951hrvrpndk7insiag80qxjbf2y0y39y8h5hnq9612ws661glk";
-  })
-  (fetchNuGet {
-    pname = "System.Formats.Asn1";
-    version = "8.0.0";
-    sha256 = "04h75wflmzl0qh125p0209wx006rkyxic1y404m606yjvpl2alq1";
+    hash = "sha256-qWqFVxuXioesVftv2RVJZOnmojUvRjb7cS3Oh3oTit4=";
   })
   (fetchNuGet {
     pname = "System.Globalization";
     version = "4.0.11";
-    sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
+    hash = "sha256-rbSgc2PIEc2c2rN6LK3qCREAX3DqA2Nq1WcLrZYsDBw=";
   })
   (fetchNuGet {
     pname = "System.Globalization";
     version = "4.3.0";
-    sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
+    hash = "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI=";
   })
   (fetchNuGet {
     pname = "System.Globalization.Calendars";
     version = "4.0.1";
-    sha256 = "0bv0alrm2ck2zk3rz25lfyk9h42f3ywq77mx1syl6vvyncnpg4qh";
+    hash = "sha256-EJN3LbN+b0O9Dr2eg7kfThCYpne0iJ/H/GIyUTNVYC8=";
   })
   (fetchNuGet {
     pname = "System.Globalization.Calendars";
     version = "4.3.0";
-    sha256 = "1xwl230bkakzzkrggy1l1lxmm3xlhk4bq2pkv790j5lm8g887lxq";
+    hash = "sha256-uNOD0EOVFgnS2fMKvMiEtI9aOw00+Pfy/H+qucAQlPc=";
   })
   (fetchNuGet {
     pname = "System.Globalization.Extensions";
     version = "4.0.1";
-    sha256 = "0hjhdb5ri8z9l93bw04s7ynwrjrhx2n0p34sf33a9hl9phz69fyc";
-  })
-  (fetchNuGet {
-    pname = "System.Globalization.Extensions";
-    version = "4.3.0";
-    sha256 = "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls";
-  })
-  (fetchNuGet {
-    pname = "System.IdentityModel.Tokens.Jwt";
-    version = "7.0.0";
-    sha256 = "15c717z4kspqxiwnia7dk1mj5gv7hg584q4x1xc7z1g0rnz28pwd";
+    hash = "sha256-zLtkPryJwqTGcJqMC6zoMMvMrT+aAL5GoumjmMtqUEI=";
   })
   (fetchNuGet {
     pname = "System.IdentityModel.Tokens.Jwt";
     version = "7.1.2";
-    sha256 = "09ds8xanyd4zgncsl77gnlcz4kqw00s9ap3wvc6c8lrj91vmc58h";
+    hash = "sha256-EBVWd0gyU8QM23xclTQAHE/yGbXvHKqZfZ80b1VHuiU=";
   })
   (fetchNuGet {
     pname = "System.IO";
     version = "4.1.0";
-    sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
+    hash = "sha256-V6oyQFwWb8NvGxAwvzWnhPxy9dKOfj/XBM3tEC5aHrw=";
   })
   (fetchNuGet {
     pname = "System.IO";
     version = "4.3.0";
-    sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
+    hash = "sha256-ruynQHekFP5wPrDiVyhNiRIXeZ/I9NpjK5pU+HPDiRY=";
   })
   (fetchNuGet {
     pname = "System.IO.Compression";
     version = "4.1.0";
-    sha256 = "0iym7s3jkl8n0vzm3jd6xqg9zjjjqni05x45dwxyjr2dy88hlgji";
+    hash = "sha256-UT4KEfJNZOk7b4X0AqLFUsqfHu6myVH/BhbRKYc+1Uc=";
   })
   (fetchNuGet {
     pname = "System.IO.Compression";
     version = "4.3.0";
-    sha256 = "084zc82yi6yllgda0zkgl2ys48sypiswbiwrv7irb3r0ai1fp4vz";
+    hash = "sha256-f5PrQlQgj5Xj2ZnHxXW8XiOivaBvfqDao9Sb6AVinyA=";
   })
   (fetchNuGet {
     pname = "System.IO.Compression.ZipFile";
     version = "4.0.1";
-    sha256 = "0h72znbagmgvswzr46mihn7xm7chfk2fhrp5krzkjf29pz0i6z82";
+    hash = "sha256-An0Twb9JODl/nuVm6MR0kJ3aj4WxGpI/1/vVp5b94kA=";
   })
   (fetchNuGet {
     pname = "System.IO.Compression.ZipFile";
     version = "4.3.0";
-    sha256 = "1yxy5pq4dnsm9hlkg9ysh5f6bf3fahqqb6p8668ndy5c0lk7w2ar";
+    hash = "sha256-WQl+JgWs+GaRMeiahTFUbrhlXIHapzcpTFXbRvAtvvs=";
   })
   (fetchNuGet {
     pname = "System.IO.FileSystem";
     version = "4.0.1";
-    sha256 = "0kgfpw6w4djqra3w5crrg8xivbanh1w9dh3qapb28q060wb9flp1";
+    hash = "sha256-4VKXFgcGYCTWVXjAlniAVq0dO3o5s8KHylg2wg2/7k0=";
   })
   (fetchNuGet {
     pname = "System.IO.FileSystem";
     version = "4.3.0";
-    sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
+    hash = "sha256-vNIYnvlayuVj0WfRfYKpDrhDptlhp1pN8CYmlVd2TXw=";
   })
   (fetchNuGet {
     pname = "System.IO.FileSystem.Primitives";
     version = "4.0.1";
-    sha256 = "1s0mniajj3lvbyf7vfb5shp4ink5yibsx945k6lvxa96r8la1612";
+    hash = "sha256-IpigKMomqb6pmYWkrlf0ZdpILtRluX2cX5sOKVW0Feg=";
   })
   (fetchNuGet {
     pname = "System.IO.FileSystem.Primitives";
     version = "4.3.0";
-    sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
+    hash = "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg=";
   })
   (fetchNuGet {
     pname = "System.IO.FileSystem.Watcher";
     version = "4.0.0";
-    sha256 = "0rgfjiqz8dqy8hmbfsls4sa46ss6p9vh86cvn1vqx7zg45pf3hir";
+    hash = "sha256-OcLhbiHvn453sJsZBHe6RmtDlCaaarcqRB439HGU7mU=";
   })
   (fetchNuGet {
     pname = "System.IO.MemoryMappedFiles";
     version = "4.0.0";
-    sha256 = "1ahp27llf76ngc0fngl8zy4y1sgflzrkmxddilnd0l0cbbq1lm6m";
+    hash = "sha256-1VQa8FoMUNAsja31OvOn7ungif+IPusAe9YcR+kRF6o=";
   })
   (fetchNuGet {
     pname = "System.IO.Pipelines";
     version = "6.0.3";
-    sha256 = "1jgdazpmwc21dd9naq3l9n5s8a1jnbwlvgkf1pnm0aji6jd4xqdz";
+    hash = "sha256-v+FOmjRRKlDtDW6+TfmyMiiki010YGVTa0EwXu9X7ck=";
   })
   (fetchNuGet {
     pname = "System.IO.Pipelines";
-    version = "8.0.0";
-    sha256 = "00f36lqz1wf3x51kwk23gznkjjrf5nmqic9n7073nhrgrvb43nid";
+    version = "9.0.0";
+    hash = "sha256-vb0NrPjfEao3kfZ0tavp2J/29XnsQTJgXv3/qaAwwz0=";
   })
   (fetchNuGet {
     pname = "System.IO.UnmanagedMemoryStream";
     version = "4.0.1";
-    sha256 = "012g8nwbfv94rhblsb3pxn1bazfpgjiy3kmy00679gg3651b87jb";
+    hash = "sha256-Sx60QjHjvXQMAL7O4aN81321gu13LE0XzCRtt7hFTwQ=";
   })
   (fetchNuGet {
     pname = "System.Linq";
     version = "4.1.0";
-    sha256 = "1ppg83svb39hj4hpp5k7kcryzrf3sfnm08vxd5sm2drrijsla2k5";
+    hash = "sha256-ZQpFtYw5N1F1aX0jUK3Tw+XvM5tnlnshkTCNtfVA794=";
   })
   (fetchNuGet {
     pname = "System.Linq";
     version = "4.3.0";
-    sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
+    hash = "sha256-R5uiSL3l6a3XrXSSL6jz+q/PcyVQzEAByiuXZNSqD/A=";
   })
   (fetchNuGet {
     pname = "System.Linq.Async";
     version = "6.0.1";
-    sha256 = "10ira8hmv0i54yp9ggrrdm1c06j538sijfjpn1kmnh9j2xk5yzmq";
+    hash = "sha256-uH5fZhcyQVtnsFc6GTUaRRrAQm05v5euJyWCXSFSOYI=";
   })
   (fetchNuGet {
     pname = "System.Linq.Expressions";
     version = "4.1.0";
-    sha256 = "1gpdxl6ip06cnab7n3zlcg6mqp7kknf73s8wjinzi4p0apw82fpg";
+    hash = "sha256-7zqB+FXgkvhtlBzpcZyd81xczWP0D3uWssyAGw3t7b4=";
   })
   (fetchNuGet {
     pname = "System.Linq.Expressions";
     version = "4.3.0";
-    sha256 = "0ky2nrcvh70rqq88m9a5yqabsl4fyd17bpr63iy2mbivjs2nyypv";
+    hash = "sha256-+3pvhZY7rip8HCbfdULzjlC9FPZFpYoQxhkcuFm2wk8=";
   })
   (fetchNuGet {
     pname = "System.Linq.Parallel";
     version = "4.0.1";
-    sha256 = "0i33x9f4h3yq26yvv6xnq4b0v51rl5z8v1bm7vk972h5lvf4apad";
+    hash = "sha256-TV1F3KYFipPmPnWFjX6hOZQNFsG2m729EdgPSFzqY0Q=";
   })
   (fetchNuGet {
     pname = "System.Linq.Queryable";
     version = "4.0.1";
-    sha256 = "11jn9k34g245yyf260gr3ldzvaqa9477w2c5nhb1p8vjx4xm3qaw";
-  })
-  (fetchNuGet {
-    pname = "System.Management";
-    version = "6.0.1";
-    sha256 = "0va0y6a2pq9nxpyigsa3qxhga2ma7iqsab96b8jgssgs1g0y7dl3";
+    hash = "sha256-XOFRO+lyoxsWtIUJfg5JCqv9Gx35ASOc94WIR8ZMVoY=";
   })
   (fetchNuGet {
     pname = "System.Memory";
-    version = "4.5.1";
-    sha256 = "0f07d7hny38lq9w69wx4lxkn4wszrqf9m9js6fh9is645csm167c";
+    version = "4.5.0";
+    hash = "sha256-YOz1pCR4RpP1ywYoJsgXnVlzsWtC2uYKQJTg0NnFXtE=";
   })
   (fetchNuGet {
     pname = "System.Memory";
     version = "4.5.3";
-    sha256 = "0naqahm3wljxb5a911d37mwjqjdxv9l0b49p5dmfyijvni2ppy8a";
+    hash = "sha256-Cvl7RbRbRu9qKzeRBWjavUkseT2jhZBUWV1SPipUWFk=";
+  })
+  (fetchNuGet {
+    pname = "System.Memory";
+    version = "4.5.5";
+    hash = "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI=";
   })
   (fetchNuGet {
     pname = "System.Net.Http";
     version = "4.1.0";
-    sha256 = "1i5rqij1icg05j8rrkw4gd4pgia1978mqhjzhsjg69lvwcdfg8yb";
+    hash = "sha256-y6PnGuObJvOkhl9CXNFJQcV3SXuEz5yRLOCxGGTEucQ=";
   })
   (fetchNuGet {
     pname = "System.Net.Http";
     version = "4.3.0";
-    sha256 = "1i4gc757xqrzflbk7kc5ksn20kwwfjhw9w7pgdkn19y3cgnl302j";
-  })
-  (fetchNuGet {
-    pname = "System.Net.Http";
-    version = "4.3.4";
-    sha256 = "0kdp31b8819v88l719j6my0yas6myv9d1viql3qz5577mv819jhl";
+    hash = "sha256-UoBB7WPDp2Bne/fwxKF0nE8grJ6FzTMXdT/jfsphj8Q=";
   })
   (fetchNuGet {
     pname = "System.Net.NameResolution";
     version = "4.0.0";
-    sha256 = "0dj3pvpv069nyia28gkl4a0fb7q33hbxz2dg25qvpah3l7pbl0qh";
-  })
-  (fetchNuGet {
-    pname = "System.Net.NameResolution";
-    version = "4.3.0";
-    sha256 = "15r75pwc0rm3vvwsn8rvm2krf929mjfwliv0mpicjnii24470rkq";
+    hash = "sha256-EAO67qEDqrtxEa+J3xccA5/lgCJ0PiRU9DYZsO++QzY=";
   })
   (fetchNuGet {
     pname = "System.Net.Primitives";
     version = "4.0.11";
-    sha256 = "10xzzaynkzkakp7jai1ik3r805zrqjxiz7vcagchyxs2v26a516r";
+    hash = "sha256-2YSijNhCdw/ZU2yfH7vE+ReA8pgxRCXPnWr+ab36v4M=";
   })
   (fetchNuGet {
     pname = "System.Net.Primitives";
     version = "4.3.0";
-    sha256 = "0c87k50rmdgmxx7df2khd9qj7q35j9rzdmm2572cc55dygmdk3ii";
+    hash = "sha256-MY7Z6vOtFMbEKaLW9nOSZeAjcWpwCtdO7/W1mkGZBzE=";
   })
   (fetchNuGet {
     pname = "System.Net.Requests";
     version = "4.0.11";
-    sha256 = "13mka55sa6dg6nw4zdrih44gnp8hnj5azynz47ljsh2791lz3d9h";
+    hash = "sha256-MLXxaUhHQC3pId/6r4q0EF37CIExt0+4Na8ZpUtRs44=";
   })
   (fetchNuGet {
     pname = "System.Net.Security";
     version = "4.0.0";
-    sha256 = "0ybyfssnm0cri37byhxnkfrzprz77nizbfj553x7s1vry2pnm5gb";
+    hash = "sha256-65Vqr/B5B336KEW69aM95+f7s5u2Q7/OiJmBarV2fnk=";
   })
   (fetchNuGet {
     pname = "System.Net.Sockets";
     version = "4.1.0";
-    sha256 = "1385fvh8h29da5hh58jm1v78fzi9fi5vj93vhlm2kvqpfahvpqls";
+    hash = "sha256-muK7oXIX7ykqhXskuUt0KX6Hzg5VogJhUS0JiOB2BY0=";
   })
   (fetchNuGet {
     pname = "System.Net.Sockets";
     version = "4.3.0";
-    sha256 = "1ssa65k6chcgi6mfmzrznvqaxk8jp0gvl77xhf1hbzakjnpxspla";
+    hash = "sha256-il7dr5VT/QWDg/0cuh+4Es2u8LY//+qqiY9BZmYxSus=";
   })
   (fetchNuGet {
     pname = "System.Net.WebHeaderCollection";
     version = "4.0.1";
-    sha256 = "10bxpxj80c4z00z3ksrfswspq9qqsw8jwxcbzvymzycb97m9b55q";
-  })
-  (fetchNuGet {
-    pname = "System.Net.WebSockets.WebSocketProtocol";
-    version = "4.5.3";
-    sha256 = "0z9ccndkkq6gpsh35q3pjm4zya47p6vakcyj8nc352g4wiizqc8c";
+    hash = "sha256-uJSV6kmL+V/9/ot1LhHXGCd8Ndcu6zk+AJ8wgGS/fYE=";
   })
   (fetchNuGet {
     pname = "System.Numerics.Vectors";
     version = "4.1.1";
-    sha256 = "1xkzrpl700pp0l6dc9fx7cj318i596w0i0qixsbrz5v65fnhbzia";
+    hash = "sha256-Kv4FrStml5+X7hGDCLhJJaIwJDvdJdYMBfcCcOjNf/Y=";
   })
   (fetchNuGet {
     pname = "System.ObjectModel";
     version = "4.0.12";
-    sha256 = "1sybkfi60a4588xn34nd9a58png36i0xr4y4v4kqpg8wlvy5krrj";
+    hash = "sha256-MudZ/KYcvYsn2cST3EE049mLikrNkmE7QoUoYKKby+s=";
   })
   (fetchNuGet {
     pname = "System.ObjectModel";
     version = "4.3.0";
-    sha256 = "191p63zy5rpqx7dnrb3h7prvgixmk168fhvvkkvhlazncf8r3nc2";
+    hash = "sha256-gtmRkWP2Kwr3nHtDh0yYtce38z1wrGzb6fjm4v8wN6Q=";
+  })
+  (fetchNuGet {
+    pname = "System.Private.Uri";
+    version = "4.0.1";
+    hash = "sha256-MjVaZHx8DUFnVUxOEEaU9GxF6EyEXbcuI1V7yRXEp0w=";
   })
   (fetchNuGet {
     pname = "System.Private.Uri";
     version = "4.3.0";
-    sha256 = "04r1lkdnsznin0fj4ya1zikxiqr0h6r6a1ww2dsm60gqhdrf0mvx";
+    hash = "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM=";
   })
   (fetchNuGet {
     pname = "System.Reactive";
     version = "6.0.0";
-    sha256 = "1mkvx1fwychpczksy6svfmniqhbm3xqblxqik6178l12xgq7aw45";
+    hash = "sha256-hXB18OsiUHSCmRF3unAfdUEcbXVbG6/nZxcyz13oe9Y=";
   })
   (fetchNuGet {
     pname = "System.Reflection";
     version = "4.1.0";
-    sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
+    hash = "sha256-idZHGH2Yl/hha1CM4VzLhsaR8Ljo/rV7TYe7mwRJSMs=";
   })
   (fetchNuGet {
     pname = "System.Reflection";
     version = "4.3.0";
-    sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
+    hash = "sha256-NQSZRpZLvtPWDlvmMIdGxcVuyUnw92ZURo0hXsEshXY=";
   })
   (fetchNuGet {
     pname = "System.Reflection.DispatchProxy";
     version = "4.0.1";
-    sha256 = "1maglcnvm3h8bfmx3rvwg4wjda7527iqp38cg1r6vh9japrw1n0r";
+    hash = "sha256-GdjA81UywW1yeAyNi+MR5agmOXl859GrWwiOui2jT9U=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Emit";
     version = "4.0.1";
-    sha256 = "0ydqcsvh6smi41gyaakglnv252625hf29f7kywy2c70nhii2ylqp";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Emit";
-    version = "4.3.0";
-    sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
+    hash = "sha256-F1MvYoQWHCY89/O4JBwswogitqVvKuVfILFqA7dmuHk=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Emit";
     version = "4.7.0";
-    sha256 = "121l1z2ypwg02yz84dy6gr82phpys0njk7yask3sihgy214w43qp";
+    hash = "sha256-Fw/CSRD+wajH1MqfKS3Q/sIrUH7GN4K+F+Dx68UPNIg=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Emit.ILGeneration";
     version = "4.0.1";
-    sha256 = "1pcd2ig6bg144y10w7yxgc9d22r7c7ww7qn1frdfwgxr24j9wvv0";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Emit.ILGeneration";
-    version = "4.3.0";
-    sha256 = "0w1n67glpv8241vnpz1kl14sy7zlnw414aqwj4hcx5nd86f6994q";
+    hash = "sha256-YG+eJBG5P+5adsHiw/lhJwvREnvdHw6CJyS8ZV4Ujd0=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Emit.Lightweight";
     version = "4.0.1";
-    sha256 = "1s4b043zdbx9k39lfhvsk68msv1nxbidhkq6nbm27q7sf8xcsnxr";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Emit.Lightweight";
-    version = "4.3.0";
-    sha256 = "0ql7lcakycrvzgi9kxz1b3lljd990az1x6c4jsiwcacrvimpib5c";
+    hash = "sha256-uVvNOnL64CPqsgZP2OLqNmxdkZl6Q0fTmKmv9gcBi+g=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Extensions";
     version = "4.0.1";
-    sha256 = "0m7wqwq0zqq9gbpiqvgk3sr92cbrw7cp3xn53xvw7zj6rz6fdirn";
+    hash = "sha256-NsfmzM9G/sN3H8X2cdnheTGRsh7zbRzvegnjDzDH/FQ=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Extensions";
     version = "4.3.0";
-    sha256 = "02bly8bdc98gs22lqsfx9xicblszr2yan7v2mmw3g7hy6miq5hwq";
+    hash = "sha256-mMOCYzUenjd4rWIfq7zIX9PFYk/daUyF0A8l1hbydAk=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Metadata";
     version = "1.3.0";
-    sha256 = "1y5m6kryhjpqqm2g3h3b6bzig13wkiw954x3b7icqjm6xypm1x3b";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.Metadata";
-    version = "1.6.0";
-    sha256 = "1wdbavrrkajy7qbdblpbpbalbdl48q3h34cchz24gvdgyrlf15r4";
+    hash = "sha256-a/RQr++mSsziWaOTknicfIQX/zJrwPFExfhK6PM0tfg=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Metadata";
     version = "6.0.1";
-    sha256 = "0fjqifk4qz9lw5gcadpfalpplyr0z2b3p9x7h0ll481a9sqvppc9";
+    hash = "sha256-id27sU4qIEIpgKenO5b4IHt6L1XuNsVe4TR9TKaLWDo=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Primitives";
     version = "4.0.1";
-    sha256 = "1bangaabhsl4k9fg8khn83wm6yial8ik1sza7401621jc6jrym28";
+    hash = "sha256-SFSfpWEyCBMAOerrMCOiKnpT+UAWTvRcmoRquJR6Vq0=";
   })
   (fetchNuGet {
     pname = "System.Reflection.Primitives";
     version = "4.3.0";
-    sha256 = "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276";
+    hash = "sha256-5ogwWB4vlQTl3jjk1xjniG2ozbFIjZTL9ug0usZQuBM=";
   })
   (fetchNuGet {
     pname = "System.Reflection.TypeExtensions";
     version = "4.1.0";
-    sha256 = "1bjli8a7sc7jlxqgcagl9nh8axzfl11f4ld3rjqsyxc516iijij7";
-  })
-  (fetchNuGet {
-    pname = "System.Reflection.TypeExtensions";
-    version = "4.3.0";
-    sha256 = "0y2ssg08d817p0vdag98vn238gyrrynjdj4181hdg780sif3ykp1";
+    hash = "sha256-R0YZowmFda+xzKNR4kKg7neFoE30KfZwp/IwfRSKVK4=";
   })
   (fetchNuGet {
     pname = "System.Resources.Reader";
     version = "4.0.0";
-    sha256 = "1jafi73dcf1lalrir46manq3iy6xnxk2z7gpdpwg4wqql7dv3ril";
+    hash = "sha256-NOax26EYc/L4bfedL2a33fg4sFXVkBwzVTQ41saJTsk=";
   })
   (fetchNuGet {
     pname = "System.Resources.ResourceManager";
     version = "4.0.1";
-    sha256 = "0b4i7mncaf8cnai85jv3wnw6hps140cxz8vylv2bik6wyzgvz7bi";
+    hash = "sha256-cZ2/3/fczLjEpn6j3xkgQV9ouOVjy4Kisgw5xWw9kSw=";
   })
   (fetchNuGet {
     pname = "System.Resources.ResourceManager";
     version = "4.3.0";
-    sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
+    hash = "sha256-idiOD93xbbrbwwSnD4mORA9RYi/D/U48eRUsn/WnWGo=";
   })
   (fetchNuGet {
     pname = "System.Runtime";
     version = "4.1.0";
-    sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
+    hash = "sha256-FViNGM/4oWtlP6w0JC0vJU+k9efLKZ+yaXrnEeabDQo=";
   })
   (fetchNuGet {
     pname = "System.Runtime";
     version = "4.3.0";
-    sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.Caching";
-    version = "8.0.0";
-    sha256 = "0d0wgbbb96svhdx2fl4disd27fvhsf3x2mafkz6dzp02bh3c31n0";
+    hash = "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg=";
   })
   (fetchNuGet {
     pname = "System.Runtime.CompilerServices.Unsafe";
-    version = "4.5.1";
-    sha256 = "1xcrjx5fwg284qdnxyi2d0lzdm5q4frlpkp0nf6vvkx1kdz2prrf";
+    version = "4.3.0";
+    hash = "sha256-aMJRpXIgk+E2vIQooc/slTwhkE2KVfcFyxTeG5RmPZE=";
   })
   (fetchNuGet {
     pname = "System.Runtime.CompilerServices.Unsafe";
     version = "5.0.0";
-    sha256 = "02k25ivn50dmqx5jn8hawwmz24yf0454fjd823qk6lygj9513q4x";
+    hash = "sha256-neARSpLPUzPxEKhJRwoBzhPxK+cKIitLx7WBYncsYgo=";
   })
   (fetchNuGet {
     pname = "System.Runtime.CompilerServices.Unsafe";
     version = "6.0.0";
-    sha256 = "0qm741kh4rh57wky16sq4m0v05fxmkjjr87krycf5vp9f0zbahbc";
+    hash = "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I=";
   })
   (fetchNuGet {
     pname = "System.Runtime.Extensions";
     version = "4.1.0";
-    sha256 = "0rw4rm4vsm3h3szxp9iijc3ksyviwsv6f63dng3vhqyg4vjdkc2z";
+    hash = "sha256-X7DZ5CbPY7jHs20YZ7bmcXs9B5Mxptu/HnBUvUnNhGc=";
   })
   (fetchNuGet {
     pname = "System.Runtime.Extensions";
     version = "4.3.0";
-    sha256 = "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60";
+    hash = "sha256-wLDHmozr84v1W2zYCWYxxj0FR0JDYHSVRaRuDm0bd/o=";
   })
   (fetchNuGet {
     pname = "System.Runtime.Handles";
     version = "4.0.1";
-    sha256 = "1g0zrdi5508v49pfm3iii2hn6nm00bgvfpjq1zxknfjrxxa20r4g";
+    hash = "sha256-j2QgVO9ZOjv7D1het98CoFpjoYgxjupuIhuBUmLLH7w=";
   })
   (fetchNuGet {
     pname = "System.Runtime.Handles";
     version = "4.3.0";
-    sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
+    hash = "sha256-KJ5aXoGpB56Y6+iepBkdpx/AfaJDAitx4vrkLqR7gms=";
   })
   (fetchNuGet {
     pname = "System.Runtime.InteropServices";
     version = "4.1.0";
-    sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
+    hash = "sha256-QceAYlJvkPRJc/+5jR+wQpNNI3aqGySWWSO30e/FfQY=";
   })
   (fetchNuGet {
     pname = "System.Runtime.InteropServices";
     version = "4.3.0";
-    sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
+    hash = "sha256-8sDH+WUJfCR+7e4nfpftj/+lstEiZixWUBueR2zmHgI=";
   })
   (fetchNuGet {
     pname = "System.Runtime.InteropServices.RuntimeInformation";
     version = "4.0.0";
-    sha256 = "0glmvarf3jz5xh22iy3w9v3wyragcm4hfdr17v90vs7vcrm7fgp6";
+    hash = "sha256-5j53amb76A3SPiE3B0llT2XPx058+CgE7OXL4bLalT4=";
   })
   (fetchNuGet {
     pname = "System.Runtime.InteropServices.RuntimeInformation";
     version = "4.3.0";
-    sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
+    hash = "sha256-MYpl6/ZyC6hjmzWRIe+iDoldOMW1mfbwXsduAnXIKGA=";
   })
   (fetchNuGet {
     pname = "System.Runtime.Loader";
     version = "4.0.0";
-    sha256 = "0lpfi3psqcp6zxsjk2qyahal7zaawviimc8lhrlswhip2mx7ykl0";
+    hash = "sha256-gE5/ehU3Qq5phhSxGuPmSv1DFVQeiyl1/+YyrO+I7lI=";
   })
   (fetchNuGet {
     pname = "System.Runtime.Numerics";
     version = "4.0.1";
-    sha256 = "1y308zfvy0l5nrn46mqqr4wb4z1xk758pkk8svbz8b5ij7jnv4nn";
+    hash = "sha256-1pJt5ZGxLPTX1mjOi8qZPXyyOMkYV0NstoUCv91HYPg=";
   })
   (fetchNuGet {
     pname = "System.Runtime.Numerics";
     version = "4.3.0";
-    sha256 = "19rav39sr5dky7afygh309qamqqmi9kcwvz3i0c5700v0c5cg61z";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.Serialization.Formatters";
-    version = "4.3.0";
-    sha256 = "114j35n8gcvn3sqv9ar36r1jjq0y1yws9r0yk8i6wm4aq7n9rs0m";
-  })
-  (fetchNuGet {
-    pname = "System.Runtime.Serialization.Primitives";
-    version = "4.3.0";
-    sha256 = "01vv2p8h4hsz217xxs0rixvb7f2xzbh6wv1gzbfykcbfrza6dvnf";
-  })
-  (fetchNuGet {
-    pname = "System.Security.AccessControl";
-    version = "5.0.0";
-    sha256 = "17n3lrrl6vahkqmhlpn3w20afgz09n7i6rv0r3qypngwi7wqdr5r";
+    hash = "sha256-P5jHCgMbgFMYiONvzmaKFeOqcAIDPu/U8bOVrNPYKqc=";
   })
   (fetchNuGet {
     pname = "System.Security.Claims";
     version = "4.0.1";
-    sha256 = "03dw0ls49bvsrffgwycyifjgz0qzr9r85skqhdyhfd51fqf398n6";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Claims";
-    version = "4.3.0";
-    sha256 = "0jvfn7j22l3mm28qjy3rcw287y9h65ha4m940waaxah07jnbzrhn";
+    hash = "sha256-xqI0HHahNAd9g3jqgnLKH4P/pIueef6cy3qvRDQFvA0=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Algorithms";
     version = "4.2.0";
-    sha256 = "148s9g5dgm33ri7dnh19s4lgnlxbpwvrw2jnzllq2kijj4i4vs85";
+    hash = "sha256-BelNIpEyToEp/VYKnje/q1P7KNEpQNtOzGPU18pLGpE=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Algorithms";
     version = "4.3.0";
-    sha256 = "03sq183pfl5kp7gkvq77myv7kbpdnq3y0xj7vi4q1kaw54sny0ml";
+    hash = "sha256-tAJvNSlczYBJ3Ed24Ae27a55tq/n4D3fubNQdwcKWA8=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Cng";
     version = "4.2.0";
-    sha256 = "118jijz446kix20blxip0f0q8mhsh9bz118mwc2ch1p6g7facpzc";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Cryptography.Cng";
-    version = "4.3.0";
-    sha256 = "1k468aswafdgf56ab6yrn7649kfqx2wm9aslywjam1hdmk5yypmv";
+    hash = "sha256-7F+m3HnmBsgE4xWF8FeCGlaEgQM3drqA6HEaQr6MEoU=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Csp";
     version = "4.0.0";
-    sha256 = "1cwv8lqj8r15q81d2pz2jwzzbaji0l28xfrpw29kdpsaypm92z2q";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Cryptography.Csp";
-    version = "4.3.0";
-    sha256 = "1x5wcrddf2s3hb8j78cry7yalca4lb5vfnkrysagbn6r9x6xvrx1";
+    hash = "sha256-WHyR6vVK3zaT4De7jgQFUar1P5fiX9ECwiVkJDFFm7M=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Encoding";
     version = "4.0.0";
-    sha256 = "0a8y1a5wkmpawc787gfmnrnbzdgxmx1a14ax43jf3rj9gxmy3vk4";
+    hash = "sha256-ZO7ha39J5uHkIF2RoEKv/bW/bLbVvYMO4+rWyYsKHik=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Encoding";
     version = "4.3.0";
-    sha256 = "1jr6w70igqn07k5zs1ph6xja97hxnb3mqbspdrff6cvssgrixs32";
+    hash = "sha256-Yuge89N6M+NcblcvXMeyHZ6kZDfwBv3LPMDiF8HhJss=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.OpenSsl";
     version = "4.0.0";
-    sha256 = "16sx3cig3d0ilvzl8xxgffmxbiqx87zdi8fc73i3i7zjih1a7f4q";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Cryptography.OpenSsl";
-    version = "4.3.0";
-    sha256 = "0givpvvj8yc7gv4lhb6s1prq6p2c4147204a0wib89inqzd87gqc";
+    hash = "sha256-mLijAozynzjiOMyh2P5BHcfVq3Ovd0T/phG08SIbXZs=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Pkcs";
-    version = "8.0.0";
-    sha256 = "04kqf1lhsq3fngiljanmrz2774x5h2fc8p57v04c51jwwqhwi9ya";
+    version = "9.0.0";
+    hash = "sha256-AjG14mGeSc2Ka4QSelGBM1LrGBW3VJX60lnihKyJjGY=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Primitives";
     version = "4.0.0";
-    sha256 = "0i7cfnwph9a10bm26m538h5xcr8b36jscp9sy1zhgifksxz4yixh";
+    hash = "sha256-sEdPftfTxQd/8DpdpqUZC2XWC0SjVCPqAkEleLl17EQ=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Primitives";
     version = "4.3.0";
-    sha256 = "0pyzncsv48zwly3lw4f2dayqswcfvdwq2nz0dgwmi7fj3pn64wby";
+    hash = "sha256-fnFi7B3SnVj5a+BbgXnbjnGNvWrCEU6Hp/wjsjWz318=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.ProtectedData";
-    version = "4.4.0";
-    sha256 = "1q8ljvqhasyynp94a1d7jknk946m20lkwy2c3wa8zw2pc517fbj6";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Cryptography.ProtectedData";
-    version = "8.0.0";
-    sha256 = "1ysjx3b5ips41s32zacf4vs7ig41906mxrsbmykdzi0hvdmjkgbx";
+    version = "9.0.0";
+    hash = "sha256-gPgPU7k/InTqmXoRzQfUMEKL3QuTnOKowFqmXTnWaBQ=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.X509Certificates";
     version = "4.1.0";
-    sha256 = "0clg1bv55mfv5dq00m19cp634zx6inm31kf8ppbq1jgyjf2185dh";
+    hash = "sha256-sBUUhJP+yYDXvcjNMKqNpn8yzGUpVABwK9vVUvYKjzI=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.X509Certificates";
     version = "4.3.0";
-    sha256 = "0valjcz5wksbvijylxijjxb1mp38mdhv03r533vnx1q3ikzdav9h";
+    hash = "sha256-MG3V/owDh273GCUPsGGraNwaVpcydupl3EtPXj6TVG0=";
   })
   (fetchNuGet {
     pname = "System.Security.Cryptography.Xml";
-    version = "8.0.0";
-    sha256 = "0x9xpq5i49qss2phv95m76jpf8y8qw6lwx2x52x8i8f1sjpkqa2x";
+    version = "9.0.0";
+    hash = "sha256-SQJWwAFrJUddEU6JiZB52FM9tGjRlJAYH8oYVzG5IJU=";
   })
   (fetchNuGet {
     pname = "System.Security.Principal";
     version = "4.0.1";
-    sha256 = "1nbzdfqvzzbgsfdd5qsh94d7dbg2v4sw0yx6himyn52zf8z6007p";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Principal";
-    version = "4.3.0";
-    sha256 = "12cm2zws06z4lfc4dn31iqv7072zyi4m910d4r6wm8yx85arsfxf";
+    hash = "sha256-9wBgPnJfFOtrhKZ7wDXZ4q12GklQ49Ka02/9v7Frf9k=";
   })
   (fetchNuGet {
     pname = "System.Security.Principal.Windows";
     version = "4.0.0";
-    sha256 = "1d3vc8i0zss9z8p4qprls4gbh7q4218l9845kclx7wvw41809k6z";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Principal.Windows";
-    version = "4.3.0";
-    sha256 = "00a0a7c40i3v4cb20s2cmh9csb5jv2l0frvnlzyfxh848xalpdwr";
-  })
-  (fetchNuGet {
-    pname = "System.Security.Principal.Windows";
-    version = "5.0.0";
-    sha256 = "1mpk7xj76lxgz97a5yg93wi8lj0l8p157a5d50mmjy3gbz1904q8";
+    hash = "sha256-38wEUCB889Mpm4WgRFEQBB+4HtE0X0wu+knrDyJie7Q=";
   })
   (fetchNuGet {
     pname = "System.Text.Encoding";
     version = "4.0.11";
-    sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
+    hash = "sha256-PEailOvG05CVgPTyKLtpAgRydlSHmtd5K0Y8GSHY2Lc=";
   })
   (fetchNuGet {
     pname = "System.Text.Encoding";
     version = "4.3.0";
-    sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
+    hash = "sha256-GctHVGLZAa/rqkBNhsBGnsiWdKyv6VDubYpGkuOkBLg=";
   })
   (fetchNuGet {
     pname = "System.Text.Encoding.CodePages";
     version = "4.0.1";
-    sha256 = "00wpm3b9y0k996rm9whxprngm8l500ajmzgy2ip9pgwk0icp06y3";
+    hash = "sha256-wxtwWQSTv5tuFP79KhUAhaL6bL4d8lSzSWkCn9aolwM=";
   })
   (fetchNuGet {
     pname = "System.Text.Encoding.CodePages";
     version = "6.0.0";
-    sha256 = "0gm2kiz2ndm9xyzxgi0jhazgwslcs427waxgfa30m7yqll1kcrww";
+    hash = "sha256-nGc2A6XYnwqGcq8rfgTRjGr+voISxNe/76k2K36coj4=";
   })
   (fetchNuGet {
     pname = "System.Text.Encoding.Extensions";
     version = "4.0.11";
-    sha256 = "08nsfrpiwsg9x5ml4xyl3zyvjfdi4mvbqf93kjdh11j4fwkznizs";
+    hash = "sha256-+kf7J3dEhgCbnCM5vHYlsTm5/R/Ud0Jr6elpHm922iI=";
   })
   (fetchNuGet {
     pname = "System.Text.Encoding.Extensions";
     version = "4.3.0";
-    sha256 = "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy";
+    hash = "sha256-vufHXg8QAKxHlujPHHcrtGwAqFmsCD6HKjfDAiHyAYc=";
   })
   (fetchNuGet {
     pname = "System.Text.Encodings.Web";
     version = "8.0.0";
-    sha256 = "1wbypkx0m8dgpsaqgyywz4z760xblnwalb241d5qv9kx8m128i11";
+    hash = "sha256-IUQkQkV9po1LC0QsqrilqwNzPvnc+4eVvq+hCvq8fvE=";
   })
   (fetchNuGet {
     pname = "System.Text.Json";
     version = "8.0.0";
-    sha256 = "134savxw0sq7s448jnzw17bxcijsi1v38mirpbb6zfxmqlf04msw";
+    hash = "sha256-XFcCHMW1u2/WujlWNHaIWkbW1wn8W4kI0QdrwPtWmow=";
   })
   (fetchNuGet {
     pname = "System.Text.RegularExpressions";
     version = "4.1.0";
-    sha256 = "1mw7vfkkyd04yn2fbhm38msk7dz2xwvib14ygjsb8dq2lcvr18y7";
+    hash = "sha256-x6OQN6MCN7S0fJ6EFTfv4rczdUWjwuWE9QQ0P6fbh9c=";
   })
   (fetchNuGet {
     pname = "System.Text.RegularExpressions";
     version = "4.3.0";
-    sha256 = "1bgq51k7fwld0njylfn7qc5fmwrk2137gdq7djqdsw347paa9c2l";
+    hash = "sha256-VLCk1D1kcN2wbAe3d0YQM/PqCsPHOuqlBY1yd2Yo+K0=";
   })
   (fetchNuGet {
     pname = "System.Threading";
     version = "4.0.11";
-    sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
+    hash = "sha256-mob1Zv3qLQhQ1/xOLXZmYqpniNUMCfn02n8ZkaAhqac=";
   })
   (fetchNuGet {
     pname = "System.Threading";
     version = "4.3.0";
-    sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
+    hash = "sha256-ZDQ3dR4pzVwmaqBg4hacZaVenQ/3yAF/uV7BXZXjiWc=";
   })
   (fetchNuGet {
     pname = "System.Threading.Channels";
     version = "6.0.0";
-    sha256 = "1qbyi7yymqc56frqy7awvcqc1m7x3xrpx87a37dgb3mbrjg9hlcj";
+    hash = "sha256-klGYnsyrjvXaGeqgfnMf/dTAMNtcHY+zM4Xh6v2JfuE=";
   })
   (fetchNuGet {
     pname = "System.Threading.Channels";
-    version = "7.0.0";
-    sha256 = "1qrmqa6hpzswlmyp3yqsbnmia9i5iz1y208xpqc1y88b1f6j1v8a";
+    version = "8.0.0";
+    hash = "sha256-c5TYoLNXDLroLIPnlfyMHk7nZ70QAckc/c7V199YChg=";
   })
   (fetchNuGet {
     pname = "System.Threading.Overlapped";
     version = "4.0.1";
-    sha256 = "0fi79az3vmqdp9mv3wh2phblfjls89zlj6p9nc3i9f6wmfarj188";
+    hash = "sha256-CAWZlavcuBQHs+kaSX9CmkpHF7wC8rFrug3XPb5KJzo=";
   })
   (fetchNuGet {
     pname = "System.Threading.Tasks";
     version = "4.0.11";
-    sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
+    hash = "sha256-5SLxzFg1df6bTm2t09xeI01wa5qQglqUwwJNlQPJIVs=";
   })
   (fetchNuGet {
     pname = "System.Threading.Tasks";
     version = "4.3.0";
-    sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
+    hash = "sha256-Z5rXfJ1EXp3G32IKZGiZ6koMjRu0n8C1NGrwpdIen4w=";
   })
   (fetchNuGet {
     pname = "System.Threading.Tasks.Dataflow";
     version = "4.6.0";
-    sha256 = "0a1davr71wssyn4z1hr75lk82wqa0daz0vfwkmg1fm3kckfd72k1";
+    hash = "sha256-YYrT3GRzVBdendxt8FUDCnOBJi0nw/CJ9VrzcPJWLSg=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Tasks.Dataflow";
+    version = "8.0.0";
+    hash = "sha256-Q6fPtMPNW4+SDKCabJzNS+dw4B04Oxd9sHH505bFtQo=";
   })
   (fetchNuGet {
     pname = "System.Threading.Tasks.Extensions";
     version = "4.0.0";
-    sha256 = "1cb51z062mvc2i8blpzmpn9d9mm4y307xrwi65di8ri18cz5r1zr";
-  })
-  (fetchNuGet {
-    pname = "System.Threading.Tasks.Extensions";
-    version = "4.3.0";
-    sha256 = "1xxcx2xh8jin360yjwm4x4cf5y3a2bwpn2ygkfkwkicz7zk50s2z";
+    hash = "sha256-+YdcPkMhZhRbMZHnfsDwpNbUkr31X7pQFGxXYcAPZbE=";
   })
   (fetchNuGet {
     pname = "System.Threading.Tasks.Parallel";
     version = "4.0.1";
-    sha256 = "114wdg32hr46dfsnns3pgs67kcha5jn47p5gg0mhxfn5vrkr2p75";
+    hash = "sha256-5VyRZ97Fug4reK/cQ6wsCrJ5jH53aGu1a4ZkKMZrnIQ=";
   })
   (fetchNuGet {
     pname = "System.Threading.Thread";
     version = "4.0.0";
-    sha256 = "1gxxm5fl36pjjpnx1k688dcw8m9l7nmf802nxis6swdaw8k54jzc";
+    hash = "sha256-7EtSJuKqcW107FYA5Ko9NFXEWUPIzNDtlfKaQV2pvb8=";
   })
   (fetchNuGet {
     pname = "System.Threading.ThreadPool";
     version = "4.0.10";
-    sha256 = "0fdr61yjcxh5imvyf93n2m3n5g9pp54bnw2l1d2rdl9z6dd31ypx";
-  })
-  (fetchNuGet {
-    pname = "System.Threading.ThreadPool";
-    version = "4.3.0";
-    sha256 = "027s1f4sbx0y1xqw2irqn6x161lzj8qwvnh2gn78ciiczdv10vf1";
+    hash = "sha256-/fowWjM/0ZZFC1Rwu0i5N71iRxV2JOd3jQV2Jn0wuTk=";
   })
   (fetchNuGet {
     pname = "System.Threading.Timer";
     version = "4.0.1";
-    sha256 = "15n54f1f8nn3mjcjrlzdg6q3520571y012mx7v991x2fvp73lmg6";
+    hash = "sha256-5lU6zt1O9JDSPr2KAHw4BYgysHnt0yyZrMNa5IIjxZY=";
   })
   (fetchNuGet {
     pname = "System.Threading.Timer";
     version = "4.3.0";
-    sha256 = "1nx773nsx6z5whv8kaa1wjh037id2f1cxhb69pvgv12hd2b6qs56";
+    hash = "sha256-pmhslmhQhP32TWbBzoITLZ4BoORBqYk25OWbru04p9s=";
+  })
+  (fetchNuGet {
+    pname = "System.ValueTuple";
+    version = "4.4.0";
+    hash = "sha256-LqpI3bSaXqVPqfEdfsWE2qX9tzFV6VPU6x4A/fVzzfM=";
   })
   (fetchNuGet {
     pname = "System.Xml.ReaderWriter";
     version = "4.0.11";
-    sha256 = "0c6ky1jk5ada9m94wcadih98l6k1fvf6vi7vhn1msjixaha419l5";
+    hash = "sha256-haZAFFQ9Sl2DhfvEbdx2YRqKEoxNMU5STaqpMmXw0zA=";
   })
   (fetchNuGet {
     pname = "System.Xml.ReaderWriter";
     version = "4.3.0";
-    sha256 = "0c47yllxifzmh8gq6rq6l36zzvw4kjvlszkqa9wq3fr59n0hl3s1";
+    hash = "sha256-QQ8KgU0lu4F5Unh+TbechO//zaAGZ4MfgvW72Cn1hzA=";
   })
   (fetchNuGet {
     pname = "System.Xml.XDocument";
     version = "4.0.11";
-    sha256 = "0n4lvpqzy9kc7qy1a4acwwd7b7pnvygv895az5640idl2y9zbz18";
+    hash = "sha256-KPz1kxe0RUBM+aoktJ/f9p51GudMERU8Pmwm//HdlFg=";
   })
   (fetchNuGet {
     pname = "System.Xml.XDocument";
     version = "4.3.0";
-    sha256 = "08h8fm4l77n0nd4i4fk2386y809bfbwqb7ih9d7564ifcxr5ssxd";
+    hash = "sha256-rWtdcmcuElNOSzCehflyKwHkDRpiOhJJs8CeQ0l1CCI=";
   })
   (fetchNuGet {
     pname = "System.Xml.XmlDocument";
     version = "4.0.1";
-    sha256 = "0ihsnkvyc76r4dcky7v3ansnbyqjzkbyyia0ir5zvqirzan0bnl1";
-  })
-  (fetchNuGet {
-    pname = "System.Xml.XmlDocument";
-    version = "4.3.0";
-    sha256 = "0bmz1l06dihx52jxjr22dyv5mxv6pj4852lx68grjm7bivhrbfwi";
+    hash = "sha256-gdoFrPo54v1LjkBF79f8EvtltVVjHz9ZI9kc5ve0GkY=";
   })
   (fetchNuGet {
     pname = "System.Xml.XPath";
     version = "4.0.1";
-    sha256 = "0fjqgb6y66d72d5n8qq1h213d9nv2vi8mpv8p28j3m9rccmsh04m";
+    hash = "sha256-lQCoK2M51SGRuGjfiuIW26Y2goABY2RLE6cZ4816WDo=";
   })
   (fetchNuGet {
     pname = "System.Xml.XPath.XDocument";
     version = "4.0.1";
-    sha256 = "1fndc70lbjvh8kxs71c7cidfm8plznd61bg4fwpiyq3mq0qg5z0z";
-  })
-  (fetchNuGet {
-    pname = "Tavis.UriTemplates";
-    version = "2.0.0";
-    sha256 = "089xzz4pcqx1zf8b0crmh1ac6s4bmdr75m1n63hja5j6kqgxbpa5";
+    hash = "sha256-H/zyMMB1YB8vd+StYJr99KLqWmSHhaP7RHDLRcFhzbo=";
   })
   (fetchNuGet {
     pname = "TestableIO.System.IO.Abstractions";
-    version = "20.0.4";
-    sha256 = "16jw4zw8pvck754r6744d11460w1fih8c77r8yzzw2w58iv2mns6";
-  })
-  (fetchNuGet {
-    pname = "TestableIO.System.IO.Abstractions.TestingHelpers";
-    version = "20.0.4";
-    sha256 = "06h43ds6pmcnjxlphhhqg3sriisi53y583rhdgfdqdg6jpa144mn";
+    version = "21.1.3";
+    hash = "sha256-ZD+4JKFD6c50Kfd8AmPCO6g5jrkUFM6hGhA1W/0WvAA=";
   })
   (fetchNuGet {
     pname = "TestableIO.System.IO.Abstractions.Wrappers";
-    version = "20.0.4";
-    sha256 = "1c5sf8dva9vswl2qqkc6xcmznia8d5nqw46yvk4b1f9idv53j5nz";
+    version = "21.1.3";
+    hash = "sha256-mS3xbH8p9rMNNpYxUb6Owb2CkDSfgnTr2XLxPKvL+6A=";
+  })
+  (fetchNuGet {
+    pname = "Tmds.LibC";
+    version = "0.2.0";
+    hash = "sha256-vUIF8ZWGQ3cIT7cWIttbhHM4RliU9uly/BQfezLm5/Q=";
   })
   (fetchNuGet {
     pname = "Websocket.Client";
-    version = "5.0.0";
-    sha256 = "0pw1yw8wa70ghy5hy69zsni42fq7m9ml3chyrhy3hdz02ix4rpgy";
+    version = "5.1.2";
+    hash = "sha256-T0uXa9hAr3+9cvpJ/FVwtqNmE7QvSJxXsIoWV624cHs=";
   })
   (fetchNuGet {
     pname = "YamlDotNet";
-    version = "13.3.1";
-    sha256 = "1wjwmaxs316npbawswq74mm3rlhydyfyx36dh7n9iv07ac0va5b9";
-  })
-  (fetchNuGet {
-    pname = "YamlDotNet";
-    version = "13.7.1";
-    sha256 = "1m2lnfb2r8382fpjyxp79wnbis7l462zksj3618142q53y33bk5z";
+    version = "15.1.0";
+    hash = "sha256-qanJgTrb9aBgRsRaqe3tpQm1z8TxVhdTeWvP7RzUedU=";
   })
 ]

--- a/pkgs/nimbus/default.nix
+++ b/pkgs/nimbus/default.nix
@@ -1,63 +1,19 @@
 {
+  applyPatches,
   fetchFromGitHub,
-  lib,
-  stdenv,
-  lsb-release,
-  which,
-  cmake,
   pkgs,
-  writeShellScriptBin,
-  buildFlags ? ["nimbus_beacon_node" "nimbus_validator_client"],
+  targets ? ["nimbus_beacon_node" "nimbus_validator_client"],
 }: let
-  nim1 = pkgs.nim-unwrapped-1.overrideAttrs rec {
-    version = "1.6.18";
-    src = pkgs.fetchurl {
-      url = "https://nim-lang.org/download/nim-${version}.tar.xz";
-      hash = "sha256-UCQaxyIpG6ljdT8EWqo1h7c8GqKK4pxXPBWluKYCoss=";
-    };
-  };
-in
-  stdenv.mkDerivation rec {
-    pname = "nimbus-eth2";
-    version = "24.6.0";
-
+  version = "24.12.0";
+  src = applyPatches {
     src = fetchFromGitHub {
       owner = "status-im";
-      repo = pname;
+      repo = "nimbus-eth2";
       rev = "v${version}";
-      hash = "sha256-cSQfuwMz0JDALJKeYpq25vvqq4SnAKkqW6kRNWGG788=";
+      hash = "sha256-DBvsnGr91a69eCj1hAeoVOpxas5rfaT36rIxWEmvIVg=";
       fetchSubmodules = true;
     };
-
-    fakeGit = writeShellScriptBin "git" "echo ${version}";
-
-    # Dunno why we need `lsb-release`, looks like for nim itself
-    # without `which` it can't find gcc
-    nativeBuildInputs = [fakeGit lsb-release nim1 which cmake];
-    enableParallelBuilding = true;
-
-    NIMFLAGS = "-d:disableMarchNative -d:release";
-
-    makeFlags = ["USE_SYSTEM_NIM=1"];
-    inherit buildFlags;
-    dontConfigure = true;
-
-    preBuild = ''
-      patchShebangs scripts vendor/nimbus-build-system/scripts
-      make nimbus-build-system-paths
-    '';
-
-    installPhase = ''
-      mkdir -p $out/bin
-      rm -f build/generate_makefile
-      cp build/* $out/bin
-    '';
-
-    meta = {
-      description = "Nim implementation of the Ethereum Beacon Chain";
-      homepage = "https://github.com/status-im/nimbus-eth2";
-      license = lib.licenses.asl20;
-      mainProgram = "nimbus_beacon_node";
-      platforms = ["x86_64-linux"];
-    };
-  }
+    patches = [./fix-hash.patch];
+  };
+in
+  import "${src}/nix" {inherit pkgs targets;}

--- a/pkgs/nimbus/default.nix
+++ b/pkgs/nimbus/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   pkgs,
   targets ? ["nimbus_beacon_node" "nimbus_validator_client"],
+  stableSystems ? ["x86_64-linux" "aarch64-linux"],
 }: let
   version = "24.12.0";
   src = applyPatches {
@@ -16,4 +17,4 @@
     patches = [./fix-hash.patch];
   };
 in
-  import "${src}/nix" {inherit pkgs targets;}
+  import "${src}/nix" {inherit pkgs targets stableSystems;}

--- a/pkgs/nimbus/fix-hash.patch
+++ b/pkgs/nimbus/fix-hash.patch
@@ -1,0 +1,11 @@
+diff --git a/nix/nimble.nix b/nix/nimble.nix
+index 5343aaa81..770f8fa5a 100644
+--- a/nix/nimble.nix
++++ b/nix/nimble.nix
+@@ -8,5 +8,5 @@ in pkgs.fetchFromGitHub {
+   repo = "nimble";
+   rev = tools.findKeyValue "^ +NimbleStableCommit = \"([a-f0-9]+)\".+" sourceFile;
+   # WARNING: Requires manual updates when Nim compiler version changes.
+-  hash = "sha256-sa0irAZjQRZLduEMBPf7sHlY1FigBJTR/vIH4ihii/w=";
++  hash = "sha256-MVHf19UbOWk8Zba2scj06PxdYYOJA6OXrVyDQ9Ku6Us=";
+ }

--- a/pkgs/reth/default.nix
+++ b/pkgs/reth/default.nix
@@ -7,22 +7,17 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "reth";
-  version = "0.2.0-beta.6";
+  version = "1.1.5";
 
   src = fetchFromGitHub {
     owner = "paradigmxyz";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-ZcQ29AwlTU6rDiknlJbOo8JubXQOJg1UVMSlRb1l8Yk=";
+    hash = "sha256-bQ45SJCdIEtBqhh/2bQh0CS8KC9eI4zF38LSL/LDOSk=";
   };
 
   cargoLock = {
     lockFile = "${src}/Cargo.lock";
-    outputHashes = {
-      "alloy-consensus-0.1.0" = "sha256-2TZeQo0d+Yp0M46VNx3OZoyDT4F31cLdOpl1tk3syfg=";
-      "discv5-0.4.1" = "sha256-agrluN1C9/pS/IMFTVlPOuYl3ZuklnTYb46duVvTPio=";
-      "revm-inspectors-0.1.0" = "sha256-ZRlYNEHD+wewlttUcMuEoTYg9Hn89JVAr7+hIeMBXog=";
-    };
   };
 
   nativeBuildInputs = [

--- a/pkgs/reth/default.nix
+++ b/pkgs/reth/default.nix
@@ -1,9 +1,7 @@
 {
-  darwin,
   fetchFromGitHub,
   lib,
   rustPlatform,
-  stdenv,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "reth";
@@ -24,14 +22,6 @@ rustPlatform.buildRustPackage rec {
     rustPlatform.bindgenHook
   ];
 
-  # `x86_64-darwin` seems to have issues with jemalloc
-  buildNoDefaultFeatures = true;
-  buildFeatures = lib.optional (stdenv.system != "x86_64-darwin") "jemalloc";
-
-  buildInputs = lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.Security
-  ];
-
   # Some tests fail due to I/O that is unfriendly with nix sandbox.
   checkFlags = [
     "--skip=builder::tests::block_number_node_config_test"
@@ -46,6 +36,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/paradigmxyz/reth";
     license = with licenses; [mit asl20];
     mainProgram = "reth";
-    platforms = ["aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux"];
+    platforms = ["aarch64-linux" "x86_64-linux"];
   };
 }


### PR DESCRIPTION
the plan is to do `nix flake update --commit-lock-file` and then get green on buildbot. Incorporates #560 #561 and #562. As discussed in #560 we drop support for reth on Darwin. I haven't touched the `nixos-24.05` input but this should be done asap