### PR TITLE
rotki-bin: 1.33.1 -> 1.37.1; add icon and enable wayland

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -62,7 +62,7 @@
       reth = callPackageUnstable ./reth {};
       rocketpool = callPackage ./rocketpool {};
       rocketpoold = callPackage ./rocketpoold {inherit bls blst;};
-      rotki-bin = callPackage2311 ./rotki-bin {};
+      rotki-bin = callPackageUnstable ./rotki-bin {};
       sedge = callPackage2311 ./sedge {
         bls = callPackage2311 ./bls {};
         mcl = callPackage2311 ./mcl {};


### PR DESCRIPTION
switched from `callPackage2311` to `callPackageUnstable` because 23.11 is EOL and `wrapProgram` didn't work on regular `callPackage`, idk why, it works on `callPackageUnstable`.

the rest of pr should be self-explanatory