### PR TITLE
Extend start timeout so checkpoint sync can complete (nimbus)

### DIFF
--- a/modules/nimbus-beacon/default.nix
+++ b/modules/nimbus-beacon/default.nix
@@ -187,6 +187,7 @@ in {
                     then cfg.args.user
                     else user;
                   StateDirectory = user;
+                  TimeoutStartSec = "5min"; # Checkpoint download may take longer than the usual 90s default
                   ExecStartPre = lib.mkBefore [
                     ''                      ${pkgs.coreutils-full}/bin/cp --no-preserve=all --update=none \
                       /proc/sys/kernel/random/uuid ${data-dir}/${cfg.args.keymanager.token-file}''


### PR DESCRIPTION
The checkpoint sync in Nimbus runs as an ExecStartPre command. This is subject to the default unit timeout which is usually 90 seconds, although it may be set to more or less than that. I find it takes about 2 minutes to complete which means the checkpoint sync is aborted. Therefore I propose specifying a longer timeout in the unit.

Of course, YMMV depending on bandwidth etc but it seemed reasonable to go for 5 minutes.