### PR TITLE
chore: add versionCheckHook to core clients

### DIFF
--- a/packages/erigon/package.nix
+++ b/packages/erigon/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   lib,
   nix-update-script,
+  versionCheckHook,
   subPackages ? [
     "cmd/erigon"
     "cmd/evm"
@@ -39,6 +40,9 @@ buildGoModule rec {
 
   ldflags = [ "-extldflags \"-Wl,--allow-multiple-definition\"" ];
   inherit subPackages;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
     category = "Execution Clients";

--- a/packages/geth/package.nix
+++ b/packages/geth/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   lib,
   nix-update-script,
+  versionCheckHook,
 }:
 let
   # A list of binaries to put into separate outputs
@@ -65,6 +66,9 @@ buildGoModule rec {
 
   # Following upstream: https://github.com/ethereum/go-ethereum/blob/v1.10.23/build/ci.go#L218
   tags = [ "urfave_cli_no_docs" ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
     category = "Execution Clients";

--- a/packages/lighthouse/package.nix
+++ b/packages/lighthouse/package.nix
@@ -12,6 +12,7 @@
   rustPlatform,
   postgresql,
   foundry,
+  versionCheckHook,
 }:
 let
   slasherContractVersion = "0.12.1";
@@ -329,6 +330,9 @@ rustPlatform.buildRustPackage rec {
     "--skip import_validators::tests::import_duplicates_when_allowed"
     "--skip import_validators::tests::import_duplicates_when_allowed_keystore_format"
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.category = "Consensus Clients";
 

--- a/packages/nimbus/package.nix
+++ b/packages/nimbus/package.nix
@@ -7,6 +7,7 @@
   writeScriptBin,
   callPackage,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 let
   version = "26.5.0";
@@ -90,6 +91,9 @@ stdenv.mkDerivation rec {
     rm -f build/generate_makefile
     cp build/* $out/bin
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = with lib; {
     homepage = "https://nimbus.guide/";

--- a/packages/prysm/package.nix
+++ b/packages/prysm/package.nix
@@ -7,6 +7,7 @@
   lib,
   libelf,
   nix-update-script,
+  versionCheckHook,
 }:
 buildGoModule rec {
   pname = "prysm";
@@ -57,6 +58,9 @@ buildGoModule rec {
     "-w"
     "-X github.com/OffchainLabs/prysm/v7/runtime/version.gitTag=v${version}"
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
     category = "Consensus Clients";

--- a/packages/reth/package.nix
+++ b/packages/reth/package.nix
@@ -9,6 +9,7 @@
   nix-update-script,
   perl,
   rustPlatform,
+  versionCheckHook,
   zlib,
 }:
 rustPlatform.buildRustPackage rec {
@@ -76,6 +77,9 @@ rustPlatform.buildRustPackage rec {
     "--skip=dump_genesis_mainnet_valid_json"
     "--skip=dump_genesis_sepolia_valid_json"
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
     category = "Execution Clients";

--- a/packages/teku/default.nix
+++ b/packages/teku/default.nix
@@ -1,1 +1,1 @@
-{ pkgs }: pkgs.callPackage ./package.nix { }
+{ pkgs }: pkgs.callPackage ./package.nix { jre = pkgs.jdk25; }

--- a/packages/teku/package.nix
+++ b/packages/teku/package.nix
@@ -1,10 +1,14 @@
 {
+  coreutils,
   fetchurl,
+  findutils,
+  gnused,
   jre,
   lib,
   makeWrapper,
   nix-update-script,
   stdenv,
+  versionCheckHook,
 }:
 stdenv.mkDerivation rec {
   pname = "teku";
@@ -22,8 +26,21 @@ stdenv.mkDerivation rec {
     cp -r bin $out/
     mkdir -p $out/lib
     cp -r lib $out/
-    wrapProgram $out/bin/${pname} --set JAVA_HOME "${jre}"
+    # The upstream launcher script relies on `uname` (coreutils), `xargs`
+    # (findutils) and `sed` (gnused) being on PATH to assemble the JVM invocation.
+    wrapProgram $out/bin/${pname} \
+      --set JAVA_HOME "${jre}" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          findutils
+          gnused
+        ]
+      }
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
     category = "Consensus Clients";


### PR DESCRIPTION
## Summary

Adds `versionCheckHook` install checks to the core execution and consensus clients so their built binaries are actually exercised (`--version`) during the build. This is cheap coverage that catches broken runtimes before a release ships.

Packages gaining the hook: **geth, reth, erigon, lighthouse, prysm, nimbus, teku**.

- `besu` already has an equivalent `testers.testVersion` check, so it was left as-is.
- `lodestar` is a `buildFHSEnv` wrapper which does not run the standard `installCheck` phase, so it needs a different approach and is out of scope here.

## Bug caught: teku was broken at runtime

Adding the hook to teku immediately surfaced that **teku 26.7.1 does not run at all** as currently packaged:

1. It is compiled for **Java 25**, but the package used the default `jre` (Java 21) → `UnsupportedClassVersionError` (`class file version 69.0` > `65.0`) on startup. Fixed by passing `jre = pkgs.jdk25` (matching `besu`).
2. The upstream gradle launcher script also needs `uname`/`xargs`/`sed` on `PATH`; these are now wrapped in via `coreutils`/`findutils`/`gnused`.

Without a run/version check, both defects were invisible.

## Testing

- `nix build .#geth` — passes with the version check.
- `nix build .#teku` — fails before the fix (both issues above), passes after.
- All 7 packages evaluate cleanly; `nix fmt` applied.
- Remaining clients (reth, erigon, lighthouse, prysm, nimbus) rely on self-contained `--version` output; left to CI to build-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)