### PR TITLE
geth: : 1.16.1 -> 1.16.2

### DIFF
--- a/pkgs/by-name/ge/geth/default.nix
+++ b/pkgs/by-name/ge/geth/default.nix
@@ -1,10 +1,9 @@
-{ buildGoModule
-, fetchFromGitHub
-, lib
-, nix-update-script
-,
-}:
-let
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}: let
   # A list of binaries to put into separate outputs
   bins = [
     "abidump"
@@ -20,55 +19,55 @@ let
     "rlpdump"
   ];
 in
-buildGoModule rec {
-  pname = "geth";
-  version = "1.16.2";
+  buildGoModule rec {
+    pname = "geth";
+    version = "1.16.2";
 
-  src = fetchFromGitHub {
-    owner = "ethereum";
-    repo = "go-ethereum";
-    rev = "v${version}";
-    hash = "sha256-12bmK9OYYIDBeN52dQElnDaOcWOzwvjpAZmzHH8IHvw=";
-  };
+    src = fetchFromGitHub {
+      owner = "ethereum";
+      repo = "go-ethereum";
+      rev = "v${version}";
+      hash = "sha256-12bmK9OYYIDBeN52dQElnDaOcWOzwvjpAZmzHH8IHvw=";
+    };
 
-  proxyVendor = true;
-  vendorHash = "sha256-i1PhF1DFdt2X4faxe5+iYsPIyco0Xb6stOzaCy6JIto=";
+    proxyVendor = true;
+    vendorHash = "sha256-i1PhF1DFdt2X4faxe5+iYsPIyco0Xb6stOzaCy6JIto=";
 
-  ldflags = [ "-s" "-w" ];
+    ldflags = ["-s" "-w"];
 
-  doCheck = false;
+    doCheck = false;
 
-  # Move binaries to separate outputs and symlink them back to $out
-  postInstall = lib.concatStringsSep "\n" (
-    builtins.map (bin: "mkdir -p \$${bin}/bin && mv $out/bin/${bin} \$${bin}/bin/ && ln -s \$${bin}/bin/${bin} $out/bin/") bins
-  );
+    # Move binaries to separate outputs and symlink them back to $out
+    postInstall = lib.concatStringsSep "\n" (
+      builtins.map (bin: "mkdir -p \$${bin}/bin && mv $out/bin/${bin} \$${bin}/bin/ && ln -s \$${bin}/bin/${bin} $out/bin/") bins
+    );
 
-  outputs = [ "out" ] ++ bins;
+    outputs = ["out"] ++ bins;
 
-  subPackages = [
-    "cmd/abidump"
-    "cmd/abigen"
-    "cmd/blsync"
-    "cmd/clef"
-    "cmd/devp2p"
-    "cmd/era"
-    "cmd/ethkey"
-    "cmd/evm"
-    "cmd/geth"
-    "cmd/rlpdump"
-    "cmd/utils"
-  ];
+    subPackages = [
+      "cmd/abidump"
+      "cmd/abigen"
+      "cmd/blsync"
+      "cmd/clef"
+      "cmd/devp2p"
+      "cmd/era"
+      "cmd/ethkey"
+      "cmd/evm"
+      "cmd/geth"
+      "cmd/rlpdump"
+      "cmd/utils"
+    ];
 
-  # Following upstream: https://github.com/ethereum/go-ethereum/blob/v1.10.23/build/ci.go#L218
-  tags = [ "urfave_cli_no_docs" ];
+    # Following upstream: https://github.com/ethereum/go-ethereum/blob/v1.10.23/build/ci.go#L218
+    tags = ["urfave_cli_no_docs"];
 
-  passthru.updateScript = nix-update-script { };
+    passthru.updateScript = nix-update-script {};
 
-  meta = with lib; {
-    description = "Official golang implementation of the Ethereum protocol";
-    homepage = "https://geth.ethereum.org/";
-    license = with licenses; [ lgpl3Plus gpl3Plus ];
-    mainProgram = "geth";
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
-  };
-}
+    meta = with lib; {
+      description = "Official golang implementation of the Ethereum protocol";
+      homepage = "https://geth.ethereum.org/";
+      license = with licenses; [lgpl3Plus gpl3Plus];
+      mainProgram = "geth";
+      platforms = ["x86_64-linux" "aarch64-linux"];
+    };
+  }

--- a/pkgs/by-name/ge/geth/default.nix
+++ b/pkgs/by-name/ge/geth/default.nix
@@ -1,9 +1,10 @@
-{
-  buildGoModule,
-  fetchFromGitHub,
-  lib,
-  nix-update-script,
-}: let
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, nix-update-script
+,
+}:
+let
   # A list of binaries to put into separate outputs
   bins = [
     "abidump"
@@ -19,55 +20,55 @@
     "rlpdump"
   ];
 in
