### PR TITLE
chore: set up daily flake update with Hercules CI

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,6 +99,29 @@
         "type": "github"
       }
     },
+    "hercules-ci-effects": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755233722,
+        "narHash": "sha256-AavrbMltJKcC2Fx0lfJoZfmy7g87ebXU0ddVenhajLA=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "99e03e72e3f7e13506f80ef9ebaedccb929d84d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1731603435,
@@ -154,6 +177,7 @@
         "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "foundry-nix": "foundry-nix",
+        "hercules-ci-effects": "hercules-ci-effects",
         "nixpkgs": "nixpkgs",
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,13 @@
     flake-utils.url = "github:numtide/flake-utils";
     flake-utils.inputs.systems.follows = "systems";
 
+    # ci
+    hercules-ci-effects = {
+      url = "github:hercules-ci/hercules-ci-effects";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
+    };
+
     # utils
     systems.url = "github:nix-systems/default";
     devshell = {
@@ -56,11 +63,14 @@
     {
       imports = [
         inputs.devshell.flakeModule
+        inputs.hercules-ci-effects.flakeModule
         inputs.treefmt-nix.flakeModule
         ./mkdocs.nix
         ./modules
         ./pkgs
+        ./hercules-ci.nix
       ];
+
       systems = import systems;
       perSystem = {
         config,

--- a/hercules-ci.nix
+++ b/hercules-ci.nix
@@ -1,0 +1,19 @@
+{
+  inputs,
+  lib,
+  ...
+}: {
+  # configuration for the Hercules CI flake update effect
+  # https://flake.parts/options/hercules-ci-effects.html#opt-hercules-ci.flake-update.enable
+  hercules-ci.flake-update = {
+    enable = true;
+    # runs every day at midnight UTC
+    when.hour = 0;
+  };
+
+  # disable the default job since buildbot already builds everything
+  herculesCI.onPush.default.outputs = lib.mkForce {
+    # use hello as a dummy output to get the checkmark
+    inherit (inputs.nixpkgs-unstable.legacyPackages.x86_64-linux) hello;
+  };
+}


### PR DESCRIPTION
There is currently no automation to automatically try to update flake inputs. hercules-ci can do it. I don't think it is able to sign its commits, which could be an issue