### PR TITLE
reth: add VERGEN_GIT_SHA

### DIFF
--- a/packages/reth/package.nix
+++ b/packages/reth/package.nix
@@ -13,8 +13,16 @@ rustPlatform.buildRustPackage rec {
     owner = "paradigmxyz";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-CtbM7z7NBU81GB48458CeRqWt97nDXTMZK4OcBL2aWc=";
+    hash = "sha256-6iSfrTIZjwoHpX1C2v8u6CvLxUsPr3hKm5MB3+37fyQ=";
+    leaveDotGit = true;
+    postFetch = ''
+      git -C "$out" rev-parse HEAD > "$out/COMMIT"
+      rm -rf "$out/.git"
+    '';
   };
+  preBuild = ''
+    export VERGEN_GIT_SHA=$(cat COMMIT)
+  '';
 
   cargoLock = {
     lockFile = "${src}/Cargo.lock";


### PR DESCRIPTION
Currently, when `reth` is paired with `lighthouse`, the latter complains:

```
{"error":"ApiError(InvalidClientVersion(\"Input must contain only hexadecimal characters\"))","level":"WARN","module":"beacon_chain::graffiti_calculator:227","msg":"Failed to populate engine version cache","ts":"2026-03-23T08:05:59.001760Z"}
{"error":"InvalidClientVersion(\"Input must contain only hexadecimal characters\")","level":"WARN","module":"execution_layer::engines:370","msg":"Execution engine call failed","ts":"2026-03-23T08:05:59.001716Z"}
```

This is fixed by the diffset.

It seems that this is part of the specification hence why the warning.

Some notes: line 19 could also be `find "$out" -name .git -print0 | xargs -0 rm -rf` but I think the current version is cleaner. I'm open to alternative approaches.

Regarding fetcher, we could use the previous one but instead fix it to a revision. Then, `VERGEN_GIT_SHA` could point to `src.hash`.

Any suggestions how we should proceed? I think the underlying problem should be fixed either way.