### PR TITLE
geth: 1.16.1 -> 1.16.2

### DIFF
--- a/pkgs/by-name/ge/geth/default.nix
+++ b/pkgs/by-name/ge/geth/default.nix
@@ -21,17 +21,17 @@
 in
   buildGoModule rec {
     pname = "geth";
-    version = "1.16.1";
+    version = "1.16.2";
 
     src = fetchFromGitHub {
       owner = "ethereum";
       repo = "go-ethereum";
       rev = "v${version}";
-      hash = "sha256-lsjs/bZhCwfp8OfTES1GDXayjDcg0R8+L0Z3pZ9/Mvs=";
+      hash = "sha256-12bmK9OYYIDBeN52dQElnDaOcWOzwvjpAZmzHH8IHvw=";
     };
 
     proxyVendor = true;
-    vendorHash = "sha256-Ggng6EDd5qRqcSbdycfivO8yiQcMOCSZt229JZcOlVs=";
+    vendorHash = "sha256-i1PhF1DFdt2X4faxe5+iYsPIyco0Xb6stOzaCy6JIto=";
 
     ldflags = ["-s" "-w"];
 


### PR DESCRIPTION
bump version of go-ethereum ( https://github.com/ethereum/go-ethereum/releases/tag/v1.16.2 )