### PR TITLE
Use portable blst

### DIFF
--- a/pkgs/by-name/erigon/default.nix
+++ b/pkgs/by-name/erigon/default.nix
@@ -26,6 +26,11 @@ buildGoModule rec {
   #   cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
   hardeningDisable = ["format"];
 
+  # Fix error: 'Caught SIGILL in blst_cgo_init'
+  # https://github.com/bnb-chain/bsc/issues/1521
+  CGO_CFLAGS = "-O -D__BLST_PORTABLE__";
+  CGO_CFLAGS_ALLOW = "-O -D__BLST_PORTABLE__";
+
   ldflags = ["-extldflags \"-Wl,--allow-multiple-definition\""];
   inherit subPackages;
 


### PR DESCRIPTION
I've added the D__BLST_PORTABLE__ flag, just as in the main nixpkgs version.

Without the D__BLST_PORTABLE__ flag, the application will SIGILL on some older systems. It's clearly not the ideal solution but without knowing whether the build system or target system supports ADX, this seems like the safest way to proceed for now.

From [blst rust docs](https://docs.rs/crate/blst/0.3.16):
> If the target application crashes with an "illegal instruction" exception [after copying to an older system], activate portable feature when building blst. Conversely, if you compile on an older Intel system, but will execute the binary on a newer one, consider instead activating force-adx feature. Though keep in mind that [cc](https://crates.io/crates/cc) passes the value of CFLAGS environment variable to the C compiler, and if set to contain specific flags, it can interfere with feature selection. -D__BLST_PORTABLE__ and -D__ADX__ are the said features' equivalents.