### PR TITLE
fix: prevent duplicate --datadir argument in reth module

### DIFF
--- a/modules/reth/default.nix
+++ b/modules/reth/default.nix
@@ -82,6 +82,7 @@ in {
 
               # filter out certain args which need to be treated differently
               specialArgs = [
+                "--datadir"
                 "--authrpc.jwtsecret"
                 "--http.enable"
                 "--metrics.enable"


### PR DESCRIPTION
The reth module was adding `--datadir` twice: once manually in the script and once through filtered args processing. This caused reth to fail with "argument '--datadir' cannot be used multiple times".

Fixed by adding --datadir to specialArgs list to filter it out from automatic processing, since it's already handled manually in the script.

🤖 Generated with [Claude Code](https://claude.ai/code)