### PR TITLE
feat: Enable `aarch64-darwin` support for `foundry`

### DIFF
--- a/pkgs/by-name/fo/foundry/default.nix
+++ b/pkgs/by-name/fo/foundry/default.nix
@@ -70,9 +70,8 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/foundry-rs/foundry";
     license = with licenses; [asl20 mit];
     maintainers = with maintainers; [mitchmindtree];
-    # For now, solc binaries are only built for x86_64.
-    # Track darwin-aarch64 here:
-    # https://github.com/ethereum/solidity/issues/12291
-    platforms = ["x86_64-linux" "x86_64-darwin"];
+    # TODO: Change this to `platforms = platforms.unix;` when this is resolved:
+    # https://github.com/ethereum/solidity/issues/11351
+    platforms = ["aarch64-darwin" "x86_64-linux" "x86_64-darwin"];
   };
 }

--- a/pkgs/by-name/fo/foundry/svm-lists/linux-amd64.json
+++ b/pkgs/by-name/fo/foundry/svm-lists/linux-amd64.json
@@ -923,9 +923,21 @@
       "urls": [
         "dweb:/ipfs/QmUQHJwVw1f8RCRTBReXEkXdpt4c3A3LEpHZWv4pRixrNW"
       ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.29+commit.ab55807c",
+      "version": "0.8.29",
+      "build": "commit.ab55807c",
+      "longVersion": "0.8.29+commit.ab55807c",
+      "keccak256": "0x13779247192b8f063c5e330f918e160c7d7315aa2950e6610f589cb19fc8bb1a",
+      "sha256": "0x18d418a40dc04d17656b1b5c8a7b35cfbab8942b51f38d005d5b59e8aa6637e0",
+      "urls": [
+        "dweb:/ipfs/QmURReQt8G4f8ZnZsJ6qcix1Ch2ga1pyrVW1x65feSwjmk"
+      ]
     }
   ],
   "releases": {
+    "0.8.29": "solc-linux-amd64-v0.8.29+commit.ab55807c",
     "0.8.28": "solc-linux-amd64-v0.8.28+commit.7893614a",
     "0.8.27": "solc-linux-amd64-v0.8.27+commit.40a35a09",
     "0.8.26": "solc-linux-amd64-v0.8.26+commit.8a97fa7a",
@@ -1011,5 +1023,5 @@
     "0.4.11": "solc-linux-amd64-v0.4.11+commit.68ef5810",
     "0.4.10": "solc-linux-amd64-v0.4.10+commit.9e8cc01b"
   },
-  "latestRelease": "0.8.28"
+  "latestRelease": "0.8.29"
 }

--- a/pkgs/by-name/fo/foundry/svm-lists/macosx-amd64.json
+++ b/pkgs/by-name/fo/foundry/svm-lists/macosx-amd64.json
@@ -1044,9 +1044,21 @@
       "urls": [
         "dweb:/ipfs/QmeUvFZkouz4maSCaGSf6pRS2RV7EoSDDSF5FXc1ZEkkvU"
       ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.29+commit.ab55807c",
+      "version": "0.8.29",
+      "build": "commit.ab55807c",
+      "longVersion": "0.8.29+commit.ab55807c",
+      "keccak256": "0xadd2d538b5341813a8c8daee465c280c90de89bdede4281d7a1b777ccf26ac2c",
+      "sha256": "0x66fabdd17c8c0091311997ec7d17b4d92e1b7b2c2d213dc14e4ff28c3de864d1",
+      "urls": [
+        "dweb:/ipfs/QmSfHSP1r24jeMPaANiiV2LLVxC2tS2jPtVkJ7V5UET8aL"
+      ]
     }
   ],
   "releases": {
+    "0.8.29": "solc-macosx-amd64-v0.8.29+commit.ab55807c",
     "0.8.28": "solc-macosx-amd64-v0.8.28+commit.7893614a",
     "0.8.27": "solc-macosx-amd64-v0.8.27+commit.40a35a09",
     "0.8.26": "solc-macosx-amd64-v0.8.26+commit.8a97fa7a",
@@ -1143,5 +1155,5 @@
     "0.4.0": "solc-macosx-amd64-v0.4.0+commit.acd334c9",
     "0.3.6": "solc-macosx-amd64-v0.3.6+commit.988fe5e5"
   },
-  "latestRelease": "0.8.28"
+  "latestRelease": "0.8.29"
 }


### PR DESCRIPTION
Originally this was disabled as solc were not providing builds for `aarch64-darwin`, however since version 0.8.24 they have switched to building "universal" binaries for macos. See this issue for context:

- https://github.com/ethereum/solidity/issues/12291

Unfortunately there are no ARM builds for linux just yet, so we still need to manually specify the supported architectures rather than using `platforms.unix`.

Ideally we'd have our own derivations for all the solc versions and just build them for every platform we want to support ourselves, but this likely wouldn't play nicely with tools like foundry that implicitly try to download the static binaries when the user tries to run forge commands.

This PR also runs the `update-svm-lists.sh` script to enable support for solc `0.8.29`.