### PR TITLE
erigon: fix module

### DIFF
--- a/pkgs/by-name/erigon/default.nix
+++ b/pkgs/by-name/erigon/default.nix
@@ -6,13 +6,13 @@
 }:
 buildGoModule rec {
   pname = "erigon";
-  version = "3.2.2-gno";
+  version = "3.2.2";
 
   src = fetchFromGitHub {
     owner = "erigontech";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-0dHdGgsIYke0s2DNj7jjhj2JXqqFucd7hilCtzsjhb0=";
+    hash = "sha256-RMid7yfCP3RsiGTbD/+cT9HinEd2+tjlav/70YNRGu0=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Recently, Gnosis Chain underwent a soft-fork to freeze the Balancer exploiter's funds.

https://forum.gnosis.io/t/balancer-hack-update/11759

Erigon `3.2.2-gno` contains code to enforce such a fork. The functionality is not gated based on the current chain configuration, and as a result, it will also apply to chains such as Mainnet and Chiado, where the canonical chain already contains offending transactions. This causes the node to fail to sync.

https://github.com/erigontech/erigon/issues/17918
https://github.com/erigontech/erigon/issues/17955

~~This is a simple, dirty fix which is to disable to functionality on all chains except Gnosis.~~

Alternatively, we could roll back to `3.2.2`. Note that the `3.2.2-gno` release appears to have been yanked.

I am currently testing this configuration on my nodes.