### PR TITLE
fix erigon module

### DIFF
--- a/modules/nixos/erigon/default.nix
+++ b/modules/nixos/erigon/default.nix
@@ -129,6 +129,7 @@ in
                 "@system-service"
                 "~@privileged"
                 "mincore"
+                "@chown"
               ];
             }
             (mkIf (cfg.args.authrpc.jwtsecret != null) {


### PR DESCRIPTION
erigon 3.5 needs to chown its logs, which the syscall filter does not allow. This only occurs after running for a while and filling the first log file

```
jun 30 22:16:28 triton erigon[84916]: [WARN] [06-30|22:16:28.004] log directory has non-default permissions; group or world access is enabled dir=/var/lib/erigon-hoodi/logs mode=0755
jun 30 22:16:28 triton erigon[84916]: [INFO] [06-30|22:16:28.004] logging to file system                   log dir=/var/lib/erigon-hoodi/logs file prefix=erigon log level=dbug json=false
jun 30 22:16:28 triton systemd[1]: erigon-hoodi.service: Main process exited, code=dumped, status=31/SYS
jun 30 22:16:28 triton systemd[1]: erigon-hoodi.service: Failed with result 'core-dump'.