### PR TITLE
Add user option in geth nixos module.

### DIFF
--- a/modules/geth/default.nix
+++ b/modules/geth/default.nix
@@ -19,6 +19,7 @@
     flatten
     mapAttrs'
     mapAttrsToList
+    mkDefault
     mkIf
     mkMerge
     nameValuePair
@@ -121,9 +122,9 @@ in {
               serviceConfig = mkMerge [
                 baseServiceConfig
                 {
-                  User = serviceName;
-                  StateDirectory = serviceName;
-                  ExecStart = "${cfg.package}/bin/geth ${scriptArgs}";
+                  User = mkDefault serviceName;
+                  StateDirectory = mkDefault serviceName;
+                  ExecStart = mkDefault "${cfg.package}/bin/geth ${scriptArgs}";
                 }
                 (mkIf (cfg.args.authrpc.jwtsecret != null) {
                   LoadCredential = ["jwtsecret:${cfg.args.authrpc.jwtsecret}"];

--- a/modules/geth/default.nix
+++ b/modules/geth/default.nix
@@ -20,6 +20,7 @@
     mapAttrs'
     mapAttrsToList
     mkDefault
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -131,6 +132,14 @@ in {
                 }
                 (mkIf (cfg.args.authrpc.jwtsecret != null) {
                   LoadCredential = ["jwtsecret:${cfg.args.authrpc.jwtsecret}"];
+                })
+                (mkIf (cfg.user != null) {
+                  DynamicUser = mkForce false;
+                  RemoveIPC = mkDefault true;
+                  PrivateTmp = mkDefault true;
+                  NoNewPrivileges = mkDefault "strict";
+                  RestrictSUIDSGID = mkDefault true;
+                  ProtectSystem = mkDefault true;
                 })
               ];
             })

--- a/modules/geth/default.nix
+++ b/modules/geth/default.nix
@@ -122,7 +122,10 @@ in {
               serviceConfig = mkMerge [
                 baseServiceConfig
                 {
-                  User = mkDefault serviceName;
+                  User =
+                    if cfg.user != null
+                    then cfg.user
+                    else mkDefault serviceName;
                   StateDirectory = mkDefault serviceName;
                   ExecStart = mkDefault "${cfg.package}/bin/geth ${scriptArgs}";
                 }

--- a/modules/geth/default.nix
+++ b/modules/geth/default.nix
@@ -133,7 +133,7 @@ in {
                 (mkIf (cfg.args.authrpc.jwtsecret != null) {
                   LoadCredential = ["jwtsecret:${cfg.args.authrpc.jwtsecret}"];
                 })
-                (mkIf (cfg.user != null) {
+                (mkIf (!cfg.dynamicUser) {
                   DynamicUser = mkForce false;
                   RemoveIPC = mkDefault true;
                   PrivateTmp = mkDefault true;

--- a/modules/geth/options.nix
+++ b/modules/geth/options.nix
@@ -9,6 +9,12 @@
     options = rec {
       enable = mkEnableOption "Go Ethereum Node";
 
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the service as.";
+      };
+
       inherit args;
 
       extraArgs = mkOption {

--- a/modules/geth/options.nix
+++ b/modules/geth/options.nix
@@ -9,13 +9,19 @@
     options = rec {
       enable = mkEnableOption "Go Ethereum Node";
 
+      inherit args;
+
+      dynamicUser = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to use systemd's DynamicUser feature.";
+      };
+
       user = mkOption {
         type = types.nullOr types.str;
         default = null;
         description = "User to run the service as.";
       };
-
-      inherit args;
 
       extraArgs = mkOption {
         type = types.listOf types.str;


### PR DESCRIPTION
I wanted to manage the user that runs the geth service directly instead of relying on DynamicUser in the systemd config. The existing geth config didn't really allow this, but adding mkDefault to User let me override it in my own config. While I was there, I thought maybe it would be useful to be able to change StateDirectory and ExecStart too, so I went ahead and wrapped those with mkDefault too - but I'm not really sure ExecStart needs it. Looking for a second opinion there.

FWIW, I wrote a little `ethOverride` function to change the user and add (most of) the settings that DynamicUser covers, which looks like this:

```
ethOverride = user: {
  DynamicUser = mkForce false;
  RemoveIPC = true;
  PrivateTmp = true;
  NoNewPrivileges = "strict";
  RestrictSUIDSGID = true;
  ProtectSystem = true;
  User = mkForce user;
};
```

Then I call the function like `systemd.services.<service-name>.serviceConfig = ethOverride myuser`.