### PR TITLE
nimbus: 25.9.0 -> 25.11.0

### DIFF
--- a/pkgs/by-name/nimbus/default.nix
+++ b/pkgs/by-name/nimbus/default.nix
@@ -4,12 +4,12 @@
   targets ? ["nimbus_beacon_node" "nimbus_validator_client" "gnosis-build" "gnosis-vc-build"],
   stableSystems ? ["x86_64-linux" "aarch64-linux"],
 }: let
-  version = "25.10.0";
+  version = "25.11.0";
   src = fetchFromGitHub {
     owner = "status-im";
     repo = "nimbus-eth2";
     rev = "v${version}";
-    hash = "sha256-/qJL9vM8006PBkB3l585IQ51pSS9+pnvgcl5eTVSuks=";
+    hash = "sha256-pQBU147GMuRamrunOjU7Y+HBh4fyhdv7bw+HqJpe4jU=";
     fetchSubmodules = true;
   };
 in


### PR DESCRIPTION
Needs some first partry Nix code backports:
- https://github.com/status-im/nimbus-eth2/pull/7687
- https://github.com/status-im/nimbus-eth2/pull/7585