### PR TITLE
dirk: add NixOS service module

### DIFF
--- a/modules/nixos/dirk/default.nix
+++ b/modules/nixos/dirk/default.nix
@@ -1,0 +1,100 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  modulesLib = import ../../../lib/modules.nix lib;
+
+  inherit (lib)
+    concatStringsSep
+    filterAttrs
+    flatten
+    last
+    mapAttrs'
+    mapAttrsToList
+    mkIf
+    mkMerge
+    nameValuePair
+    optionals
+    splitString
+    toInt
+    ;
+  inherit (lib.attrsets) zipAttrsWith;
+  inherit (modulesLib) baseServiceConfig;
+
+  eachDirk = config.services.ethereum.dirk;
+
+  format = pkgs.formats.yaml { };
+
+  # Extract the port from a "host:port" or ":port" listen address string.
+  portOf = addr: toInt (last (splitString ":" addr));
+in
+{
+  ###### interface
+  inherit (import ./options.nix { inherit lib pkgs; }) options;
+
+  ###### implementation
+  config = mkIf (eachDirk != { }) {
+    # open the gRPC server port for each service that requests it
+    networking.firewall =
+      let
+        openFirewall = filterAttrs (_: cfg: cfg.openFirewall) eachDirk;
+        perService = mapAttrsToList (
+          _: cfg:
+          let
+            listenAddr = cfg.settings.server.listen-address or null;
+          in
+          {
+            allowedTCPPorts = optionals (listenAddr != null) [ (portOf listenAddr) ];
+          }
+        ) openFirewall;
+      in
+      zipAttrsWith (_name: flatten) perService;
+
+    # create a service for each instance
+    systemd.services = mapAttrs' (
+      name:
+      let
+        serviceName = "dirk-${name}";
+      in
+      cfg:
+      let
+        # Dirk reads <base-dir>/dirk.yaml via viper. Render the settings to
+        # that file and hand Dirk a directory that contains it.
+        configFile = format.generate "dirk.yaml" cfg.settings;
+        baseDir = pkgs.linkFarm "dirk-${name}-base" [
+          {
+            name = "dirk.yaml";
+            path = configFile;
+          }
+        ];
+
+        allArgs = [
+          "--base-dir=${baseDir}"
+        ]
+        ++ cfg.extraArgs;
+
+        scriptArgs = concatStringsSep " \\\n  " allArgs;
+      in
+      nameValuePair serviceName (
+        mkIf cfg.enable {
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          description = "Dirk remote keymanager (${name})";
+
+          serviceConfig = mkMerge [
+            baseServiceConfig
+            {
+              User = if cfg.user != null then cfg.user else serviceName;
+              StateDirectory = serviceName;
+              WorkingDirectory = "%S/${serviceName}";
+              ExecStart = "${cfg.package}/bin/dirk ${scriptArgs}";
+            }
+          ];
+        }
+      )
+    ) eachDirk;
+  };
+}

--- a/modules/nixos/dirk/options.nix
+++ b/modules/nixos/dirk/options.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    types
+    literalExpression
+    ;
+
+  dirkOpts = {
+    options = {
+      enable = mkEnableOption "Dirk, a distributed remote keymanager from Attestant";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.dirk;
+        defaultText = literalExpression "pkgs.dirk";
+        description = "Package to use for the Dirk binary.";
+      };
+
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "User to run the systemd service. When null, a dynamic user is used.";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Open the gRPC server port in the firewall. The port is parsed from
+          `settings.server.listen-address`.
+        '';
+      };
+
+      settings = mkOption {
+        type = types.submodule {
+          freeformType = (pkgs.formats.yaml { }).type;
+        };
+        default = { };
+        description = ''
+          Dirk configuration. Rendered verbatim to a `dirk.yaml` file that Dirk
+          reads through `--base-dir`. Use the nested keys documented at
+          <https://github.com/attestantio/dirk/blob/master/docs/configuration.md>.
+
+          `storage-path` (slashing protection) and any filesystem `stores`
+          (wallets) must point at writable, persistent locations. The service
+          provides a state directory at `/var/lib/dirk-<name>` (also the working
+          directory), so relative paths are resolved there.
+
+          Secrets (passphrases, private keys) should be provided as majordomo
+          references (e.g. `"file:///run/credentials/..."`) rather than inline
+          values, since the generated file is world-readable in the Nix store.
+        '';
+        example = literalExpression ''
+          {
+            server = {
+              id = 12345678;
+              name = "dirk.example.com";
+              listen-address = "0.0.0.0:13141";
+            };
+            certificates = {
+              server-cert = "file:///var/lib/dirk-main/security/server.crt";
+              server-key = "file:///var/lib/dirk-main/security/server.key";
+              ca-cert = "file:///var/lib/dirk-main/security/ca.crt";
+            };
+            storage-path = "/var/lib/dirk-main/protection";
+            stores = [
+              {
+                name = "Local";
+                type = "filesystem";
+                location = "/var/lib/dirk-main/wallets";
+              }
+            ];
+            unlocker.account-passphrases = [ "file:///run/credentials/dirk-main/passphrase" ];
+            peers."12345678" = "dirk.example.com:13141";
+            permissions."client1".Local = "All";
+          }
+        '';
+      };
+
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Additional command-line arguments passed to Dirk.";
+      };
+    };
+  };
+in
+{
+  options.services.ethereum.dirk = mkOption {
+    type = types.attrsOf (types.submodule dirkOpts);
+    default = { };
+    description = "Specification of one or more Dirk keymanager instances.";
+  };
+}


### PR DESCRIPTION
## Description

Adds a NixOS service module for [Dirk](https://github.com/attestantio/dirk), Attestant's distributed remote keymanager, focused on secure signing operations.

Like the companion Vouch module, Dirk is configured through a YAML file it discovers via `--base-dir` (viper reads `<base-dir>/dirk.yaml`). The module renders the freeform `settings` attrset to `dirk.yaml` using `pkgs.formats.yaml` and points Dirk at a directory containing it.

### Features

- Multiple named instances under `services.ethereum.dirk.<name>`.
- Freeform `settings` mirroring the [upstream configuration](https://github.com/attestantio/dirk/blob/master/docs/configuration.md) (nested YAML keys).
- Hardened systemd unit via the shared `baseServiceConfig` (DynamicUser, etc.).
- Persistent state + working directory at `/var/lib/dirk-<name>` for slashing protection and filesystem wallet stores.
- `openFirewall` opens the gRPC server port, parsed from `settings.server.listen-address`.
- `extraArgs` escape hatch.

Secrets (passphrases, keys) should be provided as majordomo references (e.g. `file://...`) rather than inline, since the generated config lives in the world-readable Nix store — documented in the option description.

## Testing

Module is discovered by blueprint (`nix eval .#nixosModules` lists `dirk`). Evaluated a sample instance and verified:

- `ExecStart` = `…/bin/dirk --base-dir=/nix/store/…-dirk-main-base`
- Generated `dirk.yaml` matches the expected nested structure (server, stores, peers, permissions).
- `openFirewall` opens TCP `13141` (parsed from `0.0.0.0:13141`).
- `DynamicUser = true`, `StateDirectory = dirk-main`, `WorkingDirectory = %S/dirk-main`.

Ran `nix fmt`.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)