### PR TITLE
prysm: 5.0.3 -> 5.3.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -195,11 +195,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1736241350,
-        "narHash": "sha256-CHd7yhaDigUuJyDeX0SADbTM9FXfiWaeNyY34FL1wQU=",
+        "lastModified": 1740019556,
+        "narHash": "sha256-vn285HxnnlHLWnv59Og7muqECNMS33mWLM14soFIv2g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8c9fd3e564728e90829ee7dbac6edc972971cd0f",
+        "rev": "dad564433178067be1fbdfcce23b546254b6d641",
         "type": "github"
       },
       "original": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -58,7 +58,7 @@
       mev-rs = callPackage ./mev-rs {};
       nethermind = callPackageUnstable ./nethermind {};
       nimbus = callPackageUnstable ./nimbus {};
-      prysm = callPackage ./prysm {inherit bls blst;};
+      prysm = callPackageUnstable ./prysm {inherit bls blst;};
       reth = callPackageUnstable ./reth {};
       rocketpool = callPackage ./rocketpool {};
       rocketpoold = callPackage ./rocketpoold {inherit bls blst;};

--- a/pkgs/prysm/default.nix
+++ b/pkgs/prysm/default.nix
@@ -1,22 +1,22 @@
 {
   bls,
   blst,
-  buildGo121Module,
+  buildGo123Module,
   fetchFromGitHub,
   libelf,
 }:
-buildGo121Module rec {
+buildGo123Module rec {
   pname = "prysm";
-  version = "5.0.3";
+  version = "5.3.0";
 
   src = fetchFromGitHub {
     owner = "prysmaticlabs";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-h1ff0FqFdJMImkCI8UxRwjHqOfZuS56Mo73QJGVtE9Q=";
+    hash = "sha256-bTA7KOfhdsVIQk6d9pnBAYmmuzj3KQnvMO/OrEpx5uA=";
   };
 
-  vendorHash = "sha256-cR1/OxL2qulK8FLm469X7SwFDCxFfyEVv0vro2Fv48w=";
+  vendorHash = "sha256-1PAeAI6yaXSE881Bsp2hhPSctePc5CwWYkk8QVounAA=";
 
   buildInputs = [bls blst libelf];
 


### PR DESCRIPTION
Updated prysm to 5.3.0 and the version of go to 1.23 [to match the repo](https://github.com/prysmaticlabs/prysm/blob/8c4ea850baec0a8579e80d44af44943f50a18d3e/go.mod#L3)

This fixes [my issue with the overlay](https://github.com/nix-community/ethereum.nix/issues/575). 