### PR TITLE
geth: 1.14.13 -> 1.15.9

### DIFF
--- a/pkgs/by-name/ge/geth/default.nix
+++ b/pkgs/by-name/ge/geth/default.nix
@@ -21,17 +21,17 @@
 in
   buildGoModule rec {
     pname = "geth";
-    version = "1.14.13";
+    version = "1.15.9";
 
     src = fetchFromGitHub {
       owner = "ethereum";
       repo = "go-ethereum";
       rev = "v${version}";
-      hash = "sha256-oJe+V11WArXVmoIC7nYN6oKc0VoHtRtelidyb3v6skI=";
+      hash = "sha256-zD4uJJPVHiJ44+pBALQ4tEvYda3S7SIhn0ySyT6BSAQ=";
     };
 
     proxyVendor = true;
-    vendorHash = "sha256-IEwy3XRyj+5GjAWRjPsd5qzwEMpI/pZIwPjKdeATgkE=";
+    vendorHash = "sha256-1FuVdx84jvMBo8VO6q+WaFpK3hWn88J7p8vhIDsQHPM=";
 
     ldflags = ["-s" "-w"];
 
@@ -48,7 +48,6 @@ in
       "cmd/abidump"
       "cmd/abigen"
       "cmd/blsync"
-      "cmd/bootnode"
       "cmd/clef"
       "cmd/devp2p"
       "cmd/era"

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -47,7 +47,7 @@
         # meta.platforms = [system];
         meta.platforms = ["x86_64-linux" "aarch64-linux"];
       });
-      geth = callPackage ./by-name/ge/geth {};
+      geth = callPackageUnstable ./by-name/ge/geth {};
       geth-sealer = callPackage ./by-name/ge/geth-sealer {};
       heimdall = callPackage ./by-name/he/heimdall {};
       lighthouse = callPackageUnstable ./by-name/li/lighthouse {inherit foundry;};


### PR DESCRIPTION
This is the minimum version required for Pectra (May 7th on Ethereum)

https://github.com/ethereum/go-ethereum/releases/tag/v1.15.9