### PR TITLE
fix: Use correct nimbus validator client binary for gnosis networks

### DIFF
--- a/modules/nimbus-validator/default.nix
+++ b/modules/nimbus-validator/default.nix
@@ -29,7 +29,13 @@ in {
         nimbusValidatorName: let
           serviceName = "nimbus-validator-${nimbusValidatorName}";
         in
-          cfg:
+          cfg: let
+            bin = let
+              bins.gnosis = "nimbus_validator_client_gnosis";
+              bins.chiado = "nimbus_validator_client_gnosis";
+            in
+              bins.${cfg.network} or "nimbus_validator_client";
+          in
             nameValuePair serviceName (mkIf cfg.enable {
               after = ["network.target"];
               wantedBy = ["multi-user.target"];
@@ -44,7 +50,7 @@ in {
                     then cfg.user
                     else serviceName;
                   StateDirectory = serviceName;
-                  ExecStart = "${cfg.package}/bin/nimbus_validator_client ${lib.escapeShellArgs cfg.extraArgs}";
+                  ExecStart = "${cfg.package}/bin/${bin} ${lib.escapeShellArgs cfg.extraArgs}";
                   MemoryDenyWriteExecute = "false";
                 }
               ];

--- a/modules/nimbus-validator/options.nix
+++ b/modules/nimbus-validator/options.nix
@@ -24,6 +24,12 @@
         type = types.nullOr types.str;
         description = "Service user";
       };
+
+      network = mkOption {
+        type = types.enum ["mainnet" "prater" "sepolia" "holesky" "gnosis" "chiado" "hoodi"];
+        default = "mainnet";
+        description = "The Eth2 network to join";
+      };
     };
   };
 in {


### PR DESCRIPTION
The nimbus validator client was missing the binary selection logic already present in the nimbus beacon module. This PR simply ports the same logic into the validator module