### PR TITLE
Updated prysm and geth to versions that support pectra mainnet

### DIFF
--- a/pkgs/by-name/ge/geth/default.nix
+++ b/pkgs/by-name/ge/geth/default.nix
@@ -21,17 +21,17 @@
 in
   buildGoModule rec {
     pname = "geth";
-    version = "1.15.9";
+    version = "1.15.11";
 
     src = fetchFromGitHub {
       owner = "ethereum";
       repo = "go-ethereum";
       rev = "v${version}";
-      hash = "sha256-zD4uJJPVHiJ44+pBALQ4tEvYda3S7SIhn0ySyT6BSAQ=";
+      hash = "sha256-2XGKkimwe9h8RxO3SzUta5Bh2Ooldl2LiHqUpn8FK7I=";
     };
 
     proxyVendor = true;
-    vendorHash = "sha256-1FuVdx84jvMBo8VO6q+WaFpK3hWn88J7p8vhIDsQHPM=";
+    vendorHash = "sha256-R9Qg6estiyjMAwN6tvuN9ZuE7+JqjEy+qYOPAg5lIJY=";
 
     ldflags = ["-s" "-w"];
 

--- a/pkgs/by-name/pr/prysm/default.nix
+++ b/pkgs/by-name/pr/prysm/default.nix
@@ -1,23 +1,23 @@
 {
   bls,
   blst,
-  buildGo123Module,
+  buildGo124Module,
   fetchFromGitHub,
   libelf,
   nix-update-script,
 }:
-buildGo123Module rec {
+buildGo124Module rec {
   pname = "prysm";
-  version = "5.3.0";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "prysmaticlabs";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-bTA7KOfhdsVIQk6d9pnBAYmmuzj3KQnvMO/OrEpx5uA=";
+    hash = "sha256-H16YiHZa/flGXRretA+HqJZjPwDe8nFp770eMueM0e0=";
   };
 
-  vendorHash = "sha256-1PAeAI6yaXSE881Bsp2hhPSctePc5CwWYkk8QVounAA=";
+  vendorHash = "sha256-oKT0pmV6Gt57ZeiIcu73QblBJ3uimEsuSTbAbC2W6jc=";
 
   buildInputs = [bls blst libelf];
 


### PR DESCRIPTION
prysm 5.3.0 -> 6.0.1
geth 1.15.9 -> 1.15.11

Updates for the Pectra mainnet changes.

Sorry if this isn't the correct way of moving this forward.

The build is failing due to the following error with prysm:
```
Building subPackage ./cmd/beacon-chain
# github.com/ethereum/c-kzg-4844/v2/bindings/go
vendor/github.com/ethereum/c-kzg-4844/v2/bindings/go/main.go:5:11: fatal error: ckzg.c: No such file or directory
    5 | // #include "ckzg.c"
```

I'm able to build from the prysm repo separately using `go build -v ./...` although I lack the familiarity with go to differentiate this from how the nix build works.
