### PR TITLE
mev-boost: 1.8 -> 1.9

### DIFF
--- a/pkgs/by-name/me/mev-boost/default.nix
+++ b/pkgs/by-name/me/mev-boost/default.nix
@@ -6,16 +6,15 @@
 }:
 buildGoModule rec {
   pname = "mev-boost";
-  version = "1.8";
-
+  version = "1.9";
   src = fetchFromGitHub {
     owner = "flashbots";
     repo = "${pname}";
     rev = "v${version}";
-    hash = "sha256-EFPVBSSIef3cTrYp3X1xCEOtYcGpuW/GZXHXX+0wGd8=";
+    hash = "sha256-VBvbiB7M6X+bQ5xEwmJo5dptiR7PIBiFDqkg1fyU8ro=";
   };
 
-  vendorHash = "sha256-xkncfaqNfgPt5LEQ3JyYXHHq6slOUchomzqwkZCgCOM=";
+  vendorHash = "sha256-OyRyMsINy4I04E2QvToOEY7UKh2s6NUeJJO0gJI5uS0=";
 
   buildInputs = [blst];
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -52,7 +52,7 @@
       heimdall = callPackage ./by-name/he/heimdall {};
       lighthouse = callPackageUnstable ./by-name/li/lighthouse {inherit foundry;};
       mcl = callPackage ./by-name/mc/mcl {};
-      mev-boost = callPackage ./by-name/me/mev-boost {inherit blst;};
+      mev-boost = callPackageUnstable ./by-name/me/mev-boost {inherit blst;};
       mev-boost-builder = callPackage ./by-name/me/mev-boost-builder {inherit blst;};
       mev-boost-relay = callPackage ./by-name/me/mev-boost-relay {inherit blst;};
       mev-rs = callPackage ./by-name/me/mev-rs {};


### PR DESCRIPTION
mev-boost 1.9

Needed to update nixpkgsUnstable to get a more recent version of Go.