### PR TITLE
lighthouse-validator: auto-set --unencrypted-http-transport when http enabled

### DIFF
--- a/modules/nixos/lighthouse-validator/default.nix
+++ b/modules/nixos/lighthouse-validator/default.nix
@@ -94,6 +94,14 @@ in
           explicitBool = false;
         }) (processSettings normalSettings);
 
+        # Lighthouse refuses to serve the validator HTTP API over plain HTTP
+        # unless --unencrypted-http-transport is passed explicitly. Inject it
+        # automatically when http is enabled so users don't have to add it via
+        # extraArgs, unless they set the flag themselves in settings (#795).
+        httpTransportArgs = optionals ((s.http or false) && !(s ? "unencrypted-http-transport")) [
+          "--unencrypted-http-transport"
+        ];
+
         allArgs = [
           "--datadir"
           datadir
@@ -101,6 +109,7 @@ in
           (concatStringsSep "," beaconNodes)
         ]
         ++ cliArgs
+        ++ httpTransportArgs
         ++ cfg.extraArgs;
 
         scriptArgs = concatStringsSep " \\\n  " allArgs;

--- a/modules/nixos/lighthouse-validator/options.nix
+++ b/modules/nixos/lighthouse-validator/options.nix
@@ -45,6 +45,10 @@ let
 
           When beacon-nodes is not set, the module will automatically look up the HTTP address
           from a lighthouse-beacon service with the same instance name.
+
+          When http is enabled, the module automatically passes
+          --unencrypted-http-transport, which Lighthouse requires to serve the
+          validator HTTP API over plain HTTP.
         '';
         example = literalExpression ''
           {


### PR DESCRIPTION
## Description

Lighthouse refuses to serve the validator HTTP API over plain HTTP unless `--unencrypted-http-transport` is passed explicitly (to ensure the user is aware of the risks involved). Previously, users of the `lighthouse-validator` module had to add this flag manually via `extraArgs` whenever they set `settings.http = true`.

This change injects the flag automatically when `http` is enabled, unless the user already sets `unencrypted-http-transport` in `settings` (so no duplicate arg is produced).

## Testing

Evaluated the module for three instances and inspected the generated `ExecStart`:

| Case | `settings` | Result |
|------|-----------|--------|
| auto | `http = true` | `--http … --unencrypted-http-transport` (injected once) ✅ |
| explicit | `http = true; "unencrypted-http-transport" = true` | flag appears exactly once, no duplicate ✅ |
| nohttp | http unset | flag not present ✅ |

Ran `nix fmt`.

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)