### PR TITLE
Fix discovery script to only process direct inputs, not transitive de…

### DIFF
--- a/.github/actions/discovery.sh
+++ b/.github/actions/discovery.sh
@@ -74,8 +74,8 @@ else
         fi
       done
     else
-      # Get all inputs
-      inputs=$(echo "$metadata" | jq -r '.locks.nodes | to_entries[] | select(.key != "root") | .key' | sort)
+      # Get only direct inputs (not transitive dependencies)
+      inputs=$(echo "$metadata" | jq -r '.locks.nodes.root.inputs | keys[]' | sort)
 
       for input in $inputs; do
         current_rev=$(echo "$metadata" | jq -r ".locks.nodes.\"$input\".locked.rev // \"unknown\"" | head -c 8)


### PR DESCRIPTION
…pendencies

I noticed when working on a personal project that the update dependencies pipeline from Numtide is slightly inefficient: it also tries to update any implicit transitive dependencies we have in the flake, which is a no-op. In this instance, this only applies to `flake-parts/nixpkgs-lib`. https://github.com/nix-community/ethereum.nix/actions/runs/17720820389/job/50352821630

Granted, it would be more interesting to look at if we had an `APP_ID` set up in for this repository, and granted, it's also a good practice to hoist dependencies up to our flake so we can deduplicate them.