### PR TITLE
ethstaker-deposit-cli: init at 1.2.2

### DIFF
--- a/pkgs/by-name/et/ethstaker-deposit-cli/default.nix
+++ b/pkgs/by-name/et/ethstaker-deposit-cli/default.nix
@@ -1,0 +1,38 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  nix-update-script,
+  stdenv,
+  zlib,
+}:
+stdenv.mkDerivation rec {
+  pname = "ethstaker-deposit-cli";
+  version = "1.2.2";
+
+  src = fetchurl {
+    url = "https://github.com/ethstaker/ethstaker-deposit-cli/releases/download/v${version}/ethstaker_deposit-cli-b13dcb9-linux-amd64.tar.gz";
+    hash = "sha256-BK8/T9L9zPSuBgq95HY3YioxEU2fLlPmJyKmlKTVsgY=";
+  };
+
+  nativeBuildInputs = [autoPatchelfHook];
+
+  buildInputs = [zlib];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mv ./deposit $out/bin/deposit
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {};
+
+  meta = {
+    description = "Secure key generation for deposits";
+    homepage = "https://github.com/ethereum/staking-deposit-cli";
+    mainProgram = "deposit";
+    platforms = ["x86_64-linux"];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -37,6 +37,7 @@
       erigon = callPackage ./by-name/er/erigon {};
       eth2-testnet-genesis = callPackage ./by-name/et/eth2-testnet-genesis {inherit bls;};
       eth2-val-tools = callPackage ./by-name/et/eth2-val-tools {inherit bls mcl;};
+      ethstaker-deposit-cli = callPackage ./by-name/et/ethstaker-deposit-cli {};
       eth-validator-watcher = callPackage2311 ./by-name/et/eth-validator-watcher {};
       ethdo = callPackage ./by-name/et/ethdo {inherit bls mcl;};
       ethereal = callPackage ./by-name/et/ethereal {};


### PR DESCRIPTION
This is a fork of the EF's deposit-cli that also supports Gnosis chains