### PR TITLE
geth: 1.14.8 -> 1.14.13

### DIFF
--- a/pkgs/geth/default.nix
+++ b/pkgs/geth/default.nix
@@ -21,17 +21,17 @@
 in
   buildGoModule rec {
     pname = "geth";
-    version = "1.14.8";
+    version = "1.14.13";
 
     src = fetchFromGitHub {
       owner = "ethereum";
       repo = "go-ethereum";
       rev = "v${version}";
-      hash = "sha256-y831v6ar1RdDvGQMZf2lZKgq2IQzAAQrNwDCL0xbj24=";
+      hash = "sha256-oJe+V11WArXVmoIC7nYN6oKc0VoHtRtelidyb3v6skI=";
     };
 
     proxyVendor = true;
-    vendorHash = "sha256-CLGf64Fftu4u8Vaj66Q4xuRKBEMNZmpltUyaUMVyVJk=";
+    vendorHash = "sha256-IEwy3XRyj+5GjAWRjPsd5qzwEMpI/pZIwPjKdeATgkE=";
 
     ldflags = ["-s" "-w"];
 


### PR DESCRIPTION
> This is a security release, fixing a vulnerability (https://github.com/advisories/GHSA-q26p-9cq4-7fc2).
>
> Please update your nodes ASAP.

https://github.com/ethereum/go-ethereum/releases/tag/v1.14.13