### PR TITLE
feat: Nimbus on Gnosis chains

### DIFF
--- a/modules/nimbus-beacon/args.nix
+++ b/modules/nimbus-beacon/args.nix
@@ -5,7 +5,7 @@
 }:
 with lib; {
   network = mkOption {
-    type = types.enum ["mainnet" "prater" "sepolia" "holesky"];
+    type = types.enum ["mainnet" "prater" "sepolia" "holesky" "gnosis" "chiado"];
     default = name;
     defaultText = "name";
     description = "The Eth2 network to join";

--- a/modules/nimbus-beacon/default.nix
+++ b/modules/nimbus-beacon/default.nix
@@ -168,6 +168,11 @@ in {
               ${data-dir-arg} \
               ${concatStringsSep " \\\n" filteredArgs}
             '';
+            bin = let
+              bins.gnosis = "nimbus_beacon_node_gnosis";
+              bins.chiado = "nimbus_beacon_node_gnosis";
+            in
+              bins.${cfg.args.network} or "nimbus_beacon_node";
           in
             nameValuePair serviceName (mkIf cfg.enable {
               after = ["network.target"];
@@ -185,9 +190,9 @@ in {
                   ExecStartPre = lib.mkBefore [
                     ''                      ${pkgs.coreutils-full}/bin/cp --no-preserve=all --update=none \
                       /proc/sys/kernel/random/uuid ${data-dir}/${cfg.args.keymanager.token-file}''
-                    "${cfg.package}/bin/nimbus_beacon_node trustedNodeSync ${checkpointSyncArgs}"
+                    "${cfg.package}/bin/${bin} trustedNodeSync ${checkpointSyncArgs}"
                   ];
-                  ExecStart = "${cfg.package}/bin/nimbus_beacon_node ${scriptArgs}";
+                  ExecStart = "${cfg.package}/bin/${bin} ${scriptArgs}";
                 }
                 baseServiceConfig
                 (mkIf (cfg.args.jwt-secret != null) {

--- a/pkgs/nimbus/default.nix
+++ b/pkgs/nimbus/default.nix
@@ -2,7 +2,7 @@
   applyPatches,
   fetchFromGitHub,
   pkgs,
-  targets ? ["nimbus_beacon_node" "nimbus_validator_client"],
+  targets ? ["nimbus_beacon_node" "nimbus_validator_client" "gnosis-build" "gnosis-vc-build"],
   stableSystems ? ["x86_64-linux" "aarch64-linux"],
 }: let
   version = "24.12.0";


### PR DESCRIPTION
depends on #568

Nimbus needs to be recompiled for Gnosis Chain and Chiado. This is neatly handled by upstream Makefile, we just need to enable it and pick the right binary at configuration time. Currently running on my machine with seemingly no issues.