### PR TITLE
anchor: init at 1.3.0

### DIFF
--- a/packages/anchor/default.nix
+++ b/packages/anchor/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.callPackage ./package.nix { }

--- a/packages/anchor/package.nix
+++ b/packages/anchor/package.nix
@@ -1,0 +1,67 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  sqlite,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "anchor";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "sigp";
+    repo = "anchor";
+    rev = "v${version}";
+    hash = "sha256-m4gVZqpcH9pcw70xWQOyah+GkdLWFzzNh3l4u5v+vGk=";
+  };
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      "beacon_node_fallback-0.1.0" = "sha256-MOaXIJRrbaY2qXhoh1wT1ZAFntNZahAHT3C7vT4ZTBg=";
+      "libp2p-0.57.0" = "sha256-Ujy81IdJcfF+dUbAvfS3VNKvKOTq91jSlWeTopPnBXs=";
+    };
+  };
+
+  enableParallelBuilding = true;
+
+  cargoBuildFlags = [ "--package anchor" ];
+
+  buildFeatures = [ "portable" ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    openssl
+    sqlite
+  ];
+
+  # Use pkg-config to locate the system OpenSSL instead of vendoring it.
+  OPENSSL_NO_VENDOR = 1;
+
+  # Workspace tests need network access and fixtures; the version check below
+  # exercises the built binary instead.
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.category = "SSV";
+
+  meta = {
+    description = "Rust implementation of the SSV (Secret Shared Validators) protocol";
+    homepage = "https://github.com/sigp/anchor";
+    license = lib.licenses.asl20;
+    mainProgram = "anchor";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}


### PR DESCRIPTION
## Description

Adds [`sigp/anchor`](https://github.com/sigp/anchor), Sigma Prime's Rust implementation of the SSV (Secret Shared Validators) protocol, at version `1.3.0`.

### Packaging notes

- Built with `rustPlatform.buildRustPackage` from the `v1.3.0` tag.
- The workspace pins Lighthouse and rust-libp2p crates to git revisions, so `cargoLock.outputHashes` carries one entry per git source:
  - `beacon_node_fallback-0.1.0` → `sigp/lighthouse@4b3a9d3` (32 crates)
  - `libp2p-0.57.0` → `sigp/rust-libp2p@c774d4e` (25 crates)
- `buildFeatures = [ "portable" ]` for a portable BLS build.
- System OpenSSL and SQLite linked via `pkg-config` (`OPENSSL_NO_VENDOR = 1`); `cmake` + `rustPlatform.bindgenHook` for the C/bindgen consumers.
- `doCheck = false` (workspace tests require network + fixtures, mirroring the `lighthouse` package); `versionCheckHook` exercises the built binary.
- `passthru.category = "SSV"`.

## Testing

Hashes (source + both `cargoLock` git sources) were resolved locally and the derivation evaluates and vendors correctly. Deferring the full compile to CI, which builds every package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)