### PR TITLE
modules: add user option and disable DynamicUser when set

### DIFF
--- a/modules/nixos/besu/default.nix
+++ b/modules/nixos/besu/default.nix
@@ -15,6 +15,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -111,8 +112,12 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
-              User = serviceName;
+              User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;
               ExecStart = "${cfg.package}/bin/besu ${scriptArgs}";
 

--- a/modules/nixos/besu/options.nix
+++ b/modules/nixos/besu/options.nix
@@ -30,6 +30,12 @@ let
 
       subVolume = mkEnableOption "Use a subvolume for the state directory if the underlying filesystem supports it e.g. btrfs";
 
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           freeformType = types.attrsOf types.anything;

--- a/modules/nixos/erigon/default.nix
+++ b/modules/nixos/erigon/default.nix
@@ -15,6 +15,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -119,8 +120,12 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
-              User = serviceName;
+              User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;
               SupplementaryGroups = cfg.service.supplementaryGroups;
               ExecStart = "${cfg.package}/bin/erigon ${scriptArgs}";

--- a/modules/nixos/erigon/options.nix
+++ b/modules/nixos/erigon/options.nix
@@ -38,6 +38,12 @@ let
         };
       };
 
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           freeformType = types.attrsOf types.anything;

--- a/modules/nixos/geth-bootnode/default.nix
+++ b/modules/nixos/geth-bootnode/default.nix
@@ -15,6 +15,7 @@ let
     flatten
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -96,8 +97,12 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
-              User = serviceName;
+              User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;
               ExecStart = "${cfg.package}/bin/bootnode ${scriptArgs}";
             }

--- a/modules/nixos/geth-bootnode/options.nix
+++ b/modules/nixos/geth-bootnode/options.nix
@@ -28,6 +28,12 @@ let
         description = "Open ports in the firewall for any enabled networking services.";
       };
 
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           freeformType = types.attrsOf types.anything;

--- a/modules/nixos/geth/default.nix
+++ b/modules/nixos/geth/default.nix
@@ -16,6 +16,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -134,8 +135,12 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
-              User = serviceName;
+              User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;
               ExecStart = "${cfg.package}/bin/geth ${scriptArgs}";
             }

--- a/modules/nixos/geth/options.nix
+++ b/modules/nixos/geth/options.nix
@@ -28,6 +28,12 @@ let
         description = "Open ports in the firewall for any enabled networking services.";
       };
 
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           freeformType = types.attrsOf types.anything;

--- a/modules/nixos/helios/default.nix
+++ b/modules/nixos/helios/default.nix
@@ -14,6 +14,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -97,8 +98,12 @@ in
 
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
-              User = serviceName;
+              User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;
               ExecStart = "${cfg.package}/bin/helios ${lib.escapeShellArgs allArgs}";
             }

--- a/modules/nixos/helios/options.nix
+++ b/modules/nixos/helios/options.nix
@@ -37,6 +37,12 @@ let
         '';
       };
 
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           freeformType = types.attrsOf types.anything;

--- a/modules/nixos/lighthouse-beacon/default.nix
+++ b/modules/nixos/lighthouse-beacon/default.nix
@@ -16,6 +16,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -137,6 +138,10 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
               User = if cfg.user != null then cfg.user else user;
               StateDirectory = user;

--- a/modules/nixos/lighthouse-validator/default.nix
+++ b/modules/nixos/lighthouse-validator/default.nix
@@ -15,6 +15,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -113,6 +114,10 @@ in
 
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
               User = if cfg.user != null then cfg.user else user;
               StateDirectory = user;

--- a/modules/nixos/mev-boost/default.nix
+++ b/modules/nixos/mev-boost/default.nix
@@ -10,6 +10,7 @@ let
   inherit (lib)
     nameValuePair
     mapAttrs'
+    mkForce
     mkIf
     mkMerge
     concatStringsSep
@@ -97,8 +98,12 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
-              User = serviceName;
+              User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;
               ExecStart = "${cfg.package}/bin/mev-boost ${scriptArgs}";
             }

--- a/modules/nixos/mev-boost/options.nix
+++ b/modules/nixos/mev-boost/options.nix
@@ -22,6 +22,12 @@ let
         description = "Package to use for mev-boost binary";
       };
 
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           freeformType = types.attrsOf types.anything;

--- a/modules/nixos/nethermind/default.nix
+++ b/modules/nixos/nethermind/default.nix
@@ -16,6 +16,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -134,8 +135,12 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
-              User = serviceName;
+              User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;
               MemoryDenyWriteExecute = false; # setting this option is incompatible with JIT
               ExecStart = "${cfg.package}/bin/nethermind ${scriptArgs}";

--- a/modules/nixos/nethermind/options.nix
+++ b/modules/nixos/nethermind/options.nix
@@ -28,6 +28,12 @@ let
         description = "Open ports in the firewall for any enabled networking services.";
       };
 
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           freeformType = types.attrsOf types.anything;

--- a/modules/nixos/nimbus-beacon/default.nix
+++ b/modules/nixos/nimbus-beacon/default.nix
@@ -15,6 +15,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -127,6 +128,10 @@ in
 
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
               # Nimbus requires JIT compilation
               MemoryDenyWriteExecute = false;

--- a/modules/nixos/nimbus-validator/default.nix
+++ b/modules/nixos/nimbus-validator/default.nix
@@ -15,6 +15,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -111,6 +112,10 @@ in
 
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
               # Nimbus requires JIT compilation
               MemoryDenyWriteExecute = false;

--- a/modules/nixos/prysm-beacon/default.nix
+++ b/modules/nixos/prysm-beacon/default.nix
@@ -15,6 +15,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -129,6 +130,10 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
               User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;

--- a/modules/nixos/prysm-validator/default.nix
+++ b/modules/nixos/prysm-validator/default.nix
@@ -16,6 +16,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -122,6 +123,10 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
               User = if cfg.user != null then cfg.user else beaconServiceName;
               StateDirectory = serviceName;

--- a/modules/nixos/reth/default.nix
+++ b/modules/nixos/reth/default.nix
@@ -15,6 +15,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -125,8 +126,12 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
-              User = serviceName;
+              User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;
               ExecStart = "${cfg.package}/bin/reth node ${scriptArgs}";
 

--- a/modules/nixos/reth/options.nix
+++ b/modules/nixos/reth/options.nix
@@ -30,6 +30,12 @@ let
 
       subVolume = mkEnableOption "Use a subvolume for the state directory if the underlying filesystem supports it e.g. btrfs";
 
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service.";
+      };
+
       settings = mkOption {
         type = types.submodule {
           freeformType = types.attrsOf types.anything;

--- a/modules/nixos/teku-beacon/default.nix
+++ b/modules/nixos/teku-beacon/default.nix
@@ -15,6 +15,7 @@ let
     mapAttrs
     mapAttrs'
     mapAttrsToList
+    mkForce
     mkIf
     mkMerge
     nameValuePair
@@ -104,6 +105,10 @@ in
           # create service config by merging with the base config
           serviceConfig = mkMerge [
             baseServiceConfig
+            (mkIf (cfg.user != null) {
+              # A statically-managed user is incompatible with DynamicUser.
+              DynamicUser = mkForce false;
+            })
             {
               User = if cfg.user != null then cfg.user else serviceName;
               StateDirectory = serviceName;


### PR DESCRIPTION
## What

Adds a `user` option to the NixOS modules that were missing it and makes setting a custom user actually run the service as a real, statically-managed user (not under systemd's `DynamicUser`).

- **Execution clients + others** (geth, erigon, besu, nethermind, reth, geth-bootnode, mev-boost, helios): new `user` option (nullOr str, default null). When unset, behaviour is unchanged — `DynamicUser = true` and `User = <service>-<name>`. When set, the service runs as that user.
- **All modules**: when `user` is set, `DynamicUser = mkForce false` is applied, since a real user is incompatible with `DynamicUser`. The consensus modules (prysm, lighthouse, teku, nimbus) already exposed `user` but kept `DynamicUser` on — they now disable it too.

## Why

This is the RFC 42 module equivalent of the request in #626, which targeted the old `modules/geth/` layout (removed in #866). That PR wanted to manage the geth service user directly instead of relying on `DynamicUser`. This applies the idea uniformly across all clients and supersedes #626.

## Testing

Evaluated the resulting systemd units for every touched module, with and without `user`:

- `user` set → `User = <user>`, `DynamicUser = false`
- `user` unset → `User = <service>-<name>`, `DynamicUser = true` (defaults preserved)

`nix fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)