### PR TITLE
nethermind: 1.39.2 -> 1.39.3

### DIFF
--- a/packages/nethermind/package.nix
+++ b/packages/nethermind/package.nix
@@ -11,13 +11,13 @@
 }:
 buildDotnetModule rec {
   pname = "nethermind";
-  version = "1.39.2";
+  version = "1.39.3";
 
   src = fetchFromGitHub {
     owner = "NethermindEth";
     repo = pname;
     rev = version;
-    hash = "sha256-xSKXGtlC0s8kQcWExUYNrROxbDxDs9SKb3ki9DR9x1s=";
+    hash = "sha256-Tyoa3SqhpaIDnmnxc7fIg/f2ZR7HXll+c83YGk5ZKB8=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
workflows are borking for some unknown reason https://github.com/nix-community/ethereum.nix/actions/runs/31189995181/job/92911644138

https://github.com/NethermindEth/nethermind/releases/tag/1.39.3
> Please upgrade at your earliest convenience.