### PR TITLE
nimbus: don't restart in case of doppelganger

### DIFF
--- a/modules/nimbus-beacon/default.nix
+++ b/modules/nimbus-beacon/default.nix
@@ -194,6 +194,10 @@ in {
                     "${cfg.package}/bin/${bin} trustedNodeSync ${checkpointSyncArgs}"
                   ];
                   ExecStart = "${cfg.package}/bin/${bin} ${scriptArgs}";
+
+                  # Used by doppelganger detection to signal we should NOT restart.
+                  # https://nimbus.guide/doppelganger-detection.html
+                  RestartPreventExitStatus = 129;
                 }
                 baseServiceConfig
                 (mkIf (cfg.args.jwt-secret != null) {

--- a/modules/nimbus-validator/default.nix
+++ b/modules/nimbus-validator/default.nix
@@ -52,6 +52,10 @@ in {
                   StateDirectory = serviceName;
                   ExecStart = "${cfg.package}/bin/${bin} ${lib.escapeShellArgs cfg.extraArgs}";
                   MemoryDenyWriteExecute = "false";
+
+                  # Used by doppelganger detection to signal we should NOT restart.
+                  # https://nimbus.guide/doppelganger-detection.html
+                  RestartPreventExitStatus = 129;
                 }
               ];
             })


### PR DESCRIPTION
if doppelganger detection is triggered we really shouldn't auto-restart. Of course it's still not ideal but better