### PR TITLE
erigon: 2.61.3 -> 3.0.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,6 +131,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1731603435,
+        "narHash": "sha256-CqCX4JG7UiHvkrBTpYC3wcEurvbtTADLbo3Ns2CEoL8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1742738698,
@@ -156,6 +172,7 @@
         "foundry-nix": "foundry-nix",
         "nixpkgs": "nixpkgs",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     # packages
     nixpkgs.url = "github:nixos/nixpkgs/24.05";
     nixpkgs-2311.url = "github:nixos/nixpkgs/23.11";
+    nixpkgs-2411.url = "github:nixos/nixpkgs/24.11";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     foundry-nix = {
@@ -83,6 +84,10 @@
           pkgs2311 = lib.mkNixpkgs {
             inherit system;
             nixpkgs = inputs.nixpkgs-2311;
+          };
+          pkgs2411 = lib.mkNixpkgs {
+            inherit system;
+            nixpkgs = inputs.nixpkgs-2411;
           };
         };
 

--- a/pkgs/by-name/er/erigon/default.nix
+++ b/pkgs/by-name/er/erigon/default.nix
@@ -6,17 +6,17 @@
 }:
 buildGoModule rec {
   pname = "erigon";
-  version = "2.61.3";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "erigontech";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-VGLuPaGYx/DQc3Oc9wAbELXAtkuxr8cbePVBExlZikk=";
+    hash = "sha256-gSgkdg7677OBOkAbsEjxX1QttuIbfve2A3luUZoZ5Ik=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-1LB2T0o9LjFdpl86NPMKx1lFLrQZefAGldcSQyL6O7M=";
+  vendorHash = "sha256-8eyC3JkRcRlFw8CyTK5w1XySur2jAeFGXkEaY/3Oq0k=";
   proxyVendor = true;
 
   # Silkworm's .so fails to find libgmp when linking

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -17,6 +17,7 @@
     pkgs,
     pkgsUnstable,
     pkgs2311,
+    pkgs2411,
     system,
     ...
   }: let
@@ -24,6 +25,7 @@
     inherit (lib) platformPkgs platformApps;
     callPackageUnstable = pkgsUnstable.callPackage;
     callPackage2311 = pkgs2311.callPackage;
+    callPackage2411 = pkgs2411.callPackage;
   in {
     packages = platformPkgs system rec {
       besu = callPackageUnstable ./by-name/be/besu {};
@@ -34,7 +36,7 @@
       dirk = callPackage ./by-name/di/dirk {inherit bls mcl;};
       dreamboat = callPackage ./by-name/dr/dreamboat {inherit blst;};
       eigenlayer = callPackage ./by-name/ei/eigenlayer {};
-      erigon = callPackage ./by-name/er/erigon {};
+      erigon = callPackage2411 ./by-name/er/erigon {};
       eth2-testnet-genesis = callPackage ./by-name/et/eth2-testnet-genesis {inherit bls;};
       eth2-val-tools = callPackage ./by-name/et/eth2-val-tools {inherit bls mcl;};
       eth-validator-watcher = callPackage2311 ./by-name/et/eth-validator-watcher {};


### PR DESCRIPTION
Not sure why we didn't already have a 24.11 nixpkgs input, we have old stable ones and unstable. I added the latest stable version and, in the future, I think a lot of packages could migrate to using the same nixpkgs 24.11 stuff that erigon needed & maybe we can remove some of the older nixpkgs. But that's not the focus of this PR.

The [erigon blog](https://erigon.tech/releasing-erigon-v3-0-0/) says this upgrade is required for Pectra. But beware: requires a complete resync if upgrading from the 2.x.x series