### PR TITLE
vouch: add NixOS service module

### DIFF
--- a/modules/nixos/vouch/default.nix
+++ b/modules/nixos/vouch/default.nix
@@ -1,0 +1,99 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  modulesLib = import ../../../lib/modules.nix lib;
+
+  inherit (lib)
+    concatStringsSep
+    filterAttrs
+    flatten
+    last
+    mapAttrs'
+    mapAttrsToList
+    mkIf
+    mkMerge
+    nameValuePair
+    optionals
+    splitString
+    toInt
+    ;
+  inherit (lib.attrsets) zipAttrsWith;
+  inherit (modulesLib) baseServiceConfig;
+
+  eachVouch = config.services.ethereum.vouch;
+
+  format = pkgs.formats.yaml { };
+
+  # Extract the port from a "host:port" or ":port" listen address string.
+  portOf = addr: toInt (last (splitString ":" addr));
+in
+{
+  ###### interface
+  inherit (import ./options.nix { inherit lib pkgs; }) options;
+
+  ###### implementation
+  config = mkIf (eachVouch != { }) {
+    # open the metrics port for each service that requests it
+    networking.firewall =
+      let
+        openFirewall = filterAttrs (_: cfg: cfg.openFirewall) eachVouch;
+        perService = mapAttrsToList (
+          _: cfg:
+          let
+            metricsAddr = cfg.settings.metrics.prometheus.listen-address or null;
+          in
+          {
+            allowedTCPPorts = optionals (metricsAddr != null) [ (portOf metricsAddr) ];
+          }
+        ) openFirewall;
+      in
+      zipAttrsWith (_name: flatten) perService;
+
+    # create a service for each instance
+    systemd.services = mapAttrs' (
+      name:
+      let
+        serviceName = "vouch-${name}";
+      in
+      cfg:
+      let
+        # Vouch reads <base-dir>/vouch.yaml via viper. Render the settings to
+        # that file and hand Vouch a directory that contains it.
+        configFile = format.generate "vouch.yaml" cfg.settings;
+        baseDir = pkgs.linkFarm "vouch-${name}-base" [
+          {
+            name = "vouch.yaml";
+            path = configFile;
+          }
+        ];
+
+        allArgs = [
+          "--base-dir=${baseDir}"
+        ]
+        ++ cfg.extraArgs;
+
+        scriptArgs = concatStringsSep " \\\n  " allArgs;
+      in
+      nameValuePair serviceName (
+        mkIf cfg.enable {
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          description = "Vouch validator client (${name})";
+
+          serviceConfig = mkMerge [
+            baseServiceConfig
+            {
+              User = if cfg.user != null then cfg.user else serviceName;
+              StateDirectory = serviceName;
+              ExecStart = "${cfg.package}/bin/vouch ${scriptArgs}";
+            }
+          ];
+        }
+      )
+    ) eachVouch;
+  };
+}

--- a/modules/nixos/vouch/options.nix
+++ b/modules/nixos/vouch/options.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    types
+    literalExpression
+    ;
+
+  vouchOpts = {
+    options = {
+      enable = mkEnableOption "Vouch, an Ethereum multi-node validator client from Attestant";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.vouch;
+        defaultText = literalExpression "pkgs.vouch";
+        description = "Package to use for the Vouch binary.";
+      };
+
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service. When null, a dynamic user is used.";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Open the Prometheus metrics port in the firewall. The port is parsed
+          from `settings.metrics.prometheus.listen-address`.
+        '';
+      };
+
+      settings = mkOption {
+        type = types.submodule {
+          freeformType = (pkgs.formats.yaml { }).type;
+        };
+        default = { };
+        description = ''
+          Vouch configuration. Rendered verbatim to a `vouch.yaml` file that
+          Vouch reads through `--base-dir`. Use the nested keys documented at
+          <https://github.com/attestantio/vouch/blob/master/docs/configuration.md>.
+
+          Secrets (wallet passphrases, client certificates) should be provided
+          as majordomo references (e.g. `"file:///run/credentials/..."`) rather
+          than inline values, since the generated file is world-readable in the
+          Nix store.
+        '';
+        example = literalExpression ''
+          {
+            log-level = "info";
+            beacon-node-addresses = [ "localhost:5051" ];
+            metrics.prometheus.listen-address = "127.0.0.1:8081";
+            accountmanager.dirk = {
+              endpoints = [ "signer:8881" ];
+              accounts = [ "Validators" ];
+              client-cert = "file:///etc/vouch/client.crt";
+              client-key = "file:///etc/vouch/client.key";
+              ca-cert = "file:///etc/vouch/ca.crt";
+            };
+            blockrelay = {
+              fallback-fee-recipient = "0x0000000000000000000000000000000000000001";
+              fallback-gas-limit = 30000000;
+            };
+          }
+        '';
+      };
+
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Additional command-line arguments passed to Vouch.";
+      };
+    };
+  };
+in
+{
+  options.services.ethereum.vouch = mkOption {
+    type = types.attrsOf (types.submodule vouchOpts);
+    default = { };
+    description = "Specification of one or more Vouch validator instances.";
+  };
+}


### PR DESCRIPTION
## Description

Adds a NixOS service module for [Vouch](https://github.com/attestantio/vouch), Attestant's Ethereum multi-node validator client.

Unlike the flag-driven clients in this repo, Vouch is configured through a YAML file that it discovers via `--base-dir` (viper reads `<base-dir>/vouch.yaml`). The module therefore renders the freeform `settings` attrset to `vouch.yaml` using `pkgs.formats.yaml` and points Vouch at a directory containing it.

### Features

- Multiple named instances under `services.ethereum.vouch.<name>`.
- Freeform `settings` mirroring the [upstream configuration](https://github.com/attestantio/vouch/blob/master/docs/configuration.md) (nested YAML keys).
- Hardened systemd unit via the shared `baseServiceConfig` (DynamicUser, etc.).
- `openFirewall` opens the Prometheus metrics port, parsed from `settings.metrics.prometheus.listen-address`.
- `extraArgs` escape hatch.

Secrets should be provided as majordomo references (e.g. `file://...`) rather than inline, since the generated config lives in the world-readable Nix store — this is documented in the option description.

## Testing

Module is discovered by blueprint (`nix eval .#nixosModules` lists `vouch`). Evaluated a sample instance and verified:

- `ExecStart` = `…/bin/vouch --base-dir=/nix/store/…-vouch-main-base`
- Generated `vouch.yaml` matches the expected nested structure.
- `openFirewall` opens TCP `8081` (parsed from `127.0.0.1:8081`).
- `DynamicUser = true`, `StateDirectory = vouch-main`.

Ran `nix fmt`.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)