-  buildGoModule rec {
-    pname = "geth";
-    version = "1.16.1";
+buildGoModule rec {
+  pname = "geth";
+  version = "1.16.2";
 
-    src = fetchFromGitHub {
-      owner = "ethereum";
-      repo = "go-ethereum";
-      rev = "v${version}";
-      hash = "sha256-lsjs/bZhCwfp8OfTES1GDXayjDcg0R8+L0Z3pZ9/Mvs=";
-    };
+  src = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "go-ethereum";
+    rev = "v${version}";
+    hash = "sha256-lsjs/bZhCwfp8OfTES1GDXayjDcg0R8+L0Z3pZ9/Mvs=";
+  };
 
-    proxyVendor = true;
-    vendorHash = "sha256-Ggng6EDd5qRqcSbdycfivO8yiQcMOCSZt229JZcOlVs=";
+  proxyVendor = true;
+  vendorHash = "sha256-Ggng6EDd5qRqcSbdycfivO8yiQcMOCSZt229JZcOlVs=";
 
-    ldflags = ["-s" "-w"];
+  ldflags = [ "-s" "-w" ];
 
-    doCheck = false;
+  doCheck = false;
 
-    # Move binaries to separate outputs and symlink them back to $out
-    postInstall = lib.concatStringsSep "\n" (
-      builtins.map (bin: "mkdir -p \$${bin}/bin && mv $out/bin/${bin} \$${bin}/bin/ && ln -s \$${bin}/bin/${bin} $out/bin/") bins
-    );
+  # Move binaries to separate outputs and symlink them back to $out
+  postInstall = lib.concatStringsSep "\n" (
+    builtins.map (bin: "mkdir -p \$${bin}/bin && mv $out/bin/${bin} \$${bin}/bin/ && ln -s \$${bin}/bin/${bin} $out/bin/") bins
+  );
 
-    outputs = ["out"] ++ bins;
+  outputs = [ "out" ] ++ bins;
 
-    subPackages = [
-      "cmd/abidump"
-      "cmd/abigen"
-      "cmd/blsync"
-      "cmd/clef"
-      "cmd/devp2p"
-      "cmd/era"
-      "cmd/ethkey"
-      "cmd/evm"
-      "cmd/geth"
-      "cmd/rlpdump"
-      "cmd/utils"
-    ];
+  subPackages = [
+    "cmd/abidump"
+    "cmd/abigen"
+    "cmd/blsync"
+    "cmd/clef"
+    "cmd/devp2p"
+    "cmd/era"
+    "cmd/ethkey"
+    "cmd/evm"
+    "cmd/geth"
+    "cmd/rlpdump"
+    "cmd/utils"
+  ];
 
-    # Following upstream: https://github.com/ethereum/go-ethereum/blob/v1.10.23/build/ci.go#L218
-    tags = ["urfave_cli_no_docs"];
+  # Following upstream: https://github.com/ethereum/go-ethereum/blob/v1.10.23/build/ci.go#L218
+  tags = [ "urfave_cli_no_docs" ];
 
-    passthru.updateScript = nix-update-script {};
+  passthru.updateScript = nix-update-script { };
 
-    meta = with lib; {
-      description = "Official golang implementation of the Ethereum protocol";
-      homepage = "https://geth.ethereum.org/";
-      license = with licenses; [lgpl3Plus gpl3Plus];
-      mainProgram = "geth";
-      platforms = ["x86_64-linux" "aarch64-linux"];
-    };
-  }
+  meta = with lib; {
+    description = "Official golang implementation of the Ethereum protocol";
+    homepage = "https://geth.ethereum.org/";
+    license = with licenses; [ lgpl3Plus gpl3Plus ];
+    mainProgram = "geth";
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}

--- a/pkgs/by-name/ge/geth/default.nix
+++ b/pkgs/by-name/ge/geth/default.nix
@@ -28,11 +28,11 @@ buildGoModule rec {
     owner = "ethereum";
     repo = "go-ethereum";
     rev = "v${version}";
-    hash = "sha256-lsjs/bZhCwfp8OfTES1GDXayjDcg0R8+L0Z3pZ9/Mvs=";
+    hash = "sha256-12bmK9OYYIDBeN52dQElnDaOcWOzwvjpAZmzHH8IHvw=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-Ggng6EDd5qRqcSbdycfivO8yiQcMOCSZt229JZcOlVs=";
+  vendorHash = "sha256-i1PhF1DFdt2X4faxe5+iYsPIyco0Xb6stOzaCy6JIto=";
 
   ldflags = [ "-s" "-w" ];
 


### PR DESCRIPTION
bump go-ethereum to new version ( https://github.com/ethereum/go-ethereum/releases/tag/v1.16.2 )