### PR TITLE
fix lighthouse args.beacon-nodes

### DIFF
--- a/modules/lighthouse-validator/default.nix
+++ b/modules/lighthouse-validator/default.nix
@@ -90,7 +90,7 @@ in {
                 else "--datadir %S/${user}";
 
               beaconNodes =
-                if (cfg.args.beacon-nodes != null) && (length cfg.args.beacon-nodes == 0)
+                if (cfg.args.beacon-nodes != null) && (length cfg.args.beacon-nodes != 0)
                 then "--beacon-nodes ${concatStringsSep "," cfg.args.beacon-nodes}"
                 else let
                   beaconCfg = config.services.ethereum.lighthouse-beacon.${name};


### PR DESCRIPTION
the condition is backwards. As a result:
- If you set the option to `[]`, it fails at runtime with `error: a value is required for '--beacon-nodes <NETWORK_ADDRESSES>' but none was supplied`.
- if you set is to `[my-beacon-enpoint]`, it uses the default value (or lighthouse-beacon value) instead.