### PR TITLE
rotki-bin: set APPIMAGE=1 in wrapper

### DIFF
--- a/packages/rotki-bin/package.nix
+++ b/packages/rotki-bin/package.nix
@@ -23,6 +23,7 @@ appimageTools.wrapType2 rec {
     ''
       mv $out/bin/{rotki-bin,rotki}
       wrapProgram $out/bin/rotki \
+        --set APPIMAGE 1 \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
       install -Dm444 ${contents}/rotki.desktop -t $out/share/applications/
       install -Dm444 ${contents}/rotki.png -t $out/share/icons/hicolor/1024x1024/apps/


### PR DESCRIPTION
appimageTools extracts and runs the AppImage directly, so the AppImage runtime never sets $APPIMAGE. rotki checks this variable during startup and hangs indefinitely when it is unset. Set APPIMAGE=1 in the wrapper so
the application initializes correctly.

Closes #1074