### PR TITLE
fix: mkdocs

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -9,7 +9,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     permissions:
       contents: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2022-2023 Ethereum.nix contributors
+Copyright (c) 2022-2025 Ethereum.nix contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,74 +15,47 @@ This project is developed entirely in [Nix Flakes](https://wiki.nixos.org/wiki/F
 
 ## Eager to use Ethereum.nix?
 
-::cards::cols=2
+<div class="grid cards" markdown>
 
-- title: :material-information:{ .lg .middle } New to Ethereum.nix and Nix?
-  content: |
-    <br/>
+-   :material-information:{ .lg .middle } New to Ethereum.nix and Nix?
+
+    ---
+
     Get started by installing Nix on your system and how to use it with Ethereum.nix
-    <br/>
-    <br/>
-    [Getting Started :octicons-arrow-right-24:](./getting-started.md){ .md-button }
 
-- title: :material-apps-box:{ .lg .middle } Want to use an application now?
-  content: |
-    <br />
+    [Getting Started :octicons-arrow-right-24:](./getting-started.md)
+
+-   :material-apps-box:{ .lg .middle } Want to use an application now?
+
+    ---
+
     See our list of supported applications ready to be used in seconds.
-    <br />
-    <br />
-    [See supported Applications :octicons-arrow-right-24:](./apps.md){ .md-button }
 
-- title: :simple-nixos:{ .lg .middle } Want to run Ethereum services on NixOS?
-  content: |
-    <br />
+    [See supported Applications :octicons-arrow-right-24:](./apps.md)
+
+-   :simple-nixos:{ .lg .middle } Want to run Ethereum services on NixOS?
+
+    ---
+
     Run Ethereum services easily with our supported NixOS modules.
-    <br />
-    <br />
-    [Run Ethereum services on NixOS :octicons-arrow-right-24:](./nixos/installation.md){ .md-button }
 
-- title: :material-chat-question:{ .lg .middle } Have a question or need help?
-  content: |
-    <br />
+    [Run Ethereum services on NixOS :octicons-arrow-right-24:](./nixos/installation.md)
+
+-   :material-chat-question:{ .lg .middle } Have a question or need help?
+
+    ---
+
     Ask questions on our discussion board and get in touch with our community.
-    <br />
-    <br />
-    [Ask a question :octicons-arrow-right-24:](https://github.com/nix-community/ethereum.nix/discussions){ .md-button }
 
-::/cards::
+    [Ask a question :octicons-arrow-right-24:](https://github.com/nix-community/ethereum.nix/discussions)
+
+</div>
 
 ## About the project
 
 In the beginning Ethereum.nix was a playground for [Aldo Borrero](https://aldoborrero.com/) to experiment with _nix'ifying_
 Ethereum related processes. Since then, the project got accepted by the [Nix Community incubator program](https://github.com/nix-community)
 and it has a grown into an ever-increasing number of packages and modules targeted towards streamlining day-to-day operations across a variety of different projects.
-
-::cards::
-- title: Aldo Borrero
-  content: |
-    Creator of Ethereum.nix
-    <br/>
-    <br/>
-    Full Stack freak! Blockchain passionate!
-  image: https://avatars.githubusercontent.com/u/82811?v=4
-  url: https://github.com/aldoborrero
-- title: Brian McGee
-  content: |
-    Maintainer of Ethereum.nix
-    <br/>
-    <br/>
-    Writer of software • Lover of craft beer
-  image: https://avatars.githubusercontent.com/u/1173648?v=4
-  url: https://github.com/brianmcgee
-- title: Sergey Yakovlev
-  content: |
-    Maintainer of Ethereum.nix
-    <br/>
-    <br/>
-    Love Nix, Rust, Ethereum | SRE
-  image: https://avatars.githubusercontent.com/u/2993917?v=4
-  url: https://github.com/selfuryon
-::/cards::
 
 ## Commercial Support?
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,4 +1,4 @@
-Copyright (c) 2022-2023 Ethereum.nix contributors
+Copyright (c) 2022-2025 Ethereum.nix contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/mkdocs.nix
+++ b/mkdocs.nix
@@ -10,10 +10,10 @@
       mkdocs-custom =
         pkgsUnstable.runCommand "mkdocs-custom" {
           buildInputs = [
-            pkgsUnstable.python311
-            pkgsUnstable.python311Packages.mkdocs
-            pkgsUnstable.python311Packages.mkdocs-material
-            pkgsUnstable.python311Packages.neoteroi-mkdocs
+            pkgsUnstable.python312
+            pkgsUnstable.python312Packages.mkdocs
+            pkgsUnstable.python312Packages.mkdocs-material
+            pkgsUnstable.python312Packages.neoteroi-mkdocs
           ];
           meta.mainProgram = "mkdocs";
         } ''
@@ -23,7 +23,7 @@
           #!${pkgsUnstable.runtimeShell}
           set -euo pipefail
           export PYTHONPATH=$PYTHONPATH
-          exec ${pkgsUnstable.python311Packages.mkdocs}/bin/mkdocs "\$@"
+          exec ${pkgsUnstable.python312Packages.mkdocs}/bin/mkdocs "\$@"
           MKDOCS
 
           chmod +x $out/bin/mkdocs
@@ -31,7 +31,7 @@
       docsPath = "./docs/nixos/modules";
       nixosMarkdownDocs = runCommand "nixos-options" {} ''
         mkdir $out
-        ${lib.createNixosMarkdownDocs {modulesPath = ./modules;}}
+        ${lib.mkdocs.createNixosMarkdownDocs {modulesPath = ./modules;}}
       '';
     in
       stdenv.mkDerivation {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,6 @@ markdown_extensions:
   - attr_list
   - md_in_html
   - neoteroi.spantable
-  - neoteroi.cards
   - toc:
       permalink: true
   - pymdownx.details
@@ -113,4 +112,4 @@ extra:
       name: Ethereum.nix on Github
   generator: false # hide the line "Made with Material for MkDocs"
 
-copyright: Copyright &copy; 2022-2023 Ethereum.nix contributors
+copyright: Copyright &copy; 2022-2025 Ethereum.nix contributors


### PR DESCRIPTION
### Summary of Changes

This PR introduces the following changes:

- Migrates to use python 312 for mkdocs
- Removes neoteroi cards and uses default mkdocs cards
- Updates gh-pages workflow to use ubuntu-latest
- Fixes copyright year