### PR TITLE
feat: Enable `aarch64-darwin`, `aarch64-linux` support for `reth`

### DIFF
--- a/pkgs/by-name/re/reth/default.nix
+++ b/pkgs/by-name/re/reth/default.nix
@@ -39,6 +39,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/paradigmxyz/reth";
     license = with licenses; [mit asl20];
     mainProgram = "reth";
-    platforms = ["aarch64-linux" "x86_64-linux"];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
`reth` has supported building for ARM platforms since [at least 1.1.4](https://github.com/paradigmxyz/reth/releases/tag/v1.1.4), which precedes the current version we have pinned (1.2.0).