### PR TITLE
chore(ethstaker-deposit-cli): change repo url

### DIFF
--- a/pkgs/by-name/ethstaker-deposit-cli/default.nix
+++ b/pkgs/by-name/ethstaker-deposit-cli/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "1.2.2";
 
   src = fetchurl {
-    url = "https://github.com/eth-educators/ethstaker-deposit-cli/releases/download/v1.2.2/ethstaker_deposit-cli-b13dcb9-linux-amd64.tar.gz";
+    url = "https://github.com/ethstaker/ethstaker-deposit-cli/releases/download/v1.2.2/ethstaker_deposit-cli-b13dcb9-linux-amd64.tar.gz";
     hash = "sha256-BK8/T9L9zPSuBgq95HY3YioxEU2fLlPmJyKmlKTVsgY=";
   };
 


### PR DESCRIPTION
There are a new url here which we should I believe: https://github.com/ethstaker/ethstaker-deposit-cli