### PR TITLE
fix: update Prysm CI and deprecated testnet references

### DIFF
--- a/modules/prysm-beacon/args.nix
+++ b/modules/prysm-beacon/args.nix
@@ -1,7 +1,7 @@
 lib:
 with lib; {
   network = mkOption {
-    type = types.nullOr (types.enum ["goerli" "holesky" "prater" "ropsten" "sepolia"]);
+    type = types.nullOr (types.enum ["holesky" "hoodi" "sepolia"]);
     default = null;
     description = "The network to connect to. Mainnet (null) is the default ethereum network.";
   };
@@ -17,14 +17,14 @@ with lib; {
     type = types.nullOr types.str;
     default = null;
     description = "URL of a synced beacon node to trust in obtaining checkpoint sync data. As an additional safety measure, it is strongly recommended to only use this option in conjunction with --weak-subjectivity-checkpoint flag";
-    example = "https://goerli.checkpoint-sync.ethpandaops.io";
+    example = "https://checkpoint-sync.sepolia.ethpandaops.io";
   };
 
   genesis-beacon-api-url = mkOption {
     type = types.nullOr types.str;
     default = null;
     description = "URL of a synced beacon node to trust for obtaining genesis state. As an additional safety measure, it is strongly recommended to only use this option in conjunction with --weak-subjectivity-checkpoint flag";
-    example = "https://goerli.checkpoint-sync.ethpandaops.io";
+    example = "https://checkpoint-sync.sepolia.ethpandaops.io";
   };
 
   p2p-udp-port = mkOption {

--- a/modules/prysm-validator/args.nix
+++ b/modules/prysm-validator/args.nix
@@ -1,7 +1,7 @@
 lib:
 with lib; {
   network = mkOption {
-    type = types.nullOr (types.enum ["goerli" "holesky" "prater" "ropsten" "sepolia"]);
+    type = types.nullOr (types.enum ["holesky" "hoodi" "sepolia"]);
     default = null;
     description = "The network to connect to. Mainnet (null) is the default ethereum network.";
   };

--- a/modules/prysm-validator/default.test.nix
+++ b/modules/prysm-validator/default.test.nix
@@ -20,7 +20,7 @@
 
         ${pkgs.prysm}/bin/validator wallet create \
           --accept-terms-of-use \
-          --goerli \
+          --sepolia \
           --keymanager-kind="direct" \
           --mnemonic-25th-word-file /tmp/wallet/mnemonic.txt \
           --skip-mnemonic-25th-word-check true \
@@ -44,7 +44,7 @@
             enable = true;
             args = {
               datadir = "/tmp/prysm-validator";
-              network = "goerli";
+              network = "sepolia";
               rpc = {
                 enable = true;
                 host = "127.0.0.1";


### PR DESCRIPTION
CI will fail with:
```
Incorrect Usage: flag provided but not defined: -goerli
```

Now works with Sepolia flag:
```
[2025-03-25 11:11:11]  INFO flags: Running on the Sepolia Beacon Chain Testnet
[2025-03-25 11:11:11]  INFO accounts: Successfully created wallet with ability to import keystores walletDir=/tmp/wallet
```

Removed references to: goerli, prater, ropsten

Deprecated Testnets and removed CLI flags.

Add reference to "hoodi" Testnet, added in Prysm 5.3.2.

Updated checkpoint URL reference: https://ethpandaops.io/links/

Fix for failing CI in https://github.com/nix-community/ethereum.nix/pull/589
