### PR TITLE
ethstaker-deposit-cli: Init at 1.2.2

### DIFF
--- a/pkgs/by-name/et/ethstaker-deposit-cli/default.nix
+++ b/pkgs/by-name/et/ethstaker-deposit-cli/default.nix
@@ -1,0 +1,38 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  nix-update-script,
+  stdenv,
+  zlib,
+}:
+stdenv.mkDerivation rec {
+  pname = "staking-deposit-cli";
+  version = "1.2.2";
+
+  src = fetchurl {
+    url = "https://github.com/eth-educators/ethstaker-deposit-cli/releases/download/v1.2.2/ethstaker_deposit-cli-b13dcb9-linux-amd64.tar.gz";
+    hash = "sha256-BK8/T9L9zPSuBgq95HY3YioxEU2fLlPmJyKmlKTVsgY=";
+  };
+
+  nativeBuildInputs = [autoPatchelfHook];
+
+  buildInputs = [zlib];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mv ./deposit $out/bin/deposit
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {};
+
+  meta = {
+    description = "Secure key generation for deposits (ethstaker fork)";
+    homepage = "https://github.com/ethstaker/ethstaker-deposit-cli/";
+    mainProgram = "deposit";
+    platforms = ["x86_64-linux"];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -40,6 +40,7 @@
       eth-validator-watcher = callPackage2311 ./by-name/et/eth-validator-watcher {};
       ethdo = callPackage ./by-name/et/ethdo {inherit bls mcl;};
       ethereal = callPackage ./by-name/et/ethereal {};
+      ethstaker-deposit-cli = callPackage ./by-name/et/ethstaker-deposit-cli {};
       evmc = callPackage ./by-name/ev/evmc {};
       foundry = callPackageUnstable ./by-name/fo/foundry {};
       foundry-bin = inputs.foundry-nix.defaultPackage.${system}.overrideAttrs (_oldAttrs: {


### PR DESCRIPTION
Has support for Hoodi testnet and a few other features that the official tool is lacking